### PR TITLE
Add wildcard to site_host for port 80 if multsite subdomains is enabled (mirror port 443).

### DIFF
--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -93,7 +93,7 @@ server {
 {% if item.value.ssl is defined and item.value.ssl.enabled | default(False) %}
 server {
   listen 80;
-  server_name {{ item.value.site_hosts | join(' ') }};
+  server_name {% for host in item.value.site_hosts %} {{ host }} {% if item.value.multisite.subdomains %} *.{{ host }} {% endif %} {% endfor %};
   return 301 https://$host$request_uri;
 }
 {% endif %}


### PR DESCRIPTION
Without this, requests to http://subdomain.example.com hit `no-default.conf` and are served `HTTP 444`.