### PR TITLE
Windows compatibility fix

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -59,7 +59,7 @@ Vagrant.configure('2') do |config|
   if Vagrant::Util::Platform.windows?
     config.vm.provision :shell do |sh|
       sh.path = File.join(ANSIBLE_PATH, 'windows.sh')
-      sh.args = ANSIBLE_PATH
+      sh.args = ''
     end
   else
     config.vm.provision :ansible do |ansible|

--- a/windows.sh
+++ b/windows.sh
@@ -20,7 +20,7 @@ if [ ! -f /usr/bin/ansible ]; then
   echo "Updating system..."
   sudo apt-get -y update
   echo "Installing Ansible..."
-  sudo apt-get -y install ansible
+  sudo apt-get -y --force-yes install ansible
 fi
 
 if [ ! -d /vagrant/${ANSIBLE_PATH}/vendor ]; then


### PR DESCRIPTION
*  ANSIBLE_PATH should be '' instead of \__dir__ or the windows path will be used inside  the vagrant box
* use --force-yes to install ansible (fails without)