### PR TITLE
Add ansible-ssh role to generate ssh config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vagrant
 vendor/roles
+roles/ansible-ssh/files/config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Add ansible-ssh role to generate ssh config ([#314](https://github.com/roots/trellis/pull/314))
 * Update SSL cipher suite ([#386](https://github.com/roots/trellis/pull/386))
 * Support for other Vagrant providers (VirtualBox, VMWare, Parallels) ([#340](https://github.com/roots/trellis/pull/340))
 * Specify versions for Ansible Galaxy requirements ([#385](https://github.com/roots/trellis/pull/385))

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,6 +28,7 @@ end
 Vagrant.require_version '>= 1.5.1'
 
 Vagrant.configure('2') do |config|
+  config.vm.define 'vagrant-vm'
   config.vm.box = 'ubuntu/trusty64'
   config.ssh.forward_agent = true
 
@@ -67,8 +68,8 @@ Vagrant.configure('2') do |config|
     config.vm.provision :ansible do |ansible|
       ansible.playbook = File.join(ANSIBLE_PATH, 'dev.yml')
       ansible.groups = {
-        'web' => ['default'],
-        'development' => ['default']
+        'development' => ['vagrant-vm'],
+        'web' => ['vagrant-vm']
       }
 
       if vars = ENV['ANSIBLE_VARS']

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,4 +3,4 @@ roles_path = vendor/roles
 force_handlers = True
 
 [ssh_connection]
-ssh_args = -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s
+ssh_args = -F roles/ansible-ssh/files/config -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s

--- a/dev.yml
+++ b/dev.yml
@@ -1,9 +1,14 @@
 ---
-- name: "WordPress Server: Install LEMP Stack with PHP 5.6 and MariaDB MySQL"
+- name: Prepare Ansible SSH Config
+  hosts: web
+  gather_facts: false
+  roles:
+    - { role: ansible-ssh, tags: [ansible-ssh] }
+
+- name: WordPress Server - Install LEMP Stack with PHP 5.6 and MariaDB MySQL
   hosts: web
   sudo: yes
   remote_user: vagrant
-
   roles:
     - { role: common, tags: [common] }
     - { role: fail2ban, tags: [fail2ban] }

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -2,3 +2,5 @@ apt_cache_valid_time: 86400
 default_timezone: Etc/UTC
 hhvm: false
 www_root: /srv/www
+ssh_config_files:
+  - ~/.ssh/config

--- a/hosts/development
+++ b/hosts/development
@@ -1,6 +1,5 @@
-# Not used. Vagrant generates its own hosts file automatically and uses it
 [web]
-127.0.0.1
+vagrant-vm
 
 [development:children]
 web

--- a/roles/ansible-ssh/tasks/main.yml
+++ b/roles/ansible-ssh/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+- name: Remove prior ssh config info
+  local_action: file path=/tmp/ansible-ssh-config state=absent
+  changed_when: false
+
+- name: Gather ssh config info for Vagrant VM
+  local_action: shell vagrant ssh-config --host {{ inventory_hostname }} >> /tmp/ansible-ssh-config
+  when: "'development' in group_names"
+  register: vagrant_ssh_config
+  failed_when: vagrant_ssh_config.rc == 1
+  changed_when: false
+
+- name: Gather user-specified ssh config files
+  local_action: shell echo "" && cat {{ item }} >> /tmp/ansible-ssh-config
+  with_items: ssh_config_files | default([])
+  changed_when: false
+
+- name: Update ssh config file
+  local_action: command rsync -acv /tmp/ansible-ssh-config roles/ansible-ssh/files/config
+  register: ansible_ssh_config
+  changed_when: "'ansible-ssh-config' in ansible_ssh_config.stdout"
+
+- name: Set connection facts if control machine appears to be a Vagrant VM
+  set_fact:
+    ansible_ssh_host: 127.0.0.1
+    ansible_connection: local
+  when: vagrant_ssh_config.rc is defined and vagrant_ssh_config.rc == 127

--- a/roles/ansible-ssh/tasks/main.yml
+++ b/roles/ansible-ssh/tasks/main.yml
@@ -15,6 +15,10 @@
   with_items: ssh_config_files | default([])
   changed_when: false
 
+- name: Ensure ansible-ssh/files directory exists
+  local_action: file path=roles/ansible-ssh/files state=directory
+  changed_when: false
+
 - name: Update ssh config file
   local_action: command rsync -acv /tmp/ansible-ssh-config roles/ansible-ssh/files/config
   register: ansible_ssh_config

--- a/server.yml
+++ b/server.yml
@@ -3,8 +3,8 @@
   hosts: web
   gather_facts: false
   roles:
-    - { role: remote-user, tags: [remote-user, always] }
     - { role: ansible-ssh, tags: [ansible-ssh] }
+    - { role: remote-user, tags: [remote-user, always] }
 
 - name: WordPress Server - Install LEMP Stack with PHP 5.6 and MariaDB MySQL
   hosts: web

--- a/server.yml
+++ b/server.yml
@@ -1,9 +1,10 @@
 ---
-- name: Determine Remote User
+- name: Prepare Ansible SSH Config
   hosts: web
   gather_facts: false
   roles:
     - { role: remote-user, tags: [remote-user, always] }
+    - { role: ansible-ssh, tags: [ansible-ssh] }
 
 - name: WordPress Server - Install LEMP Stack with PHP 5.6 and MariaDB MySQL
   hosts: web


### PR DESCRIPTION
* Run `ansible-playbook dev.yml` without vagrant commands and without manually adding dev vm to ssh config. Grabs latest `vagrant ssh-config`, sorting out port forwarding between multiple VMs.
* Pairs nicely with #313 to run cross-environment playbooks (syncing files/database), including dev.
* Now you can use ssh config "includes". Files listed in `ssh_config_files` are `cat`-ed into `roles/ansible-ssh/files/config`.
* Initial discussion in #288
* #295 "Dynamic development IP" would be a really nice accompaniment

Could someone test on Windows?	
* May have to adjust or comment out the `ssh_config_files` in `group_vars/all` (?)
* The `vagrant ssh-config` command that runs would typically not be available when Windows users run `dev.yml` inside the vm. This gives return code 127, which I catch with `vagrant_ssh_config.rc == 127`, then set the `host` and `connection`, like in [`windows.sh`](https://github.com/roots/trellis/blob/8a84639257bdeaceb3b440823e2ac78c5c17906a/windows.sh#L39).
* Are the parameters `--sudo --user=vagrant` necessary in `windows.sh`? They already exist in `dev.yml`.

**Caution.** This refers to the vagrant vm as `vagrant-vm` in the hosts file. For consistency, this PR renames vagrant's reference to the vm from `default` to `vagrant-vm`. This latter means the Vagrantfile will stop working for existing VMs named `default`. Users would have to comment out the line
```
config.vm.define 'vagrant-vm'
```
and destroy the vm, then uncomment the line and `vagrant up`.

We don't have to rename the VM but it might be nice to have the names be consistent. Changing the name is a breaking change of sorts, but it seems better to do it now, while pre v1.0.