### PR TITLE
Add vagrant-bindfs for custom NFS permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Vagrant is recommended to provision servers and this comes with a basic `Vagrant
 1. Ansible >= 1.5.4 - [Installation docs](http://docs.ansible.com/intro_installation.html)
 2. Virtualbox >= 4.3.10 - [Downloads](https://www.virtualbox.org/wiki/Downloads)
 3. Vagrant >= 1.5.4 - [Downloads](http://www.vagrantup.com/downloads.html)
+4. Vagrant-bindfs >= 0.3.1 - [Docs](https://github.com/gael-ian/vagrant-bindfs) (Windows users may skip this)
 
 ### OS Notes
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,12 +19,13 @@ Vagrant.configure('2') do |config|
     #config.hostsupdater.aliases = %w(site2.dev)
   end
 
-  # adjust paths relative to Vagrantfile
+  # Adjust '../example.dev' path relative to Vagrantfile
   # Use NFS for shared folders for better performance
-  # Comment this line if you're on a windows machine
-  # and uncomment the one below
-  config.vm.synced_folder '../example.dev', '/srv/www/example.dev/current', type: 'nfs', map_uid: 0, map_gid: 0 # *nix machines
-  #config.vm.synced_folder '../example.dev', '/srv/www/example.dev/current', owner: 'vagrant', group: 'www-data', mount_options: ['dmode=776', 'fmode=775'] # windows machines
+  # *nix machines: use these two lines
+  config.vm.synced_folder '../example.dev', '/vagrant-nfs', type: 'nfs'
+  config.bindfs.bind_folder '/vagrant-nfs', '/srv/www/example.dev/current', u: 'vagrant', g: 'www-data'
+  # windows machines: uncomment line below, comment both lines above
+  #config.vm.synced_folder '../example.dev', '/srv/www/example.dev/current', owner: 'vagrant', group: 'www-data', mount_options: ['dmode=776', 'fmode=775']
 
   config.vm.provision :ansible do |ansible|
     # adjust paths relative to Vagrantfile


### PR DESCRIPTION
This PR stems out of #82.

**Notes about options.** I added the options `u: 'vagrant' and g: 'www-data'` to override the `vagrant-bindfs` default of 'vagrant' for each. This frees the `wordpress-sites` role from having to perform a `chown` to `vagrant:www-data`. 

The [bindfs man page](http://bindfs.org/docs/bindfs.1.html) indicates that `-u` and `-g` cause `chown` and `chgrp` on the mounted filesystem to always fail. So, I assume anyone customizing their playbooks to `chown` to something other than `vagrant:www-data` will see a failure warning. In that case, the `--chown-ignore` and `--chgrp-ignore` options might be of use.

**Other Notes**
- I tested on OSX only. I'm not aware of any reason it wouldn't work on other NFS-compatible hosts.
- I omitted warnings for missing `vagrant-bindfs` plugin, a la `if !Vagrant.has_plugin? 'vagrant-binfs'`
- I didn't try anything with `mount_options: ["dmode=775,fmode=664"]`
