### PR TITLE
Expanded db_create option in database.yml

### DIFF
--- a/roles/wordpress-sites/tasks/database.yml
+++ b/roles/wordpress-sites/tasks/database.yml
@@ -17,6 +17,7 @@
               login_user=root
               login_password="{{ mysql_root_password }}"
   with_items: wordpress_sites
+  when: item.db_create|default(True)
 
 - name: Copy database dump
   copy: src="{{ item.db_import }}" dest=/tmp


### PR DESCRIPTION
• Added `when` option to "Create / Assign Database.." task to handle Ansible config option `db_create`
• Default is set to true to keep with existing Bedrock-Ansible configuration
• Setting Ansible config option `db_create: false` that task will be skipped, this option is preferred for using existing remote DBs
