### PR TITLE
Comment out lookup of potentially nonexistent public keys.

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -22,13 +22,13 @@ users:
     groups:
       - "{{ web_group }}"
     keys:
-      - "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
+      # - "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
       # - https://github.com/username.keys
   - name: "{{ admin_user }}"
     groups:
       - sudo
     keys:
-      - "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
+      # - "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
       # - https://github.com/username.keys
 
 admin_user: admin


### PR DESCRIPTION
In our fork of Trellis, I like to keep `group_vars/all` unchanged from upstream and override values in separate vars files. This has been a good approach, especially since the values in `group_vars/all` are generally sensible defaults.

The `users` hash, though, provides potentially nonexistent public key paths (`~/.ssh/id_rsa.pub`) that can lead to an error during playbook execution. As a nested hash value, it's also difficult to override. Commenting them out, as is done with the example GitHub value, seems like a flexible and consistent approach.