### PR TITLE
Allow auto-generation of self signed SSL certificate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Before using Trellis, you must configure your WordPress sites. The `group_vars` 
 * `repo` - URL of the Git repo of your Bedrock project (required, used when deploying)
 * `branch` - the branch name, tag name, or commit SHA1 you want to deploy (default: `master`)
 * `ssl` - enable SSL and set paths
-  * `enabled` - `true` or `false` (required, set to `false`)
+  * `enabled` - `true` or `false` (required, set to `false`. Set to `true` without the `key` and `cert` options [to generate a *self-signed* certificate](https://github.com/roots/trellis/wiki/SSL) )
   * `key` - local relative path to private key
   * `cert` - local relative path to certificate
 * `site_install` - whether to install WordPress or not (*development* only, required)
@@ -126,7 +126,7 @@ Outgoing mail is handled by sSMTP. Configure credentials in `group_vars/all`.  S
 
 ## SSL
 
-Full SSL support is available for your WordPress sites. Our HTTPS implementation has all the best practices for performance and security. (Note: default configuration is HTTPS **only**.) See the [SSL wiki](https://github.com/roots/trellis/wiki/SSL).
+Full SSL support is available for your WordPress sites. Trellis will also *auto-generate* self-signed certificates for development purposes. Our HTTPS implementation has all the best practices for performance and security. (Note: default configuration is HTTPS **only**.) See the [SSL wiki](https://github.com/roots/trellis/wiki/SSL).
 
 ## Caching
 

--- a/roles/wordpress-setup/tasks/main.yml
+++ b/roles/wordpress-setup/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 - include: database.yml
+- include: self-signed-certificate.yml
 - include: nginx.yml
 
 - name: Create web root

--- a/roles/wordpress-setup/tasks/nginx.yml
+++ b/roles/wordpress-setup/tasks/nginx.yml
@@ -2,12 +2,12 @@
 - name: Copy SSL cert
   copy: src="{{ item.value.ssl.cert }}" dest=/etc/nginx/ssl/{{ item.value.ssl.cert | basename }} mode=0640
   with_dict: wordpress_sites
-  when: item.value.ssl.enabled | default(False)
+  when: item.value.ssl.enabled and item.value.ssl.cert is defined | default(False)
 
 - name: Copy SSL key
   copy: src="{{ item.value.ssl.key }}" dest=/etc/nginx/ssl/{{ item.value.ssl.key | basename }} mode=0600
   with_dict: wordpress_sites
-  when: item.value.ssl.enabled | default(False)
+  when: item.value.ssl.enabled and item.value.ssl.key is defined | default(False)
 
 - name: Create includes.d directories
   file: path="/etc/nginx/includes.d/{{ item.key }}" state=directory mode=0755

--- a/roles/wordpress-setup/tasks/self-signed-certificate.yml
+++ b/roles/wordpress-setup/tasks/self-signed-certificate.yml
@@ -1,0 +1,28 @@
+---
+- name: Get existing self-signed certificates
+  shell: find . -name "*_self_signed.pem"
+  args:
+    chdir: /etc/nginx/ssl/
+  register: self_signed_certs
+  changed_when: false
+
+- name: Get self-signed certificates domains
+  shell: openssl x509 -noout -subject -in {{ item | quote }} | sed -n "/^subject/s/^.*CN=//p"
+  register: self_signed_domains
+  args:
+    chdir: /etc/nginx/ssl/
+  with_items: self_signed_certs.stdout_lines
+  changed_when: false
+
+- name: Generate self-signed certificates
+  shell: >
+    openssl req -subj "/CN={{ item.value.site_hosts | first }}" -new
+    -newkey rsa:2048 -days 3650 -nodes -x509 -sha256
+    -keyout {{ item.key }}_self_signed.key -out {{ item.key }}_self_signed.pem
+  args:
+    chdir: /etc/nginx/ssl/
+  with_dict: wordpress_sites
+  when: >
+    item.value.ssl.enabled and item.value.site_hosts | first
+    not in self_signed_domains.results | default([]) | map(attribute='stdout') | list
+  notify: reload nginx

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -37,9 +37,16 @@ server {
   add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; preload";
   add_header X-Frame-Options SAMEORIGIN;
 
+  {% if item.value.ssl.cert is defined and item.value.ssl.key is defined %}
   ssl_certificate         /etc/nginx/ssl/{{ item.value.ssl.cert | basename }};
   ssl_trusted_certificate /etc/nginx/ssl/{{ item.value.ssl.cert | basename }};
   ssl_certificate_key     /etc/nginx/ssl/{{ item.value.ssl.key | basename }};
+  {% else %}
+  ssl_certificate         /etc/nginx/ssl/{{ item.key }}_self_signed.pem;
+  ssl_trusted_certificate /etc/nginx/ssl/{{ item.key }}_self_signed.pem;
+  ssl_certificate_key     /etc/nginx/ssl/{{ item.key }}_self_signed.key;
+  {% endif %}
+
   {% endif %}
 
   include includes.d/{{ item.key }}/*.conf;


### PR DESCRIPTION
As discussed in #277.

TLDR: When the SSL "enabled" key is set to true while "key" and "cert" are not provided, a self-signed certificate will be generated and used.

### How I've done it
1. First get all the already generated self-signed certificates, so we can prevent recreating those that already exists. Certs are named like their `wordress_sites` key instead of the domain to prevent recreating new files each time the domain is changed and to stay consistent with the folder naming conventions.
1. Get the domain name of the certs gathered in step 1.
1. Generate new SSL cert and key for each `wordress_sites` key "primary" domain  that is not in the list of domains gathered on step 2 and for which SSL is enabled
1. Assign generated cert and key in nginx config for the site.

### A word of warning
I encountered some difficulties while preparing this PR. The main one is that if we generate self signed certificates, we need to update them if / when the domain change (I use the first domain provided in the list if the user provide more than one). We also need to take in account that the user can have multiple sites. Handling of `wordress_sites` , which is a `dict` while trying to fetch all generated certificates files (to prevent recreating them on each provisioning) proved to be a hard task. Running `with_items` or  `with_dict` while `register`ing the output will alway return an `array` of results, and I didn't find an efficient way to make it correlate to the `wordress_sites` dict.

I think It came out OK in the end, but if you have a more elegant solution, or a more efficient way of doing this, I'm all ears!

### The one problem
There is only one situation which is unaccounted for in the current situation: if the user has multiples sites configured on the same environment (aka multiples entries in `wordress_sites`) and decide to swap the `site_hosts` between two sites in the same provisioning run, the certs [won't change](https://github.com/roots/trellis/compare/roots:master...louim:add-snake-oil-certs?expand=1#diff-ff830fc010a506c1a47b7aba05cd8bb7R23). 
Example: 

* site1 -> *example.dev*, site2 -> **mysite.dev**

changed to:

* site1 -> **mysite.dev**, site2 -> *example.dev*

I think it's an  edge-case incredibly unlikely to happen, but I wanted to have your opinions on it.