### PR TITLE
Conditionally copy .env into web root

### DIFF
--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -9,8 +9,10 @@
   with_dict: wordpress_sites
 
 - name: Copy .env file into web root
-  command: creates="{{ www_root }}/{{ item.key }}/current/.env" cp /tmp/{{ item.key }}.env {{ www_root }}/{{ item.key }}/current/.env
+  command: rsync -ac --info=NAME /tmp/{{ item.key }}.env {{ www_root }}/{{ item.key }}/current/.env
   with_dict: wordpress_sites
+  register: env
+  changed_when: env.stdout == "{{ item.key }}.env"
 
 - name: Install Dependencies with Composer
   command: composer install


### PR DESCRIPTION
closes #261
`.env` was always being created (in `/tmp`) when `env` vars changed in `group_vars/development`. However, `.env` was only being copied into web root if there wasn't already an `.env` file there.

With these changes, `.env` will always be copied into place if a new `.env` is created, any time `env` vars are changed in `group_vars/development`. Still idempotent.

---------
Edit: The next several comments were reacting to these original PR changes (now out-of-date):
```diff
 - name: Create .env file
   template: src="env.j2"
             dest="/tmp/{{ item.key }}.env"
             owner="{{ web_user }}"
             group="{{ web_group }}"
   with_dict: wordpress_sites
+  register: env
 
 - name: Copy .env file into web root
-  command: creates="{{ www_root }}/{{ item.key }}/current/.env" cp /tmp/{{ item.key }}.env {{ www_root }}/{{ item.key }}/current/.env
+  command: cp /tmp/{{ item.key }}.env {{ www_root }}/{{ item.key }}/current/.env
   with_dict: wordpress_sites
+  when: env.changed
```