### PR TITLE
Fix #375 - add static files to Nginx index directive

### DIFF
--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -12,7 +12,7 @@ server {
   error_log    {{ www_root }}/{{ item.key }}/logs/error.log;
 
   root  {{ www_root }}/{{ item.key }}/current/web;
-  index index.php;
+  index index.php index.htm index.html;
 
   charset utf-8;
 


### PR DESCRIPTION
I'm not sure if index is anywhere else (I'm still pretty new to this ansible stuff and I'm not entirely sure where to find everything). If it is, then I think we should remove repeated references to it and just put it somewhere in [nginx.conf](https://github.com/roots/trellis/blob/master/roles/nginx/templates/nginx.conf.j2#L34-L138).

See also: https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/#multiple-index-directives