### PR TITLE
Skip connection check if playbooks are being run locally.

### DIFF
--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -50,7 +50,7 @@
   changed_when: false
   sudo: no
   register: admin_user_status
-  when: not sshd_permit_root_login
+  when: not sshd_permit_root_login and ansible_connection | default('ssh') != 'local'
 
 - name: Fail if root login will be disabled but admin_user cannot connect
   fail:


### PR DESCRIPTION
The major use case for running playbooks locally is Packer builds. For a variety of reasons, Packer's Ansible provisioner uploads playbooks to the VM and runs them with `--connection=local`. So the recent addition of `local_action`s to check the user's connection causes the playbooks to fail.

There are other `local_action`s in the `deploy` and `remote_user` roles, but they are only used in the `deploy.yml` and `server.yml` playbooks, so less likely to cause an issue.