### PR TITLE
Fix #352 - Block PHP scripts in Nginx for uploads

### DIFF
--- a/roles/nginx/templates/wordpress.conf.j2
+++ b/roles/nginx/templates/wordpress.conf.j2
@@ -1,5 +1,10 @@
 # {{ ansible_managed }}
 
+# Prevent PHP scripts from being executed inside the uploads folder.
+location ~* /app/uploads/.*\.php$ {
+  deny all;
+}
+
 location / {
   try_files $uri $uri/ /index.php?$args;
 }


### PR DESCRIPTION
Prevent php scripts from being accessed or executed inside the app/uploads folder and any subdirectories by adding an nginx directive to the wordpress.conf.

This has been tested to return a 403 error for any file with a ```.php``` extension in app/uploads or any subdirectory of uploads. Assets with any other extension are not affected and can be accessed as normal.