### PR TITLE
Trellis 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
-### HEAD
+### 0.9.0: August 3rd, 2015
+* Allow auto-generation of self signed SSL certificate
+* Merge secure-root.yml into server.yml
+* Bump Ansible requirement to >= 1.9.2
+* Validate that at least the minimum required version of Ansible is used
+* Fix PHP error handling
+* Flush wp db theme roots on deploy
+* Stop recursive copying of vendor
+* Update the windows.sh script with absolute path
+* Conditionally copy .env into web root
+* Add subtree commented out
+* Add Composer binary path to the default path
+* Change base box to stock Ubuntu 14.04
+* Rename bedrock-ansible to Trellis
+* Restore strip_www functionality
+* Protect against Logjam attack by generating a strong and unique Diffie-Hellman group
+* Move SSH key handling to users role
+* Fix multisite conditional in wordpress-site.conf
+* Allow use of FastCGI caching
+* Wrap octal mode in quotes
+* Fix project_shared_children mode defaults
+* Allow for custom permissions for shared sources
+* Provide a mechanism for custom Nginx includes
+* Add trailing slash to WP core rewrite, preventing possible redirect loop
+* Insert full path to service command, add hhvm restart minute
+* Disable exposing PHP version to the world
+* wordpress-install improvements
+* Nginx h5bp config improvements
+* Make composer self-update idempotent
+* Fix project_subtree conditional
+* Remove redundant site_name when naming log files
+* Fix project_subtree check
+* Fix conditional check for multi-site deploys
+* Fix .env generation for wordpress-install
+* Mirror `server_name` in SSL and non-SSL blocks
+* Windows compatibility
+* Add swapfile role
+* Nginx: better worker_processes setting
+* Use inventory_hostname instead of ansible_hostname
+* Update Ansible version requirements
+* Add information on how to deploy with the git strategy
+* Define provider as virtualbox to avoid failure
+* Don't set HSTS header over HTTP
+* Add note about generating keys from the WordPress API
+* Use site instead of example.com
+* Be consistent with roots-example-project repo
+* Add vagrant-hostsupdater to requirements
 * SSL support
+* Vagrant: resolve site paths relative to Ansible
+* Subtree should be defined on a site
+* Remove static IP from site_hosts
+* Deploy improvements
 * WP subdomain multisite support
 * Add xdebug role
 * Add logrotate role


### PR DESCRIPTION
moving forward, updates to the changelog should be done how we're now doing them [over at sage](https://github.com/roots/sage/blob/master/CHANGELOG.md). that means that each changelog entry will need to link to the pull request associated with it.

i wanted to say thank you to everyone that has been helping this project move along. it's been really awesome watching bedrock-ansible grow into trellis, and 1.0.0 should be coming very soon.

:blue_heart: :blue_heart: :blue_heart: :blue_heart: :blue_heart: @swalkinshaw @fullyint @nathanielks @louim @austinpray @emaildano @kalenjohnson @merchantguru @chriszarate @rstormsf @davenaylor @JacobDorman @c2itllc @slackday @brettwise @evanfuture @teohhanhui @yeah568 @QWp6t @etcook @BrandonShutter & everyone else who contributed code, updated docs, and reported bugs

check out the [1.0.0 milestone](https://github.com/roots/trellis/milestones/1.0.0) to see what's left