### PR TITLE
Refactor hosts files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Refactor hosts files ([#313](https://github.com/roots/trellis/pull/313))
 * Fixes #436 - Let WP handle 404s for PHP files ([#448](https://github.com/roots/trellis/pull/448))
 * Fixes #297 - Use `php_flag` vs `php_admin_flag` ([#447](https://github.com/roots/trellis/pull/447))
 * Fixes #316 - Set WP permalink structure during install ([#316](https://github.com/roots/trellis/pull/316))

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ For remote servers, you'll need to have a base Ubuntu 14.04 server already creat
 2. Add your server IP/hostnames to `hosts/<environment>`.
 3. Specify public SSH keys for `users` in `group_vars/all/users.yml`. See the [SSH Keys docs](https://roots.io/trellis/docs/ssh-keys/).
 4. Consider setting `sshd_permit_root_login: false` in `group_vars/all/security.yml`. See the [Security docs](https://roots.io/trellis/docs/security/).
-5. Run `ansible-playbook -i hosts/<environment> server.yml`.
+5. Run `ansible-playbook server.yml -e env=<environment>`
 
 ## Deploying to remote servers
 
@@ -84,7 +84,7 @@ Full documentation: https://roots.io/trellis/docs/deploys/
 1. Add the `repo` (Git URL) of your Bedrock WordPress project in the corresponding `group_vars/<environment>/wordpress_sites.yml` file.
 2. Set the `branch` you want to deploy (optional - defaults to `master`).
 3. Run `./deploy.sh <environment> <site name>`
-4. To rollback a deploy, run `ansible-playbook -i hosts/<environment> rollback.yml --extra-vars="site=<site name>"`
+4. To rollback a deploy, run `ansible-playbook rollback.yml -e "site=<site name> env=<environment>"`
 
 ## Configuration
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,6 +1,7 @@
 [defaults]
 roles_path = vendor/roles
 force_handlers = True
+inventory = hosts
 
 [ssh_connection]
 ssh_args = -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 shopt -s nullglob
 
-DEPLOY_CMD="ansible-playbook -i hosts/$1 deploy.yml --extra-vars="site=$2""
+DEPLOY_CMD="ansible-playbook deploy.yml -e env=$1 -e site=$2"
 ENVIRONMENTS=( hosts/* )
 ENVIRONMENTS=( "${ENVIRONMENTS[@]##*/}" )
 NUM_ARGS=2

--- a/deploy.yml
+++ b/deploy.yml
@@ -1,6 +1,10 @@
 ---
+- include: variable-check.yml
+  vars:
+    playbook: deploy.yml
+
 - name: Deploy WP site
-  hosts: web
+  hosts: web:&{{ env }}
   remote_user: "{{ web_user }}"
 
   vars:

--- a/dev.yml
+++ b/dev.yml
@@ -1,6 +1,6 @@
 ---
 - name: "WordPress Server: Install LEMP Stack with PHP 5.6 and MariaDB MySQL"
-  hosts: web
+  hosts: web:&development
   sudo: yes
   remote_user: vagrant
 

--- a/hosts/development
+++ b/hosts/development
@@ -1,6 +1,7 @@
-# Not used. Vagrant generates its own hosts file automatically and uses it
-[web]
+# No edits are necessary
+
+[development]
 127.0.0.1
 
-[development:children]
-web
+[web]
+127.0.0.1

--- a/hosts/production
+++ b/hosts/production
@@ -1,5 +1,8 @@
-[web]
-192.168.50.5
+# Add each host to the [production] group and to a "type" group such as [web] or [db].
+# List each machine only once per [group], even if it will host multiple sites.
 
-[production:children]
-web
+[production]
+your_server_ip
+
+[web]
+your_server_ip

--- a/hosts/staging
+++ b/hosts/staging
@@ -1,5 +1,8 @@
-[web]
-192.168.50.5
+# Add each host to the [staging] group and to a "type" group such as [web] or [db].
+# List each machine only once per [group], even if it will host multiple sites.
 
-[staging:children]
-web
+[staging]
+your_server_ip
+
+[web]
+your_server_ip

--- a/rollback.yml
+++ b/rollback.yml
@@ -1,6 +1,10 @@
 ---
+- include: variable-check.yml
+  vars:
+    playbook: rollback.yml
+
 - name: Rollback a Deploy
-  hosts: web
+  hosts: web:&{{ env }}
   remote_user: "{{ web_user }}"
 
   vars:

--- a/server.yml
+++ b/server.yml
@@ -1,12 +1,16 @@
 ---
+- include: variable-check.yml
+  vars:
+    playbook: server.yml
+
 - name: Determine Remote User
-  hosts: web
+  hosts: web:&{{ env }}
   gather_facts: false
   roles:
     - { role: remote-user, tags: [remote-user, always] }
 
 - name: WordPress Server - Install LEMP Stack with PHP 5.6 and MariaDB MySQL
-  hosts: web
+  hosts: web:&{{ env }}
   sudo: yes
   vars_files:
     - vars/sudoer_passwords.yml

--- a/variable-check.yml
+++ b/variable-check.yml
@@ -1,0 +1,13 @@
+---
+- name: Ensure necessary variables are defined
+  hosts: localhost
+  gather_facts: false
+  vars:
+    extra_vars_command: "{{ (playbook == 'server.yml') | ternary('env=<environment>', '\"site=<domain> env=<environment>\"') }}"
+  tasks:
+    - name: Ensure environment is defined
+      fail:
+        msg: |
+          Environment missing. Use `-e` to define `env`:
+          ansible-playbook {{ playbook }} -e {{ extra_vars_command }}
+      when: env is not defined


### PR DESCRIPTION
* Enables cross-environment playbooks (e.g., syncing files/database) by loading entire `hosts` directory
* Accommodates separate web vs. db servers by making `[web]` its own group instead of a child group of `<environment>`.
* Pairs nicely with #314 
* Initial discussion in #288

Commands
* Replace `-i hosts/<environment>` with `-e env=<environment>`
* Dev can just be `ansible-playbook dev.yml`. You'd need vagrant vm in ssh config till #314 is merged.
* unchanged: `./deploy.sh <environment> <site>`

I kept hosts files separate by environment. Alternatively, a single file could look like this: 

```
# Each host machine should appear in the "Environments" section and in the "Types" section.
# Each host must only be listed once per [group], even if it will host multiple sites.


# Environments

[development]
127.0.0.1

[staging]
192.168.50.6

[production]
192.168.50.7


# Types

[web]
127.0.0.1
192.168.50.6
192.168.50.7

[db]

```