### PR TITLE
Run PHP as www-data and alter permissions to allow uploads

### DIFF
--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -55,6 +55,7 @@ project_templates:
 project_shared_children:
   - path: web/app/uploads
     src: uploads
+    mode: "0775"
 
 # The project_environment is a list of environment variables added to the various *_commands
 # Example:

--- a/roles/php/templates/php-fpm.conf.j2
+++ b/roles/php/templates/php-fpm.conf.j2
@@ -4,7 +4,7 @@
 listen = /var/run/php5-fpm-wordpress.sock
 listen.owner = www-data
 listen.group = www-data
-user = {{ web_user }}
+user = www-data
 group = {{ web_group }}
 pm = dynamic
 pm.max_children = 10


### PR DESCRIPTION
Per #368 , the current user and permissions set-up is less secure than it could be, because PHP currently has write access to the whole web root. This commit fixes that by ensuring that PHP runs as www-data, rather than web_user, and so does not have write access to the web root. It also changes the permissions on the uploads folder, which we _do_ want PHP to have write access to.
