### PR TITLE
Copy files/includes and populate templates/includes and add to includes.d.

### DIFF
--- a/roles/wordpress-setup/tasks/nginx.yml
+++ b/roles/wordpress-setup/tasks/nginx.yml
@@ -10,8 +10,29 @@
   when: item.value.ssl.enabled and item.value.ssl.key is defined | default(False)
 
 - name: Create includes.d directories
-  file: path="/etc/nginx/includes.d/{{ item.key }}" state=directory mode=0755
-  with_dict: wordpress_sites
+  file: path="/etc/nginx/includes.d/{{ item }}"
+        state=directory
+        mode=0755
+  with_items: wordpress_sites.keys()
+  register: nginx_includes_paths
+
+- name: Template files out to includes.d
+  template: src="includes.d/{{ item }}"
+            dest="/etc/nginx/includes.d/{{ item[:-3] }}"
+  with_lines: "cd ../templates/includes.d && find {{ wordpress_sites.keys() | join(' ') }} -type f -name \\*.conf.j2 2>/dev/null || :"
+  register: nginx_includes_managed
+  notify: reload nginx
+
+- name: Retrieve list of existing files in includes.d
+  shell: "find {{ nginx_includes_paths.results | map(attribute='path') | join(' ') }} -type f -name \\*.conf 2>/dev/null || :"
+  register: nginx_includes_existing
+  changed_when: false
+
+- name: Remove unmanaged files from includes.d
+  file: path="{{ item }}"
+        state=absent
+  with_items: "{{ nginx_includes_existing.stdout_lines | difference(nginx_includes_managed.results | default([]) | map(attribute='item') | map('regex_replace', '(.*)\\.j2', '/etc/nginx/includes.d/\\\\1') | list) }}"
+  notify: reload nginx
 
 - name: Create WordPress configuration for Nginx
   template: src="wordpress-site.conf.j2"


### PR DESCRIPTION
Picking up from #241, here's something that implements @louim's option 1, with both `files` and `templates` as @swalkinshaw suggested.

Be warned: This isn't pretty, and it relies on the `regex_replace` filter. Pretty sure this is safe for Ansible >= 1.8, though. 

Is there a better way to do this? I couldn't figure out how to nest a `with_fileglob` inside a `with_dict` (or a `with_items`/`wordpress_sites.keys()`), so someone could break the task if one of their folder names doesn't match one of their site keys.