### PR TITLE
Add checks for vagrant-bindfs & windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You should now have the following directories at the same level somewhere:
 
 ## Usage
 
-1. Edit `Vagrantfile` and set your `config.vm.synced_folder` path so that it points to a local relative path for a Bedrock project from #2 above.
+1. Edit `Vagrantfile` and set the `bedrock_path` variable so that it points to a local relative path for a Bedrock project from #2 above.
 2. Edit `group_vars/development` and add your WordPress site(s). See [Options](#options) below for details.
 3. Optionally add any dev hostnames to your local `/etc/hosts` file (or use the [hostsupdater plugin](https://github.com/cogitatio/vagrant-hostsupdater)).
 4. Run `vagrant up`.


### PR DESCRIPTION
See discussion at #83 (thanks again @nathanielks and @austinpray). Resolves #85.
I've researched this the best I can, but I'm still a novice, so I hope people will double-check this code.

Detects platform like [this](https://github.com/mitchellh/vagrant/commit/b2d1a26) ([inspiration](http://stackoverflow.com/a/18452093)) so windows users no longer manually uncomment their sync folder.

People may find the `bedrock_path` variable simpler than hunting for multiple places to edit the path.
- However, there is a cost to flexibility. The directory must have the same name on host and guest. Custom edits would be required when someone wants different names (e.g., wants the name `/srv/www/example.dev/current` on guest, but `bedrock` instead of `example.dev` on host).
- The "forward slash" thing is required by [basename](http://ruby-doc.org/core-1.9.3/File.html#method-c-basename).
