### PR TITLE
Ensure admin_user can connect before disabling root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Ensure admin_user can connect before disabling root ([#345](https://github.com/roots/trellis/pull/345))
 * Prevent PHP execution in uploads directory ([#356](https://github.com/roots/trellis/pull/356))
 * Update h5bp Nginx configs ([#355](https://github.com/roots/trellis/pull/355))
 * Convert sshd role variables to booleans ([#344](https://github.com/roots/trellis/pull/344))

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -9,6 +9,15 @@
               line="%sudo ALL=(ALL:ALL) ALL"
               validate="/usr/sbin/visudo -cf %s"
 
+- name: Fail if root login will be disabled but admin_user will not be a sudoer
+  assert:
+    that:
+      - "{{ admin_user in (users | map(attribute='name') | list) }}"
+      - "{% for item in users if item.name == admin_user %}{{ 'sudo' in item.groups }}{% endfor %}"
+      - "{{ admin_user in sudoer_passwords.keys() }}"
+    msg: "When `sshd_permit_root_login: false`, you must add `sudo` to the `groups` for admin_user (in `users` hash), and set a password for admin_user in `sudoer_passwords`. Otherwise Ansible could lose the ability to run the necessary sudo commands."
+  when: not sshd_permit_root_login
+
 - name: Setup users
   user: name="{{ item.name }}"
         group="{{ item.groups[0] }}"
@@ -34,3 +43,16 @@
   with_subelements:
     - users | default([])
     - keys
+
+- name: Check whether Ansible can connect as admin_user
+  local_action: command ansible {{ inventory_hostname }} -m ping -i {{ inventory_file }} -u {{ admin_user }}
+  failed_when: false
+  changed_when: false
+  sudo: no
+  register: admin_user_status
+  when: not sshd_permit_root_login
+
+- name: Fail if root login will be disabled but admin_user cannot connect
+  fail:
+    msg: 'The admin_user is unable to connect to the server. To prevent you from losing access to your server, the playbook has halted before disabling root login (`sshd_permit_root_login: false`). Ensure that the admin_user appears in your `users` hash with a valid entry for `keys`.'
+  when: not sshd_permit_root_login and admin_user_status | failed


### PR DESCRIPTION
Resolves #294 

Only merge after #344 which converts `sshd_permit_root_login` to boolean. 