### PR TITLE
Change base box to stock Ubuntu 14.04

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,7 @@ end
 Vagrant.require_version '>= 1.5.1'
 
 Vagrant.configure('2') do |config|
-  config.vm.box = 'roots/bedrock'
+  config.vm.box = 'ubuntu/trusty64'
   config.ssh.forward_agent = true
 
   # Required for NFS to work, pick any local IP


### PR DESCRIPTION
We've been enjoying quick vagrant provisions using the `roots/bedrock` box, however it does have it's downfalls

1) Maintenance, a few things need to be manually updated like wp-cli
2) Dev/Prod parity - while this may not be a huge difference, using a stock Ubuntu box will ensure that all the same steps are being taken while provisioning both the Vagrant box and staging/production servers
3) `roots/bedrock` is the wrong name, and this is a big problem for me :trollface: 

So while initial `vagrant up` will take an extra few minutes, the trade-offs should be more than worth it.