### PR TITLE
Allow user to set the timezone of the server and php

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -1,5 +1,6 @@
 ---
 apt_cache_valid_time: 86400
+default_timezone: Etc/UTC
 mariadb_dist: trusty
 mysql_user: root
 www_root: /srv/www

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,1 +1,2 @@
 minimum_ansible_version: 1.9.2
+default_timezone: Etc/UTC

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -18,3 +18,21 @@
   - python-mysqldb
   - curl
   - git-core
+
+- name: Validate timezone variable
+  stat: path=/usr/share/zoneinfo/{{ default_timezone }}
+  register: timezone_path
+  changed_when: false
+
+- name: Explain timezone error
+  fail: msg="{{ default_timezone }} is not a valid timezone. For a list of valid timezones, check https://php.net/manual/en/timezones.php"
+  when: not timezone_path.stat.exists
+
+- name: Get current timezone
+  command: cat /etc/timezone
+  register: current_timezone
+  changed_when: false
+
+- name: Set timezone
+  command: timedatectl set-timezone {{ default_timezone }}
+  when: current_timezone.stdout != default_timezone

--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -13,6 +13,7 @@ php_sendmail_path: /usr/sbin/ssmtp -t
 php_session_save_path: /tmp
 php_upload_max_filesize: 25M
 php_track_errors: 'Off'
+php_default_timezone: '{{ default_timezone }}'
 
 php_opcache_enable: 1
 php_opcache_enable_cli: 1

--- a/roles/php/templates/php.ini.j2
+++ b/roles/php/templates/php.ini.j2
@@ -14,6 +14,7 @@ session.save_path = {{ php_session_save_path }}
 track_errors = {{ php_track_errors }}
 upload_max_filesize = {{ php_upload_max_filesize }}
 expose_php = Off
+date.timezone = {{ php_default_timezone }}
 
 [mysqlnd]
 mysqlnd.collect_memory_statistics = {{ php_mysqlnd_collect_memory_statistics }}


### PR DESCRIPTION
Add a way to set server's timezone from a user value. The user value will also be used to set `date.timezone` for php-fpm.default

The timezone is compared with zone files before being set to ensure its validity.