### PR TITLE
Validate that at least the minimum required version of ansible is used

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,0 +1,1 @@
+minimum_ansible_version: 1.9.2

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+- name: Validate Ansible version
+  assert:
+    that:
+     - "{{ ansible_version is defined }}"
+     - "{{ ansible_version.full | version_compare(minimum_ansible_version, '>=') }}"
+    msg: "Your Ansible version is too old. Trellis require at least {{ minimum_ansible_version }}. Your version is {{ ansible_version.full | default('< 1.6') }}"
+
 - name: Update Apt
   apt: update_cache=yes
 


### PR DESCRIPTION
This will validate the version of Ansible used, to prevent errors that could happen with older version than what we require.

Il will also present the user with an easy to understand message if they need to upgrade their version. I set the version to `1.9.2` in prevision of #274 being merged in.