### PR TITLE
Add composer binary path to the default path.

### DIFF
--- a/roles/composer/tasks/main.yml
+++ b/roles/composer/tasks/main.yml
@@ -9,3 +9,10 @@
   command: composer self-update
   register: composer_update_result
   changed_when: composer_update_result.rc == 0 and 'already using composer version' not in composer_update_result.stderr
+
+- name: add Composer vendor binary path
+  lineinfile:
+    dest: /etc/environment
+    regexp: ^PATH="(((?!:./vendor/bin).)*)"
+    line: PATH="\1:./vendor/bin"
+    backrefs: yes


### PR DESCRIPTION
This adds the composer binary path to the default $PATH variable as discussed in #256 and #251 . I didn't chose to implement a complex regex. If anyone has a better regex, (eg it allow to append before the last quote of the path), let me know. 

I did chose to append the path in the `/etc/environment` because it is the preferred place to do it (the file contain one line : the PATH definition). After looking in the `/etc/bash.bashrc` it would have been out of place in this file.

This is also implemented globally, not only for the `vagrant` user in development. I think is wouln't hurt to have the composer binary path available on production servers too.

Feedback appreciated. 
cc: @getdave if you where wondering how to do it.