### PR TITLE
Add more HTTP security headers

### DIFF
--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -35,7 +35,9 @@ server {
   include ssl-stapling.conf;
 
   add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; preload";
+  add_header X-Content-Type-Options "nosniff" always;
   add_header X-Frame-Options SAMEORIGIN;
+  add_header X-Xss-Protection "1; mode=block" always;
 
   {% if item.value.ssl.cert is defined and item.value.ssl.key is defined %}
   ssl_certificate         /etc/nginx/ssl/{{ item.value.ssl.cert | basename }};


### PR DESCRIPTION
* `X-Xss-Protection` (https://scotthelme.co.uk/hardening-your-http-response-headers/#x-xss-protection)
* `X-Content-Type-Options` (https://scotthelme.co.uk/hardening-your-http-response-headers/#x-content-type-options)

The value here for `X-Xss-Protection` has some issues in IE8 but who cares?

We also need to look into CSP headers but that's more complicated.
