### PR TITLE
Specify fastcgi_buffer_size nginx directive explicitly

### DIFF
--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -3,6 +3,7 @@ nginx_logs_root: /var/log/nginx
 nginx_user: www-data
 strip_www: true
 nginx_fastcgi_buffers: 8 8k
+nginx_fastcgi_buffer_size: 16k
 
 # Fastcgi cache params
 nginx_cache_path: /var/cache/nginx

--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -36,8 +36,11 @@ http {
   # Hide nginx version information.
   server_tokens off;
 
-  # Setup the fastcgi cache.
+  # FastCGI buffers: bigger than default but not too big either
   fastcgi_buffers {{ nginx_fastcgi_buffers }};
+  fastcgi_buffer_size {{ nginx_fastcgi_buffer_size }};
+
+  # Setup the fastcgi cache.
   fastcgi_cache_path {{ nginx_cache_path }} levels=1:2 keys_zone=wordpress:{{ nginx_cache_key_storage_size }} max_size={{ nginx_cache_size }} inactive={{ nginx_cache_inactive }};
   fastcgi_cache_use_stale updating error timeout invalid_header http_500;
   fastcgi_cache_lock on;


### PR DESCRIPTION
Fixes #323 by:

* Adding fastcgi_buffer_size directive to nginx.conf
* Setting default value for it at 16k, which prevents a 502 error when connecting Jetpack to WordPress.com.

