### PR TITLE
Enable plugin unit testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,12 +152,35 @@ You can enable FastCGI caching on a per site basis. The cache is a low duration,
 
 The `secure-root.yml` playbook is provided to help secure your remote servers including better SSH security. See the Wiki for [Locking down root](https://github.com/roots/bedrock-ansible/wiki/Security#locking-down-root).
 
-## Unit Testing
+## Plugin Unit Testing
 
-You may wish to Unit Test your Plugins using the WP Core PHPUnit classes. To configure this ensure you have configured the test database correctly within the `group_vars/development` file. __This database will be dropped__ between each test so it is *critical* that you never use your main database as your test database.
+You may wish to Unit Test your Plugins using the WP Core PHPUnit classes. To configure this ensure you have configured the test database correctly within the `group_vars/development` file. 
+
+__Warning:__ *This database will be dropped* between each test so it is *critical* that you never use your main database as your test database.
 
 ### Testing a Plugin
 
-To test an individual plugin 
+To test an individual plugin we advise using WP CLI to scaffold the required files. To do this ssh into Vagrant and run:
+
+````wp scaffold plugin-tests my-plugin````
+
+...where `my-plugin` is the Plugin dir in which you wish to scaffold the test files. You should see several files generated. 
+
+We next need to edit the `tests/bootstrap.php` file, replacing...
+
+```
+$_tests_dir = getenv('WP_TESTS_DIR');
+if ( !$_tests_dir ) $_tests_dir = '/tmp/wordpress-tests-lib';
+```
+
+...with
+
+```
+$_tests_dir = '../../../../wp-tests-lib';
+```
+
+To run the Plugin's test suite cd into your plugin directory and run
+
+`../../../../vendor/bin/phpunit`
 
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ For a complete, working example you can see our [example project](https://github
   * `db_user` - database username (required)
   * `db_password` - database password (required)
   * `db_host` - database hostname (default: `localhost`)
+  * `test_db_name` - test database name (__must__ be different to primary `db_name`)
+  * `test_db_user` - test database user (__must__ be different to primary `db_user`
+  * `test_db_password` - test database password (__must__ be different to primary `db_password`)
   * `domain_current_site` (required if multisite.enabled is `true`)
 
 ### Mail
@@ -148,3 +151,13 @@ You can enable FastCGI caching on a per site basis. The cache is a low duration,
 ## Security
 
 The `secure-root.yml` playbook is provided to help secure your remote servers including better SSH security. See the Wiki for [Locking down root](https://github.com/roots/bedrock-ansible/wiki/Security#locking-down-root).
+
+## Unit Testing
+
+You may wish to Unit Test your Plugins using the WP Core PHPUnit classes. To configure this ensure you have configured the test database correctly within the `group_vars/development` file. __This database will be dropped__ between each test so it is *critical* that you never use your main database as your test database.
+
+### Testing a Plugin
+
+To test an individual plugin 
+
+

--- a/README.md
+++ b/README.md
@@ -154,7 +154,9 @@ The `secure-root.yml` playbook is provided to help secure your remote servers in
 
 ## Plugin Unit Testing
 
-You may wish to Unit Test your Plugins using the WP Core PHPUnit classes. To configure this ensure you have configured the test database correctly within the `group_vars/development` file. 
+You may wish to Unit Test your Plugins using the WP Core PHPUnit classes. 
+
+To do this ensure you have configured the test database correctly within the `group_vars/development` file. 
 
 __Warning:__ *This database will be dropped* between each test so it is *critical* that you never use your main database as your test database.
 

--- a/dev.yml
+++ b/dev.yml
@@ -21,3 +21,4 @@
     - { role: wp-cli, tags: [wp-cli] }
     - { role: wordpress-setup, tags: [wordpress, wordpress-setup] }
     - { role: wordpress-install, tags: [wordpress, wordpress-install] }
+    - { role: wordpress-tests, tags: [wordpress, wordpress-tests] }

--- a/group_vars/development
+++ b/group_vars/development
@@ -29,9 +29,9 @@ wordpress_sites:
       db_name: example_dev
       db_user: example_dbuser
       db_password: example_dbpassword
-      test_db_name: bedrock_test_dev_test
-      test_db_user: bedrock_test_dbuser_test
-      test_db_password: bedrock_test_dbpassword_test
+      test_db_name: example_dev_test
+      test_db_user: example_dbuser_test
+      test_db_password: example_dbpassword_test
 
 php_error_reporting: 'E_ALL'
 php_display_errors: 'On'

--- a/group_vars/development
+++ b/group_vars/development
@@ -29,6 +29,9 @@ wordpress_sites:
       db_name: example_dev
       db_user: example_dbuser
       db_password: example_dbpassword
+      test_db_name: bedrock_test_dev_test
+      test_db_user: bedrock_test_dbuser_test
+      test_db_password: bedrock_test_dbpassword_test
 
 php_error_reporting: 'E_ALL'
 php_display_errors: 'On'

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -11,3 +11,4 @@
   - python-mysqldb
   - curl
   - git-core
+  - subversion

--- a/roles/wordpress-setup/tasks/database.yml
+++ b/roles/wordpress-setup/tasks/database.yml
@@ -19,6 +19,26 @@
   with_dict: wordpress_sites
   when: item.value.db_create | default(True)
 
+- name: Create test database of sites
+  mysql_db: name="{{ item.value.env.test_db_name | default(item.key) }}"
+            state=present
+            login_host="{{ item.value.env.test_db_host | default('localhost') }}"
+            login_user="{{ mysql_user }}"
+            login_password="{{ mysql_root_password }}"
+  with_dict: wordpress_sites
+  when: item.value.db_create | default(True)
+
+- name: Create/assign test database user to db and grant permissions
+  mysql_user: name="{{ item.value.env.test_db_user }}"
+              password="{{ item.value.env.test_db_password }}"
+              priv="{{ item.value.env.test_db_name | default(item.key) }}.*:ALL"
+              state=present
+              login_host="{{ item.value.env.test_db_host | default('localhost') }}"
+              login_user="{{ mysql_user }}"
+              login_password="{{ mysql_root_password }}"
+  with_dict: wordpress_sites
+  when: item.value.db_create | default(True)
+
 - name: Copy database dump
   copy: src="{{ item.value.db_import }}" dest=/tmp
   with_dict: wordpress_sites

--- a/roles/wordpress-tests/defaults/main.yml
+++ b/roles/wordpress-tests/defaults/main.yml
@@ -1,0 +1,2 @@
+test_svn_repo: http://develop.svn.wordpress.org/trunk/tests/phpunit/includes/
+test_lib_dir: wp-tests-lib

--- a/roles/wordpress-tests/tasks/main.yml
+++ b/roles/wordpress-tests/tasks/main.yml
@@ -1,0 +1,27 @@
+- name: Create WP Tests Directory
+  file: path="{{ www_root }}/{{ item.key }}/current/{{ test_lib_dir }}"
+        owner="{{ web_user }}"
+        group="{{ web_group }}"
+        mode=0755
+        state=directory
+  with_dict: wordpress_sites
+
+- name: Clone WP PHPUnit Test Lib from WP SVN repo
+  command: svn co --quiet {{ test_svn_repo }}
+  args:
+    chdir: "{{ www_root }}/{{ item.key }}/current/{{ test_lib_dir }}"
+  with_dict: wordpress_sites
+
+- name: Create Bedrock WP Tests Config file
+  template: src="wp-tests-config.j2"
+            dest="{{ www_root }}/{{ item.key }}/current/{{ test_lib_dir }}/wp-tests-config.php"
+            owner="{{ web_user }}"
+            group="{{ web_group }}"
+  with_dict: wordpress_sites
+
+- name: Create Application Test Config file
+  template: src="application-test.j2"
+            dest="{{ www_root }}/{{ item.key }}/current/config/application-test.php"
+            owner="{{ web_user }}"
+            group="{{ web_group }}"
+  with_dict: wordpress_sites

--- a/roles/wordpress-tests/templates/application-test.j2
+++ b/roles/wordpress-tests/templates/application-test.j2
@@ -1,0 +1,56 @@
+<?php
+
+// Get paths
+$root_dir = dirname(__DIR__);
+$webroot_dir = $root_dir . '/web';
+
+/**
+ * Use Dotenv to set required environment variables and load .env file in root
+ */
+if (file_exists($root_dir . '/.env')) {
+  Dotenv::load($root_dir);
+}
+
+Dotenv::required(['TEST_DB_NAME', 'TEST_DB_USER', 'TEST_DB_PASSWORD', 'WP_HOME', 'WP_SITEURL']);
+
+/* Path to the WordPress codebase you'd like to test. Add a backslash in the end. */
+define( 'ABSPATH', $webroot_dir . '/wp/' );
+
+
+
+// Test with multisite enabled.
+// Alternatively, use the tests/phpunit/multisite.xml configuration file.
+// define( 'WP_TESTS_MULTISITE', true );
+
+// Force known bugs to be run.
+// Tests with an associated Trac ticket that is still open are normally skipped.
+// define( 'WP_TESTS_FORCE_KNOWN_BUGS', true );
+
+// Test with WordPress debug mode (default).
+define( 'WP_DEBUG', true );
+
+// ** MySQL settings ** //
+
+// This configuration file will be used by the copy of WordPress being tested.
+// wordpress/wp-config.php will be ignored.
+
+// WARNING WARNING WARNING!
+// These tests will DROP ALL TABLES in the database with the prefix named below.
+// DO NOT use a production database or one that is shared with something else.
+
+define( 'DB_NAME', getenv('TEST_DB_NAME') );
+define( 'DB_USER', getenv('TEST_DB_USER') );
+define( 'DB_PASSWORD', getenv('TEST_DB_PASSWORD') );
+define( 'DB_HOST', getenv('DB_HOST') ?: 'localhost');
+define( 'DB_CHARSET', 'utf8' );
+define( 'DB_COLLATE', '' );
+
+$table_prefix  = 'wptests_';   // Only numbers, letters, and underscores please!
+
+define( 'WP_TESTS_DOMAIN', getenv('WP_HOME') );
+define( 'WP_TESTS_EMAIL', 'admin@example.org' );
+define( 'WP_TESTS_TITLE', 'Test Blog' );
+
+define( 'WP_PHP_BINARY', 'php' );
+
+define( 'WPLANG', '' );

--- a/roles/wordpress-tests/templates/application-test.j2
+++ b/roles/wordpress-tests/templates/application-test.j2
@@ -7,11 +7,12 @@ $webroot_dir = $root_dir . '/web';
 /**
  * Use Dotenv to set required environment variables and load .env file in root
  */
+$dotenv = new Dotenv\Dotenv($root_dir);
 if (file_exists($root_dir . '/.env')) {
-  Dotenv::load($root_dir);
+  $dotenv->load();
 }
 
-Dotenv::required(['TEST_DB_NAME', 'TEST_DB_USER', 'TEST_DB_PASSWORD', 'WP_HOME', 'WP_SITEURL']);
+$dotenv->required(['TEST_DB_NAME', 'TEST_DB_USER', 'TEST_DB_PASSWORD', 'WP_HOME', 'WP_SITEURL']);
 
 /* Path to the WordPress codebase you'd like to test. Add a backslash in the end. */
 define( 'ABSPATH', $webroot_dir . '/wp/' );

--- a/roles/wordpress-tests/templates/wp-tests-config.j2
+++ b/roles/wordpress-tests/templates/wp-tests-config.j2
@@ -1,0 +1,3 @@
+<?php
+require_once(dirname(__DIR__) . '/vendor/autoload.php');
+require_once(dirname(__DIR__) . '/config/application-test.php');


### PR DESCRIPTION
A initial attempt at adding the ability to utilise the WP Unit Test library to Unit Test Plugins. Commits should outline work that has been completed. Basic work was:

* Create new Ansible role for `wordpress-tests`
* Configure Ansible to:
  * create new dir to store WP core test library
  * create test specific configuration file and store in `config` within Bedrock site
  * create a test database alongside main database
* Add PHPUnit as dependency within Composer
* Update README with basic instructions.

I'm very conscious that this is probably not up to the Roots team standards and so very keen to hear constructive feedback on how we feel this could be improved upon.