### PR TITLE
Move client_max_body_size outside of fastcgi block.

### DIFF
--- a/roles/nginx/templates/wordpress.conf.j2
+++ b/roles/nginx/templates/wordpress.conf.j2
@@ -9,6 +9,9 @@ location / {
   try_files $uri $uri/ /index.php?$args;
 }
 
+# Set the max body size equal to PHP's max POST size.
+client_max_body_size {{ php_post_max_size | default('25m') | lower }};
+
 include h5bp/directive-only/x-ua-compatible.conf;
 include h5bp/location/cross-domain-fonts.conf;
 include h5bp/location/protect-system-files.conf;

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -87,7 +87,6 @@ server {
     {% else -%}
     fastcgi_pass unix:/var/run/php5-fpm-wordpress.sock;
     {% endif -%}
-    client_max_body_size 0;
   }
 }
 


### PR DESCRIPTION
Many (plugin-supplied) upload URLs are rewritten, so putting `client_max_body_size` in a block that only matches literal PHP files means users posting to a path like `/my-custom-form/upload/` will get a `HTTP 413` error if they exceed Nginx's default `client_max_body_size` of 1 MB.