### PR TITLE
Limit sendfile off directive to development env

### DIFF
--- a/roles/wordpress-sites/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-sites/templates/wordpress-site.conf.j2
@@ -11,7 +11,7 @@ server {
 
   charset utf-8;
 
-  {% if item.env.wp_env | default('development') -%}
+  {% if item.env.wp_env == 'development' -%}
     # See Virtualbox section at http://wiki.nginx.org/Pitfalls
     sendfile off;
   {%- endif %}


### PR DESCRIPTION
Because the `sendfile off` directive was still making it in to configs for staging and production.

I used single quotes because the the original line had single quotes. If you prefer double quotes, maybe you want them in the change of #75 as well.
