### PR TITLE
Use ansible ping module to determine remote user

### DIFF
--- a/roles/remote-user/tasks/main.yml
+++ b/roles/remote-user/tasks/main.yml
@@ -1,10 +1,14 @@
 ---
 - name: Determine whether to connect as root or admin_user
-  local_action: shell ssh -o PasswordAuthentication=no root@{{ inventory_hostname }} "echo can_connect"
+  local_action: command ansible {{ inventory_hostname }} -m ping -i {{ inventory_file }} -u root
   failed_when: false
   changed_when: false
   register: root_status
 
 - name: Set remote user for each host
   set_fact:
-    ansible_ssh_user: "{{ (root_status.stdout == 'can_connect') | ternary('root', admin_user) }}"
+    ansible_ssh_user: "{{ (root_status.rc == 0) | ternary('root', admin_user) }}"
+
+- name: Announce which user was selected
+  debug:
+    msg: "Note: Ansible will attempt connections as user = {{ ansible_ssh_user }}"


### PR DESCRIPTION
Thanks @louim for [pointing out](https://github.com/roots/trellis/issues/288#issuecomment-127487221) that if a user's hosts file were to use a nickname like this... 
```
[web]
nickname ansible_ssh_host=192.168.50.5
```
... the remote-user task would try `ssh root@nickname` when it should really use the `ansible_ssh_host` value if it exists, with the `ansible_hostname` as the fallback default.

Thinking about this, I realized the hosts file could have other important parameters to use too, such as `ansible_ssh_port`, `ansible_ssh_private_key_file`, etc. 

Rather than try to add in all these parameters to a local action ssh command, I realized we could just use the [ping module](http://docs.ansible.com/ansible/ping_module.html) which tests whether Ansible can connect to each host in the exact manner used for `ansible-playbook` commands (I think).

This should be a more reliable approach. It should also help avoid problems like [this](https://discourse.roots.io/t/fatal-192-168-50-5-ssh-error-permission-denied-publickey/4566/9), which resulted from the task testing a manual ssh connection that is slightly different from the connection Ansible would use on its own.

Successfully handles the AWS issue raised in #285