### PR TITLE
Update git remote URL before cloning on deploys

### DIFF
--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -2,6 +2,24 @@
 - name: Initialize
   deploy_helper: path="{{ project_root }}" state=present
 
+- name: Check whether project source path is a git repo
+  stat: path={{ project_source_path }}/.git
+  register: git_project
+
+- name: Get current git remote URL
+  command: git config --get remote.origin.url
+  args:
+    chdir: "{{ project_source_path }}"
+  register: remote_origin_url
+  when: git_project.stat.exists
+  changed_when: false
+
+- name: Update git remote URL
+  command: git remote set-url origin {{ project_git_repo }}
+  args:
+    chdir: "{{ project_source_path }}"
+  when: git_project.stat.exists and remote_origin_url.stdout != project_git_repo
+
 - name: Clone project files
   git: repo="{{ project_git_repo }}"
        dest="{{ project_source_path }}"


### PR DESCRIPTION
**Problem:** The git module doesn't always pick up on changes to the `repo` variable, sometimes failing to clone the new repo. Potential examples: [one](https://discourse.roots.io/t/can-not-ssh-to-remote-server-with-ansible/4449/8), [two](https://discourse.roots.io/t/trellis-deploy-not-pulling-latest-git-version/4209), [three](https://discourse.roots.io/t/trellis-server-setup-fail-at-github-ssh-keys/4323/6).

**Steps to reproduce**
* run deploy.yml with default `repo: git@github.com:roots/bedrock.git`
* change `repo: git@github.com:roots/roots-example-project.com.git` (and uncomment `subtree: site`)
* run deploy.yml again

**Exepected outcome:** New clone should be made on second run of deploy.yml after changing `repo`.

**Actual outcome:** "Clone project files" task reports `ok` instead of `changed` and no new clone is made. The old `roots/bedrock.git` clone remains and is copied to new release directory, despite `repo` variable indicating `roots/roots-example-project.com.git`.

**Why it happens:** The git module doesn't check for updates by comparing the clone with the `repo` specified. Instead, it compares the clone with the clone's remote by running [`git ls-remote origin -h HEAD`](https://github.com/ansible/ansible-modules-core/blob/2d3e93e55823d03891e1c6612e959ee785f17575/source_control/git.py#L378) in the clone's path.

(**Edit:** _The rest of this comment is now out-dated._)

**Fix:** This PR puts clones in paths that are unique to each `repo`. Previously, the "Steps" above only yielded a clone directly in `shared/source`. If this PR were merged, the "Steps" above would yield clones in
`shared/source/bedrock.git-aedf427`
`shared/source/roots-example-project.com.git-55f77f1`

Now, when the git module runs `git ls-remote` while checking for updates, it only ever runs it in a clone directory corresponding to the `repo` the user specified.

The hash at the end of the filename is created from the full path of the repo. Adding the hash ensures that a new clone will still be made when the basename stays the same but there is a change in git user and/or git host.