### PR TITLE
Flush wp db theme roots on deploy

### DIFF
--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -84,6 +84,7 @@ project_post_build_commands:
 # Post finalize commands are run with Ansible's `shell` module.
 # These are meant primarily for service restarts such as php5-fpm or memcached.
 project_post_finalize_commands:
+  - if wp core is-installed; then wp eval 'wp_clean_themes_cache(); switch_theme(get_stylesheet());'; fi
   - sudo service php5-fpm reload
 
 # At the end of the role, the unfinished_filename is removed and the "current" symlink is set to


### PR DESCRIPTION
### Problem
WSOD with status 200 after deploy (only if you do **not** navigate to wp-admin or re-activate theme)

**Setup**
```
# create DO droplet then set ip to variable
export DO_IP=xx.xx.xx.xxx
# also add IP and staging.example.com to /etc/hosts

# Prepare trellis and provision
mkdir tmp
cd tmp
git clone git@github.com:roots/trellis.git
cd trellis
ansible-galaxy install -r requirements.yml
sed -i '' "s/192.168.50.5/$DO_IP/g" hosts/staging
ansible-playbook -i hosts/staging server.yml
```

**Deploy 1** -- no problem yet
```
./deploy.sh staging example.com
ssh web@$DO_IP "cd /srv/www/example.com/current && wp core install --url=http://staging.example.com --title='Example Staging Site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com"
ssh web@$DO_IP "cd /srv/www/example.com/current && wp theme activate twentytwelve"

# browse to example.com -- site loads fine

# correct deploy 1 release path in stylesheet_root, template_root, transient
ssh web@$DO_IP "cd /srv/www/example.com/current && wp option get template_root && wp option get stylesheet_root && wp option get _site_transient_theme_roots"
```

**Deploy 2** -- here's the WSOD problem due to out-of-date "theme roots" in db
```
./deploy.sh staging example.com

# refresh browser at example.com -- WSOD (without first going to wp-admin or activating a theme)

# incorrect deploy 1 release path in db -- should be deploy 2 release path
ssh web@$DO_IP "cd /srv/www/example.com/current && wp option get template_root && wp option get stylesheet_root && wp option get _site_transient_theme_roots"
```

**Deploy 3** -- same WSOD, incorrect deploy 1 release path in db -- should be deploy 3 release path

### Potential solution
This PR adds [`project_post_finalize_commands`](https://github.com/roots/trellis/blob/d12b4b261f88913d0c8b57756c1c9aa2232a0c63/roles/deploy/defaults/main.yml#L86-L87) that...
- clear theme roots transients by running `wp_clean_themes_cache()`
- update "theme roots" by running `switch_theme()` to the current theme
```
git pull https://github.com/fullyint/trellis.git theme-roots
```

**Deploy 4** -- no more WSOD problem
```
./deploy.sh staging example.com

# refresh browser at example.com -- page loads (no more WSOD)

# correct deploy 4 release path in db
ssh web@$DO_IP "cd /srv/www/example.com/current && wp option get template_root && wp option get stylesheet_root && wp option get _site_transient_theme_roots"
```

### What's happening
Capistrano-style deploys have had [trouble with out-of-date theme roots](https://github.com/roots/bedrock/pull/101) in the db, leading to a white screen. Some have addressed the issue by running a conditional search-replace on the `stylesheet_root` and `template_root` in the db. 

However, it seems cleaner to run [`switch_theme()`](https://github.com/WordPress/WordPress/blob/4.2.2/wp-includes/theme.php#L761) to the current theme, which will refresh the `wp_option` values for `stylesheet_root` and `template_root`. It does so via [`get_raw_theme_root()`](https://github.com/WordPress/WordPress/blob/4.2.2/wp-includes/theme.php#L604), which consults [`get_theme_roots()`](https://github.com/WordPress/WordPress/blob/4.2.2/wp-includes/theme.php#L343), which tries to use `get_site_transient( 'theme_roots' )`, which consults a `wp_options` transient named `_site_transient_theme_roots`.

This `_site_transient_theme_roots` contains absolute paths that don't update on deploy, so it points to out-of-date release directories. But, as in [wp theme unit tests](https://github.com/tommcfarlin/Basic-Theme/blob/b59e438772e026d1165059e2fb9bd12c472c711a/tests/tests/test_includes_class-wp-theme.php#L17), if we ['wp_clean_themes_cache()'](https://github.com/WordPress/WordPress/blob/4.2.2/wp-includes/theme.php#L115), the `get_theme_roots()` above will [`search_theme_directories( true ); // Regenerate the transient`](https://github.com/WordPress/WordPress/blob/4.2.2/wp-includes/theme.php#L351), getting the release path of the latest deploy, adding it to `stylesheet_root` and `template_root`.

Any of you WP pros see any problems with this? Recommend a better solution?