### PR TITLE
Improve subtree variable name and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Rename WP site variable `subtree` to `subtree_path` ([#329](https://github.com/roots/trellis/pull/329))
 * Add extra HTTP security headers ([#322](https://github.com/roots/trellis/pull/322))
 * HHVM restart cron job fix ([#327](https://github.com/roots/trellis/pull/327))
 * Improve SSH remote user detection ([#321](https://github.com/roots/trellis/pull/321))

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ For example: configure the sites on your Vagrant development VM by editing `grou
 * `local_path` - path targeting Bedrock-based site directory (required for development)
 * `repo` - URL of the Git repo of your Bedrock project (required, used when deploying)
 * `branch` - the branch name, tag name, or commit SHA1 you want to deploy (default: `master`)
+* `subtree_path` - relative path to your Bedrock/WP directory in your repo (above) if its not the root (like in the [roots-example-project](https://github.com/roots/roots-example-project.com))
 * `ssl` - enable SSL and set paths
   * `enabled` - `true` or `false` (required, set to `false`. Set to `true` without the `key` and `cert` options [to generate a *self-signed* certificate](https://github.com/roots/trellis/wiki/SSL) )
   * `key` - local relative path to private key

--- a/group_vars/production/wordpress_sites.yml
+++ b/group_vars/production/wordpress_sites.yml
@@ -6,7 +6,7 @@ wordpress_sites:
     local_path: ../site # path targeting local Bedrock site directory (relative to Ansible root)
     repo: git@github.com:roots/bedrock.git
     branch: master
-    # subtree: site # Use this if following the roots-example-project structure
+    # subtree_path: site # relative path to your Bedrock/WP directory in your repo (above) if its not the root (like the roots-example-project structure)
     multisite:
       enabled: false
       subdomains: false

--- a/group_vars/staging/wordpress_sites.yml
+++ b/group_vars/staging/wordpress_sites.yml
@@ -6,7 +6,7 @@ wordpress_sites:
     local_path: ../site # path targeting local Bedrock site directory (relative to Ansible root)
     repo: git@github.com:roots/bedrock.git
     branch: master
-    # subtree: site # Use this if following the roots-example-project structure
+    # subtree_path: site # relative path to your Bedrock/WP directory in your repo (above) if its not the root (like the roots-example-project structure)
     multisite:
       enabled: false
       subdomains: false

--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -1,7 +1,7 @@
 # If you use the "git" strategy:
 # - you must set a repository (no default)
 project_git_repo: "{{ project.repo }}"
-project_subtree: "{{ project.subtree | default(false) }}"
+project_subtree_path: "{{ project.subtree_path | default(false) }}"
 # - you can set the git ref to deploy (can be a branch, tag or commit hash)
 project_version: "{{ project.branch | default('master') }}"
 

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -34,8 +34,8 @@
   command: cp -pr {{ project_source_path }} {{ deploy_helper.new_release_path }}
 
 - name: Move project subtree into root folder
-  shell: mv {{ deploy_helper.new_release_path }}/{{ project_subtree }}/* {{ deploy_helper.new_release_path }}
-  when: project_subtree != 'False'
+  shell: mv {{ deploy_helper.new_release_path }}/{{ project_subtree_path }}/* {{ deploy_helper.new_release_path }}
+  when: project_subtree_path != 'False'
 
 - name: Remove unwanted files/folders from new release
   file: path="{{ deploy_helper.new_release_path }}/{{ item }}" state=absent


### PR DESCRIPTION
Renamed `subtree` to `subtree_path` to better reflect what it actually is. `subtree` also wasn't even documented in the `README`.