### PR TITLE
Use Windows envar to determine number of CPUs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Use Windows environment variable to determine number of CPUs ([#366](https://github.com/roots/trellis/pull/366))
 * Check for galaxy roles before `vagrant up` ([#365](https://github.com/roots/trellis/pull/365))
 * Install Xdebug by default in development environment ([#363](https://github.com/roots/trellis/pull/363))
 * Ensure admin_user can connect before disabling root ([#345](https://github.com/roots/trellis/pull/345))

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -83,6 +83,7 @@ Vagrant.configure('2') do |config|
   config.vm.provider 'virtualbox' do |vb|
     # Give VM access to all cpu cores on the host
     cpus = case RbConfig::CONFIG['host_os']
+      when ENV['NUMBER_OF_PROCESSORS'] then ENV['NUMBER_OF_PROCESSORS'].to_i
       when /darwin/ then `sysctl -n hw.ncpu`.to_i
       when /linux/ then `nproc`.to_i
       else 2


### PR DESCRIPTION
Modern versions of Windows have an environment variable `NUMBER_OF_PROCESSORS` that can be used as a quick and dirty way to get the number of CPUs.

Older versions of Windows, where this envar isn't present, will still fall back to a value of `2`.