### PR TITLE
Use H5BP server configs

### DIFF
--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+logs_root: /var/log/nginx/
+nginx_user: www-data
+strip_www: true

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -5,6 +5,21 @@
 - name: Install Nginx
   apt: name=nginx state=present force=yes
 
+- name: Grab h5bp/server-configs-nginx
+  git:  repo=https://github.com/h5bp/server-configs-nginx.git
+        dest=/tmp/server-configs-nginx
+        version="3db5d61f81d7229d12b89e0355629249a49ee4ac"
+        force=yes
+
+- name: Copy over h5bp configuration
+  command: cp -r /tmp/server-configs-nginx/{{ item }} /etc/nginx/{{ item }}
+  with_items:
+    - "mime.types"
+    - "h5bp/"
+
+- name: Install nginx.conf
+  template: src=nginx.conf.j2 dest=/etc/nginx/nginx.conf
+
 - name: Disable default server
   file: path=/etc/nginx/sites-enabled/default state=absent
 

--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -1,0 +1,119 @@
+# nginx Configuration File
+# http://wiki.nginx.org/Configuration
+
+# Run as a less privileged user for security reasons.
+user {{ nginx_user }};
+
+# How many worker threads to run;
+# "auto" sets it to the number of CPU cores available in the system, and
+# offers the best performance. Don't set it higher than the number of CPU
+# cores if changing this parameter.
+
+# The maximum number of connections for Nginx is calculated by:
+# max_clients = worker_processes * worker_connections
+worker_processes 2;
+
+# Maximum open file descriptors per process;
+# should be > worker_connections.
+worker_rlimit_nofile 8192;
+
+events {
+  # When you need > 8000 * cpu_cores connections, you start optimizing your OS,
+  # and this is probably the point at which you hire people who are smarter than
+  # you, as this is *a lot* of requests.
+  worker_connections 8000;
+}
+
+# Default error log file
+# (this is only used when you don't override error_log on a server{} level)
+error_log  {{ logs_root }}/error.log warn;
+pid        /var/run/nginx.pid;
+
+http {
+
+  # Hide nginx version information.
+  server_tokens off;
+
+  # Define the MIME types for files.
+  include       mime.types;
+  default_type  application/octet-stream;
+
+  # Update charset_types due to updated mime.types
+  charset_types text/xml text/plain text/vnd.wap.wml application/x-javascript application/rss+xml text/css application/javascript application/json;
+
+  # Format to use in log files
+  log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+
+  # Default log file
+  # (this is only used when you don't override access_log on a server{} level)
+  access_log {{ logs_root }}/access.log main;
+
+  # How long to allow each connection to stay idle; longer values are better
+  # for each individual client, particularly for SSL, but means that worker
+  # connections are tied up longer. (Default: 65)
+  keepalive_timeout 20;
+
+  # Speed up file transfers by using sendfile() to copy directly
+  # between descriptors rather than using read()/write().
+  sendfile        on;
+
+  # Tell Nginx not to send out partial frames; this increases throughput
+  # since TCP frames are filled up before being sent out. (adds TCP_CORK)
+  tcp_nopush      on;
+
+
+  # Compression
+
+  # Enable Gzip compressed.
+  gzip on;
+
+  # Compression level (1-9).
+  # 5 is a perfect compromise between size and cpu usage, offering about
+  # 75% reduction for most ascii files (almost identical to level 9).
+  gzip_comp_level    5;
+
+  # Don't compress anything that's already small and unlikely to shrink much
+  # if at all (the default is 20 bytes, which is bad as that usually leads to
+  # larger files after gzipping).
+  gzip_min_length    256;
+
+  # Compress data even for clients that are connecting to us via proxies,
+  # identified by the "Via" header (required for CloudFront).
+  gzip_proxied       any;
+
+  # Tell proxies to cache both the gzipped and regular version of a resource
+  # whenever the client's Accept-Encoding capabilities header varies;
+  # Avoids the issue where a non-gzip capable client (which is extremely rare
+  # today) would display gibberish if their proxy gave them the gzipped version.
+  gzip_vary          on;
+
+  # Compress all output labeled with one of the following MIME-types.
+  gzip_types
+    application/atom+xml
+    application/javascript
+    application/json
+    application/rss+xml
+    application/vnd.ms-fontobject
+    application/x-font-ttf
+    application/x-web-app-manifest+json
+    application/xhtml+xml
+    application/xml
+    font/opentype
+    image/svg+xml
+    image/x-icon
+    text/css
+    text/plain
+    text/x-component;
+  # text/html is always compressed by HttpGzipModule
+
+
+  # This should be turned on if you are going to have pre-compressed copies (.gz) of
+  # static files available. If not it should be left off as it will cause extra I/O
+  # for the check. It is best if you enable this in a location{} block for
+  # a specific directory, or on an individual server{} level.
+  # gzip_static on;
+
+  include sites-enabled/*;
+}

--- a/roles/nginx/templates/wordpress.conf.j2
+++ b/roles/nginx/templates/wordpress.conf.j2
@@ -7,3 +7,7 @@ location ~ \.php$ {
   include fastcgi_params;
   fastcgi_pass unix:/var/run/php5-fpm-$site_name.sock;
 }
+
+include h5bp/directive-only/x-ua-compatible.conf;
+include h5bp/location/cross-domain-fonts.conf;
+include h5bp/location/protect-system-files.conf;

--- a/roles/wordpress-sites/tasks/nginx.yml
+++ b/roles/wordpress-sites/tasks/nginx.yml
@@ -12,6 +12,10 @@
         state=link
   with_items: wordpress_sites
 
+- name: Enable better default site to drop unknown requests
+  command: > 
+    cp /tmp/server-configs-nginx/sites-available/no-default /etc/nginx/sites-enabled/no-default.conf
+
 - name: Copy php-fpm configuration
   template: src="php-fpm.conf.j2"
             dest="/etc/php5/fpm/pool.d/{{ item.site_name }}.conf"

--- a/roles/wordpress-sites/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-sites/templates/wordpress-site.conf.j2
@@ -1,13 +1,15 @@
 server {
   set $site_name {{ item.site_name }};
 
-  listen       *:80;
+  listen *:80;
   server_name  {{ item.site_hosts | join(' ') }};
   access_log   {{ www_root }}/{{ item.site_name }}/logs/{{ item.site_name }}.access.log;
   error_log    {{ www_root }}/{{ item.site_name }}/logs/{{ item.site_name }}.error.log;
 
   root  {{ www_root }}/{{ item.site_name }}/current/web;
   index index.php;
+
+  charset utf-8;
 
   {% if item.env.wp_env | default('development') -%}
     # See Virtualbox section at http://wiki.nginx.org/Pitfalls
@@ -20,3 +22,11 @@ server {
 
   include wordpress.conf;
 }
+
+{% for host in item.site_hosts if strip_www %}
+server {
+  listen *:80;
+  server_name www.{{ host }};
+  return 301 $scheme://{{ host }}$request_uri;
+}
+{% endfor %}


### PR DESCRIPTION
This has been tested locally but I would like to try to deploy it on digital ocean to see if it runs alright on a remote server (shouldn't be an issue)

Any feedback on this?

---

Checks out a stable version of h5bp/server-configs-nginx and applies it
to the /etc/nginx folder

http://goo.gl/pBfB4W

Misc:
Adds "restart nginx" handler

closes https://github.com/roots/bedrock-ansible/issues/31
