### PR TITLE
Fix Nginx postrotate log script

### DIFF
--- a/group_vars/all/logrotate.yml
+++ b/group_vars/all/logrotate.yml
@@ -17,4 +17,4 @@ logrotate_scripts:
         if [ -d /etc/logrotate.d/httpd-prerotate ]; then \
               run-parts /etc/logrotate.d/httpd-prerotate; \
             fi \
-      postrotate: invoke-rc.d nginx rotate >/dev/null 2>&1
+      postrotate: service nginx rotate


### PR DESCRIPTION
Addresses one of the two issues raised here: https://github.com/roots/trellis/issues/315

Per `man service`:

```
The existence of an upstart  job  of  the  same name 
as  a script in /etc/init.d will cause the upstart job
to take precedence over the init.d script.
```

So, `invoke-rc.d nginx rotate >/dev/null 2>&1` fails because the `rotate` function has been removed since the switch of nginx to Upstart. This is seen when running `sudo logrotate -vf /etc/logrotate.d/wordpress-sites` on a vanilla bedrock/trellis/sage install, which will result in:

`error: error running shared postrotate script for '"/srv/www/**/logs/*.log" '`

Of note, the script should send the -USR1 signal to the master process to avoid the old worker processes which are shutting down from still using the old log file(s).