### PR TITLE
Fix multisite install

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,6 @@ ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
 
 require 'yaml'
 
-PRIVATE_IP   = '192.168.50.5'
 ANSIBLE_PATH = __dir__ # path targeting Ansible directory (relative to Vagrantfile)
 
 # Set Ansible roles_path relative to Ansible directory
@@ -28,7 +27,7 @@ Vagrant.configure('2') do |config|
   config.ssh.forward_agent = true
 
   # Required for NFS to work, pick any local IP
-  config.vm.network :private_network, ip: PRIVATE_IP
+  config.vm.network :private_network, ip: '192.168.50.5'
 
   hostname, *aliases = wordpress_sites.flat_map { |(_name, site)| site['site_hosts'] }
   config.vm.hostname = hostname

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,7 +50,7 @@ Vagrant.configure('2') do |config|
   
   # Comment out this control block for subdomain multisite installs
   if Vagrant.has_plugin? 'vagrant-hostsupdater'
-    config.hostsupdater.aliases = aliases
+    config.hostsupdater.aliases = aliases + www_aliases
   else
     puts 'vagrant-hostsupdater missing, please install the plugin:'
     puts 'vagrant plugin install vagrant-hostsupdater'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,21 +34,6 @@ Vagrant.configure('2') do |config|
   config.vm.hostname = hostname
   www_aliases = ["www.#{hostname}"] + aliases.map { |host| "www.#{host}" }
 
-  # Uncomment this control block for subdomain multisite installs
-  # See note on next control block
-  # if Vagrant.has_plugin? 'landrush'
-  #   config.landrush.enabled = true
-  #   config.landrush.tld = config.vm.hostname
-  # 
-  #   aliases.each do |host|
-  #     config.landrush.host host, PRIVATE_IP
-  #   end
-  # else
-  #   puts 'landrush missing, please install the plugin:'
-  #   puts 'vagrant plugin install landrush'
-  # end
-  
-  # Comment out this control block for subdomain multisite installs
   if Vagrant.has_plugin? 'vagrant-hostsupdater'
     config.hostsupdater.aliases = aliases + www_aliases
   else

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,7 @@ ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
 
 require 'yaml'
 
+PRIVATE_IP   = '192.168.50.5'
 ANSIBLE_PATH = __dir__ # path targeting Ansible directory (relative to Vagrantfile)
 
 # Set Ansible roles_path relative to Ansible directory
@@ -27,14 +28,29 @@ Vagrant.configure('2') do |config|
   config.ssh.forward_agent = true
 
   # Required for NFS to work, pick any local IP
-  config.vm.network :private_network, ip: '192.168.50.5'
+  config.vm.network :private_network, ip: PRIVATE_IP
 
   hostname, *aliases = wordpress_sites.flat_map { |(_name, site)| site['site_hosts'] }
   config.vm.hostname = hostname
   www_aliases = ["www.#{hostname}"] + aliases.map { |host| "www.#{host}" }
 
+  # Uncomment this control block for subdomain multisite installs
+  # See note on next control block
+  # if Vagrant.has_plugin? 'landrush'
+  #   config.landrush.enabled = true
+  #   config.landrush.tld = config.vm.hostname
+  # 
+  #   aliases.each do |host|
+  #     config.landrush.host host, PRIVATE_IP
+  #   end
+  # else
+  #   puts 'landrush missing, please install the plugin:'
+  #   puts 'vagrant plugin install landrush'
+  # end
+  
+  # Comment out this control block for subdomain multisite installs
   if Vagrant.has_plugin? 'vagrant-hostsupdater'
-    config.hostsupdater.aliases = aliases + www_aliases
+    config.hostsupdater.aliases = aliases
   else
     puts 'vagrant-hostsupdater missing, please install the plugin:'
     puts 'vagrant plugin install vagrant-hostsupdater'

--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -42,7 +42,7 @@
   register: multisite_statuses
   with_dict: wordpress_sites
   changed_when: False
-  failed_when: site_statuses.rc != 1 and site_statuses.rc != 0
+  failed_when: multisite_statuses.rc != 1 and multisite_statuses.rc != 0
   when: item.value.multisite.enabled == True
 
 - name: Install WP

--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -32,19 +32,6 @@
   failed_when: site_statuses.stderr != ""
   when: item.value.multisite.enabled == False
 
-- name: WP network installed?
-  command: wp core is-installed
-           --allow-root
-           --network
-           --url="{{ item.value.env.wp_home }}"
-  args:
-    chdir: "{{ www_root }}/{{ item.key }}/current/"
-  register: multisite_statuses
-  with_dict: wordpress_sites
-  changed_when: False
-  failed_when: multisite_statuses.rc != 1 and multisite_statuses.rc != 0
-  when: item.value.multisite.enabled == True
-
 - name: Install WP
   command: wp core install
            --allow-root
@@ -58,6 +45,19 @@
   with_items: site_statuses.results
   when: item.rc == 1 and item.item.value.site_install == True and (item.item.value.multisite.enabled | default(False) == False)
 
+- name: WP network installed?
+  command: wp core is-installed
+           --allow-root
+           --network
+           --url="{{ item.item.value.env.wp_home }}"
+  args:
+    chdir: "{{ www_root }}/{{ item.item.key }}/current/"
+  register: site_statuses
+  with_dict: wordpress_sites
+  changed_when: False
+  failed_when: site_statuses.rc != 1 and site_statuses.rc != 0
+  when: item.value.multisite.enabled == True
+
 - name: Install WP Multisite
   command: wp core multisite-install
            --allow-root
@@ -70,8 +70,8 @@
            --admin_email="{{ item.item.value.admin_email }}"
   args:
     chdir: "{{ www_root }}/{{ item.item.key }}/current/"
-  with_items: multisite_statuses.results
-  when: item.rc == 1 and item.item.value.site_install == True and (item.item.value.multisite.enabled | default(False) == True)
+  with_items: site_statuses.results
+  when: item.skipped != True and item.item.value.multisite.enabled == True and item.rc == 1 and item.item.value.site_install == True and (item.item.value.multisite.enabled | default(False) == False)
 
 - name: Restart HHVM
   service: name=hhvm state=restarted

--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -39,10 +39,10 @@
            --url="{{ item.value.env.wp_home }}"
   args:
     chdir: "{{ www_root }}/{{ item.key }}/current/"
-  register: site_statuses
+  register: multisite_statuses
   with_dict: wordpress_sites
   changed_when: False
-  failed_when: site_statuses.rc != 1 | site_statuses.rc != 0
+  failed_when: site_statuses.rc != 1 and site_statuses.rc != 0
   when: item.value.multisite.enabled == True
 
 - name: Install WP
@@ -70,7 +70,7 @@
            --admin_email="{{ item.item.value.admin_email }}"
   args:
     chdir: "{{ www_root }}/{{ item.item.key }}/current/"
-  with_items: site_statuses.results
+  with_items: multisite_statuses.results
   when: item.rc == 1 and item.item.value.site_install == True and (item.item.value.multisite.enabled | default(False) == True)
 
 - name: Restart HHVM

--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -30,7 +30,7 @@
   with_dict: wordpress_sites
   changed_when: False
   failed_when: site_statuses.stderr != ""
-  when: item.value.multisite.enabled | default(False) == False
+  when: item.value.multisite.enabled == False
 
 - name: WP network installed?
   command: wp core is-installed
@@ -43,9 +43,20 @@
   with_dict: wordpress_sites
   changed_when: False
   failed_when: site_statuses.rc != 1 | site_statuses.rc != 0
-  when: item.value.multisite.enabled | default(False) == True
-  
-  when: item.rc == 1 and item.item.value.site_install == True and item.item.value.multisite.enabled == False
+  when: item.value.multisite.enabled == True
+
+- name: Install WP
+  command: wp core install
+           --allow-root
+           --url="{{ item.item.value.env.wp_home }}"
+           --title="{{ item.item.value.site_title | default(item.item.key) }}"
+           --admin_user="{{ item.item.value.admin_user }}"
+           --admin_password="{{ item.item.value.admin_password }}"
+           --admin_email="{{ item.item.value.admin_email }}"
+  args:
+    chdir: "{{ www_root }}/{{ item.item.key }}/current/"
+  with_items: site_statuses.results
+  when: item.rc == 1 and item.item.value.site_install == True and (item.item.value.multisite.enabled | default(False) == False)
 
 - name: Install WP Multisite
   command: wp core multisite-install
@@ -60,7 +71,7 @@
   args:
     chdir: "{{ www_root }}/{{ item.item.key }}/current/"
   with_items: site_statuses.results
-  when: item.rc == 1 and item.item.value.site_install == True and item.item.value.multisite.enabled == True
+  when: item.rc == 1 and item.item.value.site_install == True and (item.item.value.multisite.enabled | default(False) == True)
 
 - name: Restart HHVM
   service: name=hhvm state=restarted

--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -45,18 +45,7 @@
   failed_when: site_statuses.rc != 1 | site_statuses.rc != 0
   when: item.value.multisite.enabled | default(False) == True
   
-- name: Install WP
-  command: wp core install
-           --allow-root
-           --url="{{ item.item.value.env.wp_home }}"
-           --title="{{ item.item.value.site_title | default(item.item.key) }}"
-           --admin_user="{{ item.item.value.admin_user }}"
-           --admin_password="{{ item.item.value.admin_password }}"
-           --admin_email="{{ item.item.value.admin_email }}"
-  args:
-    chdir: "{{ www_root }}/{{ item.item.key }}/current/"
-  with_items: site_statuses.results
-  when: item.rc == 1 and item.item.value.site_install == True and (item.item.value.multisite.enabled | default(False) == False)
+  when: item.rc == 1 and item.item.value.site_install == True and item.item.value.multisite.enabled == False
 
 - name: Install WP Multisite
   command: wp core multisite-install
@@ -71,7 +60,7 @@
   args:
     chdir: "{{ www_root }}/{{ item.item.key }}/current/"
   with_items: site_statuses.results
-  when: item.rc == 1 and item.item.value.site_install == True and (item.item.value.multisite.enabled | default(False) == True)
+  when: item.rc == 1 and item.item.value.site_install == True and item.item.value.multisite.enabled == True
 
 - name: Restart HHVM
   service: name=hhvm state=restarted

--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -23,14 +23,15 @@
   changed_when: "'Nothing to install or update' not in composer_results.stderr"
 
 - name: WP installed?
-  command: wp core is-installed --allow-root
+  command: wp core is-installed
+           --allow-root
+           --url="{{ item.value.env.wp_home }}"
   args:
     chdir: "{{ www_root }}/{{ item.key }}/current/"
   register: site_statuses
   with_dict: wordpress_sites
   changed_when: False
-  failed_when: site_statuses.stderr != ""
-  when: item.value.multisite.enabled == False
+  failed_when: False
 
 - name: Install WP
   command: wp core install
@@ -45,19 +46,6 @@
   with_items: site_statuses.results
   when: item.rc == 1 and item.item.value.site_install == True and (item.item.value.multisite.enabled | default(False) == False)
 
-- name: WP network installed?
-  command: wp core is-installed
-           --allow-root
-           --network
-           --url="{{ item.item.value.env.wp_home }}"
-  args:
-    chdir: "{{ www_root }}/{{ item.item.key }}/current/"
-  register: site_statuses
-  with_dict: wordpress_sites
-  changed_when: False
-  failed_when: site_statuses.rc != 1 and site_statuses.rc != 0
-  when: item.value.multisite.enabled == True
-
 - name: Install WP Multisite
   command: wp core multisite-install
            --allow-root
@@ -71,7 +59,7 @@
   args:
     chdir: "{{ www_root }}/{{ item.item.key }}/current/"
   with_items: site_statuses.results
-  when: item.skipped != True and item.item.value.multisite.enabled == True and item.rc == 1 and item.item.value.site_install == True and (item.item.value.multisite.enabled | default(False) == False)
+  when: item.rc == 1 and item.item.value.site_install == True and (item.item.value.multisite.enabled | default(False) == True)
 
 - name: Restart HHVM
   service: name=hhvm state=restarted

--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -22,44 +22,33 @@
   with_dict: wordpress_sites
   changed_when: "'Nothing to install or update' not in composer_results.stderr"
 
-- name: WP installed?
-  command: wp core is-installed
-           --allow-root
-           --url="{{ item.value.env.wp_home }}"
-  args:
-    chdir: "{{ www_root }}/{{ item.key }}/current/"
-  register: site_statuses
-  with_dict: wordpress_sites
-  changed_when: False
-  failed_when: False
-
 - name: Install WP
   command: wp core install
            --allow-root
-           --url="{{ item.item.value.env.wp_home }}"
-           --title="{{ item.item.value.site_title | default(item.item.key) }}"
-           --admin_user="{{ item.item.value.admin_user }}"
-           --admin_password="{{ item.item.value.admin_password }}"
-           --admin_email="{{ item.item.value.admin_email }}"
+           --url="{{ item.value.env.wp_home }}"
+           --title="{{ item.value.site_title | default(item.key) }}"
+           --admin_user="{{ item.value.admin_user }}"
+           --admin_password="{{ item.value.admin_password }}"
+           --admin_email="{{ item.value.admin_email }}"
   args:
-    chdir: "{{ www_root }}/{{ item.item.key }}/current/"
-  with_items: site_statuses.results
-  when: item.rc == 1 and item.item.value.site_install == True and (item.item.value.multisite.enabled | default(False) == False)
+    chdir: "{{ www_root }}/{{ item.key }}/current/"
+  with_dict: wordpress_sites
+  when: item.value.site_install == True and (item.value.multisite.enabled | default(False) == False)
 
 - name: Install WP Multisite
   command: wp core multisite-install
            --allow-root
-           --url="{{ item.item.value.env.wp_home }}"
-           --base="{{ item.item.value.multisite.base_path | default('/') }}"
-           --subdomains="{{ item.item.value.multisite.subdomains | default('false') }}"
-           --title="{{ item.item.value.site_title | default(item.item.key) }}"
-           --admin_user="{{ item.item.value.admin_user }}"
-           --admin_password="{{ item.item.value.admin_password }}"
-           --admin_email="{{ item.item.value.admin_email }}"
+           --url="{{ item.value.env.wp_home }}"
+           --base="{{ item.value.multisite.base_path | default('/') }}"
+           --subdomains="{{ item.value.multisite.subdomains | default('false') }}"
+           --title="{{ item.value.site_title | default(item.key) }}"
+           --admin_user="{{ item.value.admin_user }}"
+           --admin_password="{{ item.value.admin_password }}"
+           --admin_email="{{ item.value.admin_email }}"
   args:
-    chdir: "{{ www_root }}/{{ item.item.key }}/current/"
-  with_items: site_statuses.results
-  when: item.rc == 1 and item.item.value.site_install == True and (item.item.value.multisite.enabled | default(False) == True)
+    chdir: "{{ www_root }}/{{ item.key }}/current/"
+  with_dict: wordpress_sites
+  when: item.value.site_install == True and (item.value.multisite.enabled | default(False) == True)
 
 - name: Restart HHVM
   service: name=hhvm state=restarted

--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -23,13 +23,28 @@
   changed_when: "'Nothing to install or update' not in composer_results.stderr"
 
 - name: WP installed?
-  command: wp core is-installed --allow-root
+  command: wp core is-installed
+           --allow-root
   args:
     chdir: "{{ www_root }}/{{ item.key }}/current/"
   register: site_statuses
   with_dict: wordpress_sites
   changed_when: False
   failed_when: site_statuses.stderr != ""
+  when: item.value.multisite.enabled | default(False) == False
+
+- name: WP network installed?
+  command: wp core is-installed
+           --allow-root
+           --network
+           --url="{{ item.value.env.wp_home }}"
+  args:
+    chdir: "{{ www_root }}/{{ item.key }}/current/"
+  register: site_statuses
+  with_dict: wordpress_sites
+  changed_when: False
+  failed_when: site_statuses.rc > 1
+  when: item.value.multisite.enabled | default(False) == True
 
 - name: Install WP
   command: wp core install

--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -23,8 +23,7 @@
   changed_when: "'Nothing to install or update' not in composer_results.stderr"
 
 - name: WP installed?
-  command: wp core is-installed
-           --allow-root
+  command: wp core is-installed --allow-root
   args:
     chdir: "{{ www_root }}/{{ item.key }}/current/"
   register: site_statuses
@@ -43,9 +42,9 @@
   register: site_statuses
   with_dict: wordpress_sites
   changed_when: False
-  failed_when: site_statuses.rc > 1
+  failed_when: site_statuses.rc != 1 | site_statuses.rc != 0
   when: item.value.multisite.enabled | default(False) == True
-
+  
 - name: Install WP
   command: wp core install
            --allow-root

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -24,7 +24,7 @@ server {
   {% if item.value.multisite.enabled | default(false) -%}
     {% if item.value.multisite.subdomains | default(false) -%}
       rewrite ^/(wp-.*.php)$ /wp/$1 last;
-      rewrite ^/(wp-(content|admin|includes)/.*) /wp/$1 last;
+      rewrite ^/(wp-(content|admin|includes).*) /wp/$1 last;
     {%- else -%}
       include wordpress_multisite_subdirectories.conf;
     {%- endif %}

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -7,7 +7,7 @@ server {
   listen 80;
   {% endif %}
 
-  server_name  {{ item.value.site_hosts | join(' ') }};
+  server_name  {% for host in item.value.site_hosts %} {{ host }} {% if item.value.multisite.subdomains %} *.{{ host }} {% endif %} {% endfor %};
   access_log   {{ www_root }}/{{ item.key }}/logs/access.log;
   error_log    {{ www_root }}/{{ item.key }}/logs/error.log;
 


### PR DESCRIPTION
Regarding #266.

### wp installed?
WP_CLI outputs a variety of information to STDERR and/or STDOUT depending on the scenario that it is working through. That output, while possibly being helpful for debugging purposes, is not directly useful to the two install plays that follow. Therefore, after toying around with ideas for expanded conditionals or group_by usage I simplified and chose to set `failed_when: False`.

FWIW, this play appears redundant and may be able to be removed/replaced entirely. WP-CLI appears to call `is_blog_installed()` at the beginning of both its `install` function and `multisite_install` function - see lines 433-434, 502-503 both leading to lines 560-563 in [this file](https://github.com/wp-cli/wp-cli/blob/master/php/commands/core.php). As it is, keeping this play may open up some possibilities for custom modifications/expansion based on individual user needs.

I also addressed the HTTP_HOST issues which were cropping up in the process as well.

### wildcard handling for server_name
I used @austinpray's code. It works.

### how to/the wiki
The procedures in the wiki basically work. Specifically the steps are:
1. Manually add the multisite constants to the `config/application.php` file. If they are not added and Bedrock is in use, WP-CLI will stick the constants at the end of the `wp-config.php` file, which is unworkable.
2. Update the `multisite` settings in `group_vars`, including adding `domain_current_site: example.com` under `env`.
3. (For subdomain installs only) Make sure that the Landrush plugin is installed and then swap in the changes given in the wiki into the `Vagrantfile`.