### PR TITLE
Task for setting right php-fpm logfile permissions

### DIFF
--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -17,6 +17,9 @@
   - php5-dev
   - php5-imap
 
+- name: Set permissions for log file
+  file: path=/var/log/php5-fpm.log group=www-data mode="g=rw"
+
 - name: Start php5-fpm service
   service: name=php5-fpm state=started enabled=true
 


### PR DESCRIPTION
Need to be sure that php-fpm has access to write to it's log
before service starts to avoid failure.