### PR TITLE
Add no-dev option to composer install

### DIFF
--- a/roles/wordpress-sites/tasks/main.yml
+++ b/roles/wordpress-sites/tasks/main.yml
@@ -29,6 +29,7 @@
 
 - name: Install Dependencies with Composer
   command: composer install
+           {% if item.env.wp_env != 'development' %} --no-dev {% endif %}
   args:
     chdir: "{{ www_root }}/{{ item.site_name }}/current/"
   with_items: wordpress_sites


### PR DESCRIPTION
In my `bedrock/composer.json` I have the standard `require` directive for plugins to install, but also a [`require-dev`](https://getcomposer.org/doc/04-schema.md#require-dev) directive listing plugins for the development site only.

This PR conditionally adds the `--no-dev` option to `composer install` when `item.env.wp_env != 'development'` so that dev-only plugins are NOT installed on staging and production sites.

P.S. Any refinements to my understanding of github PR etiquette? When I have ideas to share in code, I figure it goes in a PR when I think you'll most likely merge the code. Otherwise I figure I should share the code in an issue. Any reason you want to avoid rejected PRs in the project history? (That concern is why I submitted [the code](https://github.com/fullyint/bedrock-ansible/commit/154a355ca2289d6511ad0c32c9448c9bdeb88a67) of #73 as an issue instead of as a PR.)
