### PR TITLE
Update main.yml

### DIFF
--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -9,5 +9,5 @@ nginx_cache_duration: 30s
 nginx_cache_key_storage_size: 10m
 nginx_cache_size: 250m
 nginx_cache_inactive: 1h
-nginx_skip_cache_uri: /wp-admin/|/xmlrpc.php|wp-.*.php|/feed/|index.php|sitemap(_index)?.xml
+nginx_skip_cache_uri: /wp-admin/|/xmlrpc.php|wp-.*.php|/feed/|index.php|cart|checkout|sitemap(_index)?.xml
 nginx_skip_cache_cookie: comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in


### PR DESCRIPTION
Caching was breaking carts.  This prevents nginx from caching cart items.  

You can see the bug here: https://www.caltonnutrition.com/app/uploads/2015/08/CaltonBug.mp4

adding `cart` and `checkout` prevents `nginx` from breaking this again.