### PR TITLE
Fixes `|default` formatting

### DIFF
--- a/roles/fail2ban/templates/jail.local.j2
+++ b/roles/fail2ban/templates/jail.local.j2
@@ -26,7 +26,7 @@ action = %({{ fail2ban_action }})s
 {% for service in fail2ban_services %}
 [{{ service.name }}]
 
-enabled = {{ service.enabled|default("true") }}
+enabled = {{ service.enabled | default("true") }}
 port = {{ service.port }}
 filter = {{ service.filter }}
 logpath = {{ service.logpath }}

--- a/roles/wordpress-sites/tasks/database.yml
+++ b/roles/wordpress-sites/tasks/database.yml
@@ -6,7 +6,7 @@
             login_user=root
             login_password="{{ mysql_root_password }}"
   with_items: wordpress_sites
-  when: item.db_create|default(True)
+  when: item.db_create | default(True)
 
 - name: Create/assign database user to db and grant permissions
   mysql_user: name="{{ item.env.db_user }}"
@@ -21,7 +21,7 @@
 - name: Copy database dump
   copy: src="{{ item.db_import }}" dest=/tmp
   with_items: wordpress_sites
-  when: item.db_import|default(False)
+  when: item.db_import | default(False)
 
 - name: Import database
   mysql_db: name="{{ item.env.db_name | default(item.site_name) }}"
@@ -31,5 +31,5 @@
             login_user="{{ item.env.db_user }}"
             login_password="{{ item.env.db_password }}"
   with_items: wordpress_sites
-  when: item.db_import|default(False)
+  when: item.db_import | default(False)
   notify: reload nginx

--- a/roles/wordpress-sites/tasks/main.yml
+++ b/roles/wordpress-sites/tasks/main.yml
@@ -33,7 +33,7 @@
   args:
     chdir: "{{ www_root }}/{{ item.site_name }}/current/"
   with_items: wordpress_sites
-  when: item.run_composer|default(True) == True
+  when: item.run_composer | default(True) == True
 
 - name: WP installed?
   command: wp core is-installed --allow-root
@@ -54,7 +54,7 @@
   args:
     chdir: "{{ www_root }}/{{ item.item.site_name }}/current/"
   with_items: site_statuses.results
-  when: item.rc == 1 and item.item.site_install == True and item.item.multisite.enabled|default(False) == False
+  when: item.rc == 1 and item.item.site_install == True and item.item.multisite.enabled | default(False) == False
   notify: reload nginx
 
 - name: Install WP Multisite
@@ -70,7 +70,7 @@
   args:
     chdir: "{{ www_root }}/{{ item.item.site_name }}/current/"
   with_items: site_statuses.results
-  when: item.rc == 1 and item.item.site_install == True and item.item.multisite.enabled|default(False) == True
+  when: item.rc == 1 and item.item.site_install == True and item.item.multisite.enabled | default(False) == True
   notify: reload nginx
 
 - name: Setup system cron
@@ -80,4 +80,4 @@
         job="curl -s {{ item.env.wp_siteurl }}/wp-cron.php"
         cron_file="wordpress-{{ item.site_name|replace('.', '_') }}"
   with_items: wordpress_sites
-  when: item.system_cron|default(False) == True
+  when: item.system_cron | default(False) == True


### PR DESCRIPTION
The mvp here: 

``` bash
ag -0 "\|default" --files-with-matches | xargs -0 -I {} sed -i'' -e 's/|default/ | default/g' {}
```
