### PR TITLE
hhvm restart IO redirection typo should be 2>&1

### DIFF
--- a/roles/hhvm/tasks/main.yml
+++ b/roles/hhvm/tasks/main.yml
@@ -37,7 +37,7 @@
   cron: name="Restart HHVM daily"
         hour="{{ hhvm_daily_restart_hour }}"
         minute="{{ hhvm_daily_restart_minute }}"
-        job="/usr/sbin/service hhvm restart >/dev/null >2&1"
+        job="/usr/sbin/service hhvm restart >/dev/null 2>&1"
         user=root
         cron_file=hhvm-daily-restart
   when: hhvm_daily_restart | default(True)


### PR DESCRIPTION
For the hhvm restart the IO redirection should be 2>&1

Current command raises error: /bin/sh: 1: 1: not found