### PR TITLE
Update wp-cli phar_url

### DIFF
--- a/roles/wp-cli/defaults/main.yml
+++ b/roles/wp-cli/defaults/main.yml
@@ -1,2 +1,2 @@
-phar_url: https://raw.github.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+phar_url: https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
 bin_path: /usr/bin/wp


### PR DESCRIPTION
The old phar_url still works for now, but has a 301 redirect. Github has [new user content domains](https://developer.github.com/changes/2014-04-25-user-content-security/).
