### PR TITLE
Set permisssions on files deployed via rsync

### DIFF
--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -48,7 +48,11 @@
   with_items: project_pre_build_commands_local
 
 - name: Copy project local files
-  synchronize: src="{{ item.src }}" dest="{{ deploy_helper.new_release_path }}/{{ item.dest }}"
+  synchronize: src="{{ item.src }}"
+               dest="{{ deploy_helper.new_release_path }}/{{ item.dest }}"
+               group=no
+               owner=no
+               rsync_opts=--chmod=Du=rwx,--chmod=Dg=rx,--chmod=Do=rx,--chmod=Fu=rw,--chmod=Fg=r,--chmod=Fo=r
   with_items: project_local_files
 
 - name: Copy project templates


### PR DESCRIPTION
Followup to #303 and roots/roots-example-project.com#22

Unfortunately we can't just use
`rsync_opts=--chmod=Du=rwx,Dg=rx,Do=rx,Fu=rw,Fg=r,Fo=r`
because of ansible/ansible-modules-core#1163