### PR TITLE
removed ansible_controller

### DIFF
--- a/roles/ferm/README.md
+++ b/roles/ferm/README.md
@@ -104,33 +104,6 @@ ferm_input_list:
 
 This would be the same as above except it would be scoped to the groups and hosts list.
 
-## Example common plays in your playbook
-
-This role expects an `ansible_controller` fact to be set. Notice how the play is ran without sudo. This is necessary for ansible to populate `ansible_env.SSH_CLIENT`.
-
-What this does is set a rule so that only the computer running the ansible playbook will be able to connect on the ssh port. It is dynamic and completely hands free because if you want to run the playbook from a different machine in the future it will automatically update the IP address.
-
-```
----
-- name: ensure all servers are commonly configured (without sudo)
-  hosts: all:!localhost
-  sudo: false
-
-  tasks:
-    - name: ensure IP address of the ansible controller is set
-      set_fact:
-        ansible_controller: '{{ ansible_env.SSH_CLIENT.split(" ") | first }}/32'
-      when: ansible_controller is undefined and ansible_connection != "local"
-      tags: [ferm]
-
-- name: ensure all servers are commonly configured (with sudo)
-  hosts: all
-  sudo: true
-
-  roles:
-    - { role: ferm, tags: [ferm] }
-```
-
 ## Example app play in your playbook
 
 To open the http/https ports on your server add the following to the appropriate group or host vars file:

--- a/roles/ferm/tasks/main.yml
+++ b/roles/ferm/tasks/main.yml
@@ -21,13 +21,6 @@
   notify:
     - restart ferm
 
-- name: ensure ssh access is always allowed by the ansible controller
-  template: src=etc/ferm/filter-input.d/ansible_controller.conf.j2
-            dest=/etc/ferm/filter-input.d/10_ansible_controller.conf
-  when: ansible_controller is defined and ansible_controller
-  notify:
-    - restart ferm
-
 - name: ensure iptables INPUT rules are removed
   file: state=absent
         {% if item.filename is defined and item.filename %}

--- a/roles/ferm/templates/etc/ferm/filter-input.d/ansible_controller.conf.j2
+++ b/roles/ferm/templates/etc/ferm/filter-input.d/ansible_controller.conf.j2
@@ -1,6 +1,0 @@
-# {{ ansible_managed }}
-# manual customization of this file is not recommended
-
-{% if ansible_controller is defined and ansible_controller %}
-protocol tcp dport ssh saddr {{ ansible_controller }} ACCEPT;
-{% endif %}

--- a/site.yml
+++ b/site.yml
@@ -1,17 +1,4 @@
 ---
-- name: Ensure all servers are commonly configured and set 'ansible_controller'
-  hosts: all:!localhost
-  sudo: false
-  remote_user: admin
-
-  tasks:
-    - name: ensure IP address of the ansible controller is set
-      set_fact:
-        ansible_controller: '{{ ansible_env.SSH_CLIENT.split(" ") | first }}/32'
-      when: ansible_controller is undefined and ansible_connection != "local"
-      tags: [common, ferm]
-    - debug: var=ansible_controller
-
 - name: "WordPress Server: Install LEMP Stack with PHP 5.5 and MariaDB MySQL"
   hosts: web
   sudo: yes


### PR DESCRIPTION
Removing this as it makes the default SSH rules a little too inflexible. It only allows 1 IP to SSH in by default when most people might use multiple machines or have a non-static IP.
