### PR TITLE
Fix remote user handling for AWS

### DIFF
--- a/roles/remote-user/tasks/main.yml
+++ b/roles/remote-user/tasks/main.yml
@@ -1,9 +1,10 @@
 ---
 - name: Determine whether to connect as root or admin_user
-  local_action: shell ssh -o PasswordAuthentication=no root@{{ inventory_hostname }} "echo root" || echo {{ admin_user }}
+  local_action: shell ssh -o PasswordAuthentication=no root@{{ inventory_hostname }} "echo can_connect"
+  failed_when: false
   changed_when: false
-  register: remote_user
+  register: root_status
 
 - name: Set remote user for each host
   set_fact:
-    ansible_ssh_user: "{{ remote_user.stdout }}"
+    ansible_ssh_user: "{{ (root_status.stdout == 'can_connect') | ternary('root', admin_user) }}"

--- a/roles/sshd/README.md
+++ b/roles/sshd/README.md
@@ -26,7 +26,7 @@ sshd_server_key_bits: 768
 sshd_syslog_facility: AUTH
 sshd_log_level: INFO
 sshd_login_grace_time: 120
-sshd_permit_root_login: "no"
+sshd_permit_root_login: "yes"
 sshd_strict_modes: "yes"
 sshd_rsa_authentication: "yes"
 sshd_pubkey_authentication: "yes"


### PR DESCRIPTION
resolves #285

I also corrected the sshd role README to indicate the default `sshd_permit_root_login: "yes"`.

I could update the [`fail2ban README`](https://github.com/roots/trellis/blob/b6cd573f0ae4010e6254ff61ee07b7c5bb1c2e1b/roles/fail2ban/README.md) to show the [default](https://github.com/roots/trellis/blob/b6cd573f0ae4010e6254ff61ee07b7c5bb1c2e1b/roles/fail2ban/defaults/main.yml#L6)
```yaml
fail2ban_ignoreip: 127.0.0.1/8 {{ lookup('pipe', 'dig +short myip.opendns.com @resolver1.opendns.com') }}
```
I'm concerned that the required explanation would bog things down too much and simply not be worth it. 