### PR TITLE
Fix PHP error handling

### DIFF
--- a/roles/php/templates/php-fpm.conf.j2
+++ b/roles/php/templates/php-fpm.conf.j2
@@ -13,6 +13,8 @@ pm.min_spare_servers = 1
 pm.max_spare_servers = 3
 pm.max_requests = 500
 chdir = {{ www_root }}/
+php_admin_flag[log_errors] = on
+php_admin_flag[display_errors] = {{ php_display_errors }}
 php_admin_value[open_basedir] = {{ www_root }}/:/tmp
 {% if memcached_sessions %}
 session.save_handler = memcached


### PR DESCRIPTION
These settings in our PHP-FPM conf help us achieve our intended goal of PHP error logging:

* development: log and display all errors
* production: log errors only

Setting `log_errors` is the key here.

/cc @nathanielks @austinpray 