### PR TITLE
Fix #316 - Add wp-cli permalink command

### DIFF
--- a/group_vars/development/wordpress_sites.yml
+++ b/group_vars/development/wordpress_sites.yml
@@ -9,6 +9,7 @@ wordpress_sites:
     admin_user: admin
     admin_password: admin
     admin_email: admin@example.dev
+    permalink_structure: "/%postname%/"
     multisite:
       enabled: false
       subdomains: false

--- a/group_vars/production/wordpress_sites.yml
+++ b/group_vars/production/wordpress_sites.yml
@@ -7,6 +7,7 @@ wordpress_sites:
     repo: git@github.com:roots/bedrock.git
     branch: master
     # subtree_path: site # relative path to your Bedrock/WP directory in your repo (above) if it is not the root (like the roots-example-project structure)
+    permalink_structure: "/%postname%/"
     multisite:
       enabled: false
       subdomains: false

--- a/group_vars/staging/wordpress_sites.yml
+++ b/group_vars/staging/wordpress_sites.yml
@@ -7,6 +7,7 @@ wordpress_sites:
     repo: git@github.com:roots/bedrock.git
     branch: master
     # subtree_path: site # relative path to your Bedrock/WP directory in your repo (above) if it is not the root (like the roots-example-project structure)
+    permalink_structure: "/%postname%/"
     multisite:
       enabled: false
       subdomains: false

--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -37,6 +37,27 @@
   when: item.value.site_install == True and (item.value.multisite.enabled | default(False) == False)
   changed_when: "'WordPress is already installed.' not in wp_install_results.stdout"
 
+- name: Check Existing Permalink Structure
+  command: wp rewrite list --format=count
+           --allow-root
+           --url="{{ item.value.env.wp_home }}"
+  args:
+    chdir: "{{ www_root }}/{{ item.key }}/current/"
+  register: wp_permalink_check_results
+  with_dict: wordpress_sites
+  when: item.value.site_install and not item.value.multisite.enabled | default(false)
+  changed_when: False
+
+- name: Setup Permalink Structure
+  command: wp rewrite structure {{ item.value.permalink_structure | default("/%postname%/") }}
+           --allow-root
+           --url="{{ item.value.env.wp_home }}"
+  args:
+    chdir: "{{ www_root }}/{{ item.key }}/current/"
+  register: wp_permalink_results
+  with_dict: wordpress_sites
+  when: "'No rewrite rules' in wp_permalink_check_results.results.0.stderr"
+
 - name: Install WP Multisite
   command: wp core multisite-install
            --allow-root


### PR DESCRIPTION
I had the same issue as others in #316 where permalinks weren't enabled by default.  This adds a wp-cli command to turn them on based on a new variable `permalink_structure`.  It seemed like everyone wanted it on by default so I did not make an "enabled" option