### PR TITLE
Make changing mysql root password possible.

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -10,7 +10,7 @@
     - { role: ferm, tags: [ferm] }
     - { role: ntp }
     - { role: sshd, tags: [sshd] }
-    - { role: mariadb, tags: [mariadb] }
+    - { role: mariadb, tags: [mariadb], when: not mysql_remote_database }
     - { role: ssmtp, tags: [ssmtp mail] }
     - { role: php, when: not hhvm, tags: [php] }
     - { role: hhvm, when: hhvm, tags: [hhvm] }

--- a/group_vars/all
+++ b/group_vars/all
@@ -1,7 +1,8 @@
 ---
 apt_cache_valid_time: 86400
 mariadb_dist: trusty
-mysql_user: root
+mysql_remote_database: false
+mysql_root_user: root
 www_root: /srv/www
 
 mail_smtp_server: smtp.mandrillapp.com:587

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -20,8 +20,6 @@
               host="{{ item }}"
               password="{{ mysql_root_password }}"
               check_implicit_admin=yes
-              login_user="{{ mysql_user }}"
-              login_password="{{ mysql_root_password }}"
               state=present
   with_items:
     - "{{ inventory_hostname }}"
@@ -29,11 +27,17 @@
     - ::1
     - localhost
 
+- name: Copy .my.cnf file with root password credentials.
+  template:
+    src: my.cnf.j2
+    dest: ~/.my.cnf
+    owner: root
+    group: root
+    mode: 0600
+
 - name: Delete anonymous MySQL server users
   mysql_user: user=""
               host="{{ item }}"
-              login_user="{{ mysql_user }}"
-              login_password="{{ mysql_root_password }}"
               state=absent
   with_items:
     - localhost
@@ -43,5 +47,3 @@
 - name: Remove the test database
   mysql_db: name=test
             state=absent
-            login_user="{{ mysql_user }}"
-            login_password="{{ mysql_root_password }}"

--- a/roles/mariadb/templates/my.cnf.j2
+++ b/roles/mariadb/templates/my.cnf.j2
@@ -1,0 +1,3 @@
+[client]
+user=root
+password={{ mysql_root_password }}

--- a/roles/wordpress-setup/tasks/database.yml
+++ b/roles/wordpress-setup/tasks/database.yml
@@ -3,10 +3,10 @@
   mysql_db: name="{{ item.value.env.db_name | default(item.key) }}"
             state=present
             login_host="{{ item.value.env.db_host | default('localhost') }}"
-            login_user="{{ mysql_user }}"
+            login_user="{{ mysql_root_user }}"
             login_password="{{ mysql_root_password }}"
   with_dict: wordpress_sites
-  when: item.value.db_create | default(True)
+  when: not mysql_remote_database and item.value.db_create | default(True)
 
 - name: Create/assign database user to db and grant permissions
   mysql_user: name="{{ item.value.env.db_user }}"
@@ -14,10 +14,10 @@
               priv="{{ item.value.env.db_name | default(item.key) }}.*:ALL"
               state=present
               login_host="{{ item.value.env.db_host | default('localhost') }}"
-              login_user="{{ mysql_user }}"
+              login_user="{{ mysql_root_user }}"
               login_password="{{ mysql_root_password }}"
   with_dict: wordpress_sites
-  when: item.value.db_create | default(True)
+  when: not mysql_remote_database and item.value.db_create | default(True)
 
 - name: Copy database dump
   copy: src="{{ item.value.db_import }}" dest=/tmp

--- a/server.yml
+++ b/server.yml
@@ -18,7 +18,7 @@
     - { role: ntp }
     - { role: users, tags: [users] }
     - { role: sshd, tags: [sshd] }
-    - { role: mariadb, tags: [mariadb] }
+    - { role: mariadb, tags: [mariadb], when: not mysql_remote_database }
     - { role: ssmtp, tags: [ssmtp mail] }
     - { role: php, when: not hhvm, tags: [php] }
     - { role: hhvm, when: hhvm, tags: [hhvm] }


### PR DESCRIPTION
This pull request makes it possible to change the root password. it fixes #237. I also removed the option `mysql_user` because it wasn't really doing anything. (The user is hardcoded to `root` in the task and it's not possible to change the root username without running some SQL).

This should only be merged after @swalkinshaw update the base box, else it's gonna break in the development environment.