### PR TITLE
Fix windows provisioning path problem

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -59,7 +59,6 @@ Vagrant.configure('2') do |config|
   if Vagrant::Util::Platform.windows?
     config.vm.provision :shell do |sh|
       sh.path = File.join(ANSIBLE_PATH, 'windows.sh')
-      sh.args = ANSIBLE_PATH
     end
   else
     config.vm.provision :ansible do |ansible|

--- a/windows.sh
+++ b/windows.sh
@@ -5,7 +5,7 @@
 # @author Andrea Brandi
 # @version 1.0
 
-ANSIBLE_PATH=$1
+ANSIBLE_PATH="$(find /vagrant -name 'windows.sh' -printf '%h' -quit)"
 TEMP_HOSTS="/tmp/ansible_hosts"
 
 # Create an ssh key if not already created.
@@ -23,9 +23,9 @@ if [ ! -f /usr/bin/ansible ]; then
   sudo apt-get -y install ansible
 fi
 
-if [ ! -d /vagrant/${ANSIBLE_PATH}/vendor ]; then
+if [ ! -d ${ANSIBLE_PATH}/vendor ]; then
   echo "Running Ansible Galaxy install"
-  ansible-galaxy install -r /vagrant/${ANSIBLE_PATH}/requirements.yml -p /vagrant/${ANSIBLE_PATH}/vendor/roles
+  ansible-galaxy install -r ${ANSIBLE_PATH}/requirements.yml -p ${ANSIBLE_PATH}/vendor/roles
 fi
 
 if [ -d ${TEMP_HOSTS} ]; then
@@ -33,8 +33,8 @@ if [ -d ${TEMP_HOSTS} ]; then
   rm -rf ${TEMP_HOSTS}
 fi
 
-cp -R /vagrant/${ANSIBLE_PATH}/hosts ${TEMP_HOSTS} && chmod -x ${TEMP_HOSTS}/*
+cp -R ${ANSIBLE_PATH}/hosts ${TEMP_HOSTS} && chmod -x ${TEMP_HOSTS}/*
 echo "Running Ansible Playbooks"
-cd /vagrant/${ANSIBLE_PATH}/
-ansible-playbook /vagrant/${ANSIBLE_PATH}/dev.yml -i ${TEMP_HOSTS}/development --sudo --user=vagrant --connection=local
+cd ${ANSIBLE_PATH}/
+ansible-playbook ${ANSIBLE_PATH}/dev.yml -i ${TEMP_HOSTS}/development --sudo --user=vagrant --connection=local
 rm -rf ${TEMP_HOSTS}


### PR DESCRIPTION
Fixes windows provisioning, while retaining the variable nesting of the provisioning folder relative to the Vagrantfile

I successfully tested it with standard Trellis, and the example project where the Vagrantfile is one level up. @bezko if you want to test this out, it should be working as intended. 

This would fix #262 and render #264 obsolete. More testing is appreciated, as I normally don't develop on Windows. Since the fix is related to the linux VM, Windows shouldn't have anything to do with it. 