### PR TITLE
Vagrant provider agnostic setup

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,9 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# Specify Vagrant provider as Virtualbox
-ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
-
 require 'yaml'
 
 ANSIBLE_PATH = __dir__ # absolute path to Ansible directory
@@ -81,23 +78,58 @@ Vagrant.configure('2') do |config|
     end
   end
 
-  config.vm.provider 'virtualbox' do |vb|
-    # Give VM access to all cpu cores on the host
-    cpus = case RbConfig::CONFIG['host_os']
-      when ENV['NUMBER_OF_PROCESSORS'] then ENV['NUMBER_OF_PROCESSORS'].to_i
-      when /darwin/ then `sysctl -n hw.ncpu`.to_i
-      when /linux/ then `nproc`.to_i
-      else 2
-    end
+  # Give VM access to all cpu cores on the host
+  cpus = case RbConfig::CONFIG['host_os']
+    when ENV['NUMBER_OF_PROCESSORS'] then ENV['NUMBER_OF_PROCESSORS'].to_i
+    when /darwin/ then `sysctl -n hw.ncpu`.to_i
+    when /linux/ then `nproc`.to_i
+    else 2
+  end
 
-    # Customize memory in MB
-    vb.customize ['modifyvm', :id, '--memory', 1024]
+  # Give VM more memory
+  memory = 1024
+
+  # Virtualbox settings
+  config.vm.provider 'virtualbox' do |vb|
+    # Customize  VM settings
+    vb.customize ['modifyvm', :id, '--memory', memory]
     vb.customize ['modifyvm', :id, '--cpus', cpus]
 
     # Fix for slow external network connections
     vb.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
     vb.customize ['modifyvm', :id, '--natdnsproxy1', 'on']
   end
+
+  # VMware Workstation settings
+  config.vm.provider 'vmware_workstation' do |vmw, override|
+    # Override provider box
+    override.vm.box = 'puppetlabs/ubuntu-14.04-64-nocm'
+
+    # Customize  VM settings
+    vmw.vmx['memsize'] = memory
+    vmw.vmx['numvcpus'] = cpus
+  end
+
+  # VMware Fusion settings
+  config.vm.provider 'vmware_fusion' do |vmf, override|
+    # Override provider box
+    override.vm.box = 'puppetlabs/ubuntu-14.04-64-nocm'
+
+    # Customize  VM settings
+    vmf.vmx['memsize'] = memory
+    vmf.vmx['numvcpus'] = cpus
+  end
+
+  # Parallels settings
+  config.vm.provider 'parallels' do |prl, override|
+    # Override provider box
+    override.vm.box = 'parallels/ubuntu-14.04'
+
+    # Customize  VM settings
+    prl.memory = memory
+    prl.cpus = cpus
+  end
+
 end
 
 def local_site_path(site)

--- a/windows.sh
+++ b/windows.sh
@@ -13,6 +13,12 @@ if [ ! -f ~/.ssh/id_rsa ]; then
   echo -e "\n\n\n" | ssh-keygen -t rsa
 fi
 
+# Check that add-apt-repository is installed for non-standard Vagrant boxes
+if [ ! -f /usr/bin/add-apt-repository ]; then
+  echo "Adding add-apt-repository..."
+  sudo apt-get -y install software-properties-common
+fi
+
 # Install Ansible and its dependencies if not installed.
 if [ ! -f /usr/bin/ansible ]; then
   echo "Adding Ansible repository..."


### PR DESCRIPTION
This allows Trellis to be provider agnostic without losing any functionality.  I've tested on Windows 8.1 with VMWare Workstation 11 using Vagrant 1.7.4