### PR TITLE
Accommodate file encryption via ansible vault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.vault_pass
 .vagrant
 vendor/roles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Accommodate file encryption via ansible vault ([#317](https://github.com/roots/trellis/pull/317))
 * Fixes #353 - Allow insecure curl reqs for cron ([#450](https://github.com/roots/trellis/pull/450))
 * Fixes #374 - Remove composer vendor/bin from $PATH ([#449](https://github.com/roots/trellis/pull/449))
 * Refactor hosts files ([#313](https://github.com/roots/trellis/pull/313))

--- a/README.md
+++ b/README.md
@@ -64,14 +64,14 @@ example.com/    - Primary folder for the project
 
 ## Development setup
 
-1. Configure your [WordPress sites](#wordpress-sites) in `group_vars/development/wordpress_sites.yml`
+1. Configure your [WordPress sites](#wordpress-sites) in `group_vars/development/wordpress_sites.yml` and in `group_vars/development/vault.yml`.
 2. Run `vagrant up`
 
 ## Remote server setup (staging/production)
 
 For remote servers, you'll need to have a base Ubuntu 14.04 server already created.
 
-1. Configure your [WordPress sites](#wordpress-sites) in `group_vars/<environment>/wordpress_sites.yml`. Also see the [Passwords docs](https://roots.io/trellis/docs/passwords/).
+1. Configure your [WordPress sites](#wordpress-sites) in `group_vars/<environment>/wordpress_sites.yml` and in `group_vars/<environment>/vault.yml`. See the [Vault docs](https://roots.io/trellis/docs/vault/) for how to encrypt files containing passwords.
 2. Add your server IP/hostnames to `hosts/<environment>`.
 3. Specify public SSH keys for `users` in `group_vars/all/users.yml`. See the [SSH Keys docs](https://roots.io/trellis/docs/ssh-keys/).
 4. Consider setting `sshd_permit_root_login: false` in `group_vars/all/security.yml`. See the [Security docs](https://roots.io/trellis/docs/security/).
@@ -96,9 +96,9 @@ Full documentation: https://roots.io/trellis/docs/deploys/
 
 Before using Trellis, you must configure your WordPress sites.
 
-The `group_vars` directory contains directories for each environment (`development`, `staging`, and `production`). Each environment has its own `wordpress_sites.yml` variables file in [YAML](http://en.wikipedia.org/wiki/YAML) format.
+The `group_vars` directory contains directories for each environment (`development`, `staging`, and `production`). Each environment has its own `wordpress_sites.yml` variables file in [YAML](http://en.wikipedia.org/wiki/YAML) format, with an accompanying `vault.yml` file for sensitive information.
 
-For example: configure the sites on your Vagrant development VM by editing `group_vars/development/wordpress_sites.yml`.
+For example: configure the sites on your Vagrant development VM by editing `group_vars/development/wordpress_sites.yml` and `group_vars/development/vault.yml`.
 
 `wordpress_sites` is the top-level dictionary used to define the WordPress sites, databases, Nginx vhosts, etc that will be created. Each site's variables are nested under a site "key" (e.g., `example.com`). This key is just a descriptive name and serves as the default value for some variables. See our [example project](https://github.com/roots/roots-example-project.com/blob/master/ansible/group_vars/development/wordpress_sites.yml) for a complete working example.
 
@@ -120,7 +120,7 @@ For example: configure the sites on your Vagrant development VM by editing `grou
 * `db_import` - Path to local `sql` dump file which will be imported (optional)
 * `admin_user` - WP admin user name (*development* only, required)
 * `admin_email` - WP admin email address (*development* only, required)
-* `admin_password` - WP admin user password (*development* only, required)
+* `admin_password` - WP admin user password (*development* only, required, in `vault.yml`)
 * `multisite` - hash of multisite options. See the [Multisite docs](https://roots.io/trellis/docs/multisite/).
   * `enabled` - Multisite enabled flag (required, set to `false`)
   * `subdomains` - subdomains option
@@ -135,7 +135,7 @@ For example: configure the sites on your Vagrant development VM by editing `grou
   * `wp_env` - environment (required, matches group name: `development`, `staging`, `production`)
   * `db_name` - database name (required)
   * `db_user` - database username (required)
-  * `db_password` - database password (required)
+  * `db_password` - database password (required, in `vault.yml`)
   * `db_host` - database hostname (default: `localhost`)
   * `domain_current_site` (required if multisite.enabled is `true`)
 

--- a/group_vars/all/mail.yml
+++ b/group_vars/all/mail.yml
@@ -3,4 +3,4 @@ mail_smtp_server: smtp.example.com:587
 mail_admin: admin@example.com
 mail_hostname: example.com
 mail_user: smtp_user
-mail_password: smtp_password
+mail_password: "{{ vault_mail_password }}" # Define this variable in group_vars/all/vault.yml

--- a/group_vars/all/security.yml
+++ b/group_vars/all/security.yml
@@ -11,5 +11,7 @@ ferm_input_list:
     hits: 20
 
 # Documentation: https://roots.io/trellis/docs/security/
-sshd_permit_root_login: true # If `false`, `admin_user` must be in 'users' (`users.yml`) with sudo group and in `sudoer_passwords`
+# If sshd_permit_root_login: false, admin_user must be in 'users' (`group_vars/all/users.yml`) with sudo group
+# and in 'sudoer_passwords' (`group_vars/<environment>/main.yml`)
+sshd_permit_root_login: true
 sshd_password_authentication: false

--- a/group_vars/all/users.yml
+++ b/group_vars/all/users.yml
@@ -1,6 +1,7 @@
 # Documentation: https://roots.io/trellis/docs/ssh-keys/
 admin_user: admin
 
+# Also define sudoer_passwords in group_vars/<environment>/main.yml
 users:
   - name: "{{ web_user }}"
     groups:

--- a/group_vars/all/vault.yml
+++ b/group_vars/all/vault.yml
@@ -1,0 +1,2 @@
+# Documentation: https://roots.io/trellis/docs/vault/
+vault_mail_password: smtp_password

--- a/group_vars/development/main.yml
+++ b/group_vars/development/main.yml
@@ -1,3 +1,4 @@
 ferm_enabled: false
-mysql_root_password: devpw
+mysql_root_password: "{{ vault_mysql_root_password }}" # Define this variable in group_vars/development/vault.yml
+sudoer_passwords: "{{ vault_sudoer_passwords }}" # Define this variable in group_vars/development/vault.yml
 web_user: vagrant

--- a/group_vars/development/vault.yml
+++ b/group_vars/development/vault.yml
@@ -1,0 +1,13 @@
+# Documentation: https://roots.io/trellis/docs/vault/
+vault_mysql_root_password: devpw
+
+# Documentation: https://roots.io/trellis/docs/security/
+vault_sudoer_passwords:
+  admin: $6$rounds=100000$JUkj1d3hCa6uFp6R$3rZ8jImyCpTP40e4I5APx7SbBvDCM8fB6GP/IGOrsk/GEUTUhl1i/Q2JNOpj9ashLpkgaCxqMqbFKdZdmAh26/
+
+# Variables to accompany `group_vars/development/wordpress_sites.yml`
+vault_wordpress_sites:
+  example.com:
+    admin_password: admin
+    env:
+      db_password: example_dbpassword

--- a/group_vars/development/wordpress_sites.yml
+++ b/group_vars/development/wordpress_sites.yml
@@ -7,7 +7,7 @@ wordpress_sites:
     site_install: true
     site_title: Example Site
     admin_user: admin
-    admin_password: admin
+    # admin_password: (defined in group_vars/development/vault.yml)
     admin_email: admin@example.dev
     permalink_structure: "/%postname%/"
     multisite:
@@ -25,4 +25,4 @@ wordpress_sites:
       wp_env: development
       db_name: example_dev
       db_user: example_dbuser
-      db_password: example_dbpassword
+      # db_password: (defined in group_vars/development/vault.yml)

--- a/group_vars/production/main.yml
+++ b/group_vars/production/main.yml
@@ -1,1 +1,2 @@
-mysql_root_password: productionpw
+mysql_root_password: "{{ vault_mysql_root_password }}" # Define this variable in group_vars/production/vault.yml
+sudoer_passwords: "{{ vault_sudoer_passwords }}" # Define this variable in group_vars/production/vault.yml

--- a/group_vars/production/vault.yml
+++ b/group_vars/production/vault.yml
@@ -1,0 +1,22 @@
+# Documentation: https://roots.io/trellis/docs/vault/
+vault_mysql_root_password: productionpw
+
+# Documentation: https://roots.io/trellis/docs/security/
+vault_sudoer_passwords:
+  admin: $6$rounds=100000$JUkj1d3hCa6uFp6R$3rZ8jImyCpTP40e4I5APx7SbBvDCM8fB6GP/IGOrsk/GEUTUhl1i/Q2JNOpj9ashLpkgaCxqMqbFKdZdmAh26/
+
+# Variables to accompany `group_vars/production/wordpress_sites.yml`
+vault_wordpress_sites:
+  example.com:
+    env:
+      db_password: example_dbpassword
+      # Generate your keys here: https://api.wordpress.org/secret-key/1.1/salt/
+      # These CANNOT contain the characters "{%" in succession
+      auth_key: "generateme"
+      secure_auth_key: "generateme"
+      logged_in_key: "generateme"
+      nonce_key: "generateme"
+      auth_salt: "generateme"
+      secure_auth_salt: "generateme"
+      logged_in_salt: "generateme"
+      nonce_salt: "generateme"

--- a/group_vars/production/wordpress_sites.yml
+++ b/group_vars/production/wordpress_sites.yml
@@ -23,14 +23,13 @@ wordpress_sites:
       wp_env: production
       db_name: example_prod
       db_user: example_dbuser
-      db_password: example_dbpassword
-      # Generate your keys here: https://api.wordpress.org/secret-key/1.1/salt/
-      # These CANNOT contain the characters "{%" in succession
-      auth_key: "generateme"
-      secure_auth_key: "generateme"
-      logged_in_key: "generateme"
-      nonce_key: "generateme"
-      auth_salt: "generateme"
-      secure_auth_salt: "generateme"
-      logged_in_salt: "generateme"
-      nonce_salt: "generateme"
+      # Define the following variables in group_vars/production/vault.yml
+      # db_password:
+      # auth_key:
+      # secure_auth_key:
+      # logged_in_key:
+      # nonce_key:
+      # auth_salt:
+      # secure_auth_salt:
+      # logged_in_salt:
+      # nonce_salt:

--- a/group_vars/staging/main.yml
+++ b/group_vars/staging/main.yml
@@ -1,1 +1,2 @@
-mysql_root_password: stagingpw
+mysql_root_password: "{{ vault_mysql_root_password }}" # Define this variable in group_vars/staging/vault.yml
+sudoer_passwords: "{{ vault_sudoer_passwords }}" # Define this variable in group_vars/staging/vault.yml

--- a/group_vars/staging/vault.yml
+++ b/group_vars/staging/vault.yml
@@ -1,0 +1,22 @@
+# Documentation: https://roots.io/trellis/docs/vault/
+vault_mysql_root_password: stagingpw
+
+# Documentation: https://roots.io/trellis/docs/security/
+vault_sudoer_passwords:
+  admin: $6$rounds=100000$JUkj1d3hCa6uFp6R$3rZ8jImyCpTP40e4I5APx7SbBvDCM8fB6GP/IGOrsk/GEUTUhl1i/Q2JNOpj9ashLpkgaCxqMqbFKdZdmAh26/
+
+# Variables to accompany `group_vars/staging/wordpress_sites.yml`
+vault_wordpress_sites:
+  example.com:
+    env:
+      db_password: example_dbpassword
+      # Generate your keys here: https://api.wordpress.org/secret-key/1.1/salt/
+      # These CANNOT contain the characters "{%" in succession
+      auth_key: "generateme"
+      secure_auth_key: "generateme"
+      logged_in_key: "generateme"
+      nonce_key: "generateme"
+      auth_salt: "generateme"
+      secure_auth_salt: "generateme"
+      logged_in_salt: "generateme"
+      nonce_salt: "generateme"

--- a/group_vars/staging/wordpress_sites.yml
+++ b/group_vars/staging/wordpress_sites.yml
@@ -23,14 +23,13 @@ wordpress_sites:
       wp_env: staging
       db_name: example_staging
       db_user: example_dbuser
-      db_password: example_dbpassword
-      # Generate your keys here: https://api.wordpress.org/secret-key/1.1/salt/
-      # These CANNOT contain the characters "{%" in succession
-      auth_key: "generateme"
-      secure_auth_key: "generateme"
-      logged_in_key: "generateme"
-      nonce_key: "generateme"
-      auth_salt: "generateme"
-      secure_auth_salt: "generateme"
-      logged_in_salt: "generateme"
-      nonce_salt: "generateme"
+      # Define the following variables in group_vars/staging/vault.yml
+      # db_password:
+      # auth_key:
+      # secure_auth_key:
+      # logged_in_key:
+      # nonce_key:
+      # auth_salt:
+      # secure_auth_salt:
+      # logged_in_salt:
+      # nonce_salt:

--- a/roles/deploy/templates/env.j2
+++ b/roles/deploy/templates/env.j2
@@ -1,3 +1,6 @@
 {% for key, value in project.env.iteritems() %}
 {{ key | upper }}="{{ value }}"
 {% endfor %}
+{% for key, value in vault_wordpress_sites[site].env.iteritems() %}
+{{ key | upper }}="{{ value }}"
+{% endfor %}

--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -28,7 +28,7 @@
            --url="{{ item.value.env.wp_home }}"
            --title="{{ item.value.site_title | default(item.key) }}"
            --admin_user="{{ item.value.admin_user }}"
-           --admin_password="{{ item.value.admin_password }}"
+           --admin_password="{{ vault_wordpress_sites[item.key].admin_password }}"
            --admin_email="{{ item.value.admin_email }}"
   args:
     chdir: "{{ www_root }}/{{ item.key }}/current/"
@@ -66,7 +66,7 @@
            --subdomains="{{ item.value.multisite.subdomains | default('false') }}"
            --title="{{ item.value.site_title | default(item.key) }}"
            --admin_user="{{ item.value.admin_user }}"
-           --admin_password="{{ item.value.admin_password }}"
+           --admin_password="{{ vault_wordpress_sites[item.key].admin_password }}"
            --admin_email="{{ item.value.admin_email }}"
   args:
     chdir: "{{ www_root }}/{{ item.key }}/current/"

--- a/roles/wordpress-install/templates/env.j2
+++ b/roles/wordpress-install/templates/env.j2
@@ -1,3 +1,6 @@
 {% for key, value in item.value.env.iteritems() %}
 {{ key | upper }}="{{ value }}"
 {% endfor %}
+{% for key, value in vault_wordpress_sites[item.key].env.iteritems() %}
+{{ key | upper }}="{{ value }}"
+{% endfor %}

--- a/roles/wordpress-setup/tasks/database.yml
+++ b/roles/wordpress-setup/tasks/database.yml
@@ -10,7 +10,7 @@
 
 - name: Create/assign database user to db and grant permissions
   mysql_user: name="{{ item.value.env.db_user }}"
-              password="{{ item.value.env.db_password }}"
+              password="{{ vault_wordpress_sites[item.key].env.db_password }}"
               append_privs=yes
               priv="{{ item.value.env.db_name | default(item.key) }}.*:ALL"
               state=present
@@ -31,7 +31,7 @@
             target="/tmp/{{ item.value.db_import | basename }}"
             login_host="{{ item.value.env.db_host | default('localhost') }}"
             login_user="{{ item.value.env.db_user }}"
-            login_password="{{ item.value.env.db_password }}"
+            login_password="{{ vault_wordpress_sites[item.key].env.db_password }}"
   with_dict: wordpress_sites
   when: item.value.db_import | default(False)
   notify: reload nginx

--- a/server.yml
+++ b/server.yml
@@ -12,8 +12,6 @@
 - name: WordPress Server - Install LEMP Stack with PHP 5.6 and MariaDB MySQL
   hosts: web:&{{ env }}
   sudo: yes
-  vars_files:
-    - vars/sudoer_passwords.yml
   roles:
     - { role: common, tags: [common] }
     - { role: swapfile, swapfile_size: 1GB, tags: [swapfile] }

--- a/vars/sudoer_passwords.yml
+++ b/vars/sudoer_passwords.yml
@@ -1,5 +1,0 @@
----
-# Passwords should follow the guidelines presented here:
-# http://docs.ansible.com/faq.html#how-do-i-generate-crypted-passwords-for-the-user-module
-sudoer_passwords:
-  admin: $6$rounds=100000$JUkj1d3hCa6uFp6R$3rZ8jImyCpTP40e4I5APx7SbBvDCM8fB6GP/IGOrsk/GEUTUhl1i/Q2JNOpj9ashLpkgaCxqMqbFKdZdmAh26/


### PR DESCRIPTION
 Moves some variables to `group_vars/<environment>/vault.yml` files.

To start using [Ansible Vault](http://docs.ansible.com/ansible/playbooks_vault.html):
1) copy `.vault_pass.example` to `.vault_pass`, edit the password, and probably `chmod 600 .vault_pass`
2) edit `ansible.cfg`:
```diff
- vault_password_file = .vault_pass.example
+ vault_password_file = .vault_pass
```
3) encrypt `vault.yml` files with command below (doesn't support fileglobs -- ansible/ansible#6241):
```
ansible-vault encrypt group_vars/all/vault.yml group_vars/development/vault.yml group_vars/staging/vault.yml group_vars/production/vault.yml
```

Preliminary discussion in #308 where I mentioned these items:
* encryption is optional
* there are scripts to help one avoid committing unencrypted password files

Would we want `mysql_root_user: root` vaulted? It is currently in `group_vars/all/database.yml`.