### PR TITLE
Add variable for MariaDB dist

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -1,2 +1,3 @@
 ---
 www_root: /srv/www
+mariadb_dist: trusty

--- a/roles/mariadb/defaults/main.yml
+++ b/roles/mariadb/defaults/main.yml
@@ -1,3 +1,3 @@
 keyserver_fingerprint: "0xcbcb082a1bb943db"
 mirror: nyc2.mirrors.digitalocean.com
-mariadb_version: "10.0"
+version: "10.0"

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -6,8 +6,8 @@
 - name: Add MariaDB MySQL deb and deb-src
   apt_repository: repo="{{ item }}" state=present
   with_items:
-  - "deb http://{{ mirror }}/mariadb/repo/{{ mariadb_version }}/ubuntu {{ ansible_distribution_release }} main"
-  - "deb-src http://{{ mirror }}/mariadb/repo/{{ mariadb_version }}/ubuntu {{ ansible_distribution_release }} main"
+  - "deb http://{{ mirror }}/mariadb/repo/{{ version }}/ubuntu {{ mariadb_dist | default(ansible_distribution_release) }} main"
+  - "deb-src http://{{ mirror }}/mariadb/repo/{{ version }}/ubuntu {{ mariadb_dist | default(ansible_distribution_release) }} main"
 
 - name: Install MariaDB MySQL server
   apt: name=mariadb-server state=present


### PR DESCRIPTION
No specific dist release of MariaDB exists for Ubuntu 14.10 Utopic yet so we'll introduce a variable set to Trusty by default for now.

@austinpray @BrandonShutter
