### PR TITLE
Shift db_import to run after wp install

### DIFF
--- a/roles/wordpress-sites/handlers/main.yml
+++ b/roles/wordpress-sites/handlers/main.yml
@@ -1,3 +1,7 @@
 ---
 - name: reload nginx
   service: name=nginx state=reloaded
+
+- name: Import database
+  mysql_db: name={{ item.env.db_name | default(item.site_name) }} state=import target=/tmp/{{ item.db_import | basename }} login_host={{ item.env.db_host | default('localhost') }}
+  with_items: wordpress_sites

--- a/roles/wordpress-sites/tasks/database.yml
+++ b/roles/wordpress-sites/tasks/database.yml
@@ -3,16 +3,12 @@
   copy: src={{ item.db_import }} dest=/tmp
   with_items: wordpress_sites
   when: item.db_import|default(False)
+  notify: Import database
 
 - name: Create database of sites
   mysql_db: name={{ item.env.db_name | default(item.site_name) }} state=present login_host={{ item.env.db_host | default('localhost') }}
   with_items: wordpress_sites
   when: item.db_create|default(True)
-
-- name: Import database
-  mysql_db: name={{ item.env.db_name | default(item.site_name) }} state=import target=/tmp/{{ item.db_import | basename }} login_host={{ item.env.db_host | default('localhost') }}
-  with_items: wordpress_sites
-  when: item.db_import|default(False)
 
 - name: Create/assign database user to db and grant permissions
   mysql_user: name={{ item.env.db_user }}


### PR DESCRIPTION
**The problem.** The command 'wp core is-installed' seems to interpret the presence of an imported db to mean WP is already installed, so 'wp core install' doesn't end up running and the site won't load.

**Potential solution.** This commit moves the 'Import database' play to a handler to be run at the end of the 'wordpress-sites' role (so the db imports _after_ 'wp core install'). The handler is "notified" to run via the 'Copy database dump' play in roles/wordpress-sites/tasks/database.yml.

**Note.** For better or worse, a 'vagrant provision' command will not re-import or overwrite a database that has already been imported.
