### PR TITLE
Validate subtree_path during deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Add check to validate `subtree_path` during deploy ([#334](https://github.com/roots/trellis/pull/334))
 * Rename WP site variable `subtree` to `subtree_path` ([#329](https://github.com/roots/trellis/pull/329))
 * Add extra HTTP security headers ([#322](https://github.com/roots/trellis/pull/322))
 * HHVM restart cron job fix ([#327](https://github.com/roots/trellis/pull/327))

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -33,6 +33,15 @@
 - name: Copy files to new build dir
   command: cp -pr {{ project_source_path }} {{ deploy_helper.new_release_path }}
 
+- name: Check for project subtree
+  stat: path={{ deploy_helper.new_release_path }}/{{ project_subtree_path }}
+  register: project_subtree_full_path
+  when: project_subtree_path != 'False'
+
+- name: Fail if project_subtree_path is set incorrectly
+  fail: msg="subtree is set to '{{ project_subtree_path }}' but that path does not exist in the repo. Edit `subtree_path` for '{{ site }}' in `wordpress_sites.yml`."
+  when: project_subtree_path != 'False' and not project_subtree_full_path.stat.exists
+
 - name: Move project subtree into root folder
   shell: mv {{ deploy_helper.new_release_path }}/{{ project_subtree_path }}/* {{ deploy_helper.new_release_path }}
   when: project_subtree_path != 'False'


### PR DESCRIPTION
Setting a proper `subtree_path` seems to be a common problem. Previously
the error was a fairly cryptic one during the `mv` command.

Now we'll check if the `subtree_path` actually exists in the cloned repo
and provide a useful fail msg if it does not.