### PR TITLE
Do not raise on missing galaxy folder on window

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,7 +21,7 @@ else
   raise "#{config_file} was not found. Please set `ANSIBLE_PATH` in your Vagrantfile."
 end
 
-if !Dir.exists?(galaxy_roles)
+if !Dir.exists?(galaxy_roles) && !Vagrant::Util::Platform.windows?
   raise "You are missing the required Ansible Galaxy roles. Run `ansible-galaxy install -r requirements.yml` to get them."
 end
 


### PR DESCRIPTION
The folder will be created in the VM, not on the host. Fixes #370. This should be incorporated to #367 (which is cleaner). 