### PR TITLE
Remove unused default generated_env_vars

### DIFF
--- a/roles/wordpress-setup/defaults/main.yml
+++ b/roles/wordpress-setup/defaults/main.yml
@@ -1,10 +1,1 @@
-generated_env_vars:
-  - auth_key
-  - secure_auth_key
-  - logged_in_key
-  - nonce_key
-  - auth_salt
-  - secure_auth_salt
-  - logged_in_salt
-  - nonce_salt
 memcached_sessions: false


### PR DESCRIPTION
I think `generated_env_vars` [were cut out](https://github.com/roots/trellis/commit/373fe77e90e5208fc96a9def301bb9e17b66f2ac#diff-ed7dcb7411922b93d3e5eab85343ea1bL10) in Ansible deploys.