### PR TITLE
Simplify Vagrantfile - read group_vars/development

### DIFF
--- a/group_vars/development
+++ b/group_vars/development
@@ -4,7 +4,7 @@ wordpress_sites:
   - site_name: example.dev
     site_hosts:
       - example.dev
-      - 192.168.50.5
+    local_path: '../example.dev' # path targeting local project directory (relative to root/Vagrantfile)
     user: vagrant
     group: www-data
     site_install: true


### PR DESCRIPTION
Previously there was some duplication between configuring the `Vagrantfile` and also `group_vars/development`. Another downside was the Ansible playbook supports multiple sites but the `Vagrantfile` did nothing to easily allow that.

Now the `Vagrantfile` will read `group_vars/development` and automatically set up all the hosts and synced folders. The only addition needed for this is setting `local_path` on each site.

@fullyint love to get your thoughts on this.
