### PR TITLE
Nginx fastcgi buffers: set better default

### DIFF
--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -1,7 +1,8 @@
 ---
-logs_root: /var/log/nginx
+nginx_logs_root: /var/log/nginx
 nginx_user: www-data
 strip_www: true
+nginx_fastcgi_buffers: 8 8k
 
 # Fastcgi cache params
 nginx_cache_path: /var/cache/nginx

--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -28,7 +28,7 @@ events {
 
 # Default error log file
 # (this is only used when you don't override error_log on a server{} level)
-error_log  {{ logs_root }}/error.log warn;
+error_log  {{ nginx_logs_root }}/error.log warn;
 pid        /run/nginx.pid;
 
 http {
@@ -37,6 +37,7 @@ http {
   server_tokens off;
 
   # Setup the fastcgi cache.
+  fastcgi_buffers {{ nginx_fastcgi_buffers }}
   fastcgi_cache_path {{ nginx_cache_path }} levels=1:2 keys_zone=wordpress:{{ nginx_cache_key_storage_size }} max_size={{ nginx_cache_size }} inactive={{ nginx_cache_inactive }};
   fastcgi_cache_use_stale updating error timeout invalid_header http_500;
   fastcgi_cache_lock on;
@@ -59,7 +60,7 @@ http {
 
   # Default log file
   # (this is only used when you don't override access_log on a server{} level)
-  access_log {{ logs_root }}/access.log main;
+  access_log {{ nginx_logs_root }}/access.log main;
 
   # How long to allow each connection to stay idle; longer values are better
   # for each individual client, particularly for SSL, but means that worker


### PR DESCRIPTION
The value of "8 8k" results in a 64KB buffer size. This buffer size should be slightly bigger than the average response size.

The higher this value is over your average response size, the more memory is wasted on each request.

Reference: https://github.com/roots/trellis/issues/281