### PR TITLE
add nonempty option to config.bindfs.bind_folder

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,7 +57,7 @@ Vagrant.configure('2') do |config|
     else
       wordpress_sites.each_pair do |name, site|
         config.vm.synced_folder local_site_path(site), nfs_path(name), type: 'nfs'
-        config.bindfs.bind_folder nfs_path(name), remote_site_path(name), u: 'vagrant', g: 'www-data'
+        config.bindfs.bind_folder nfs_path(name), remote_site_path(name), u: 'vagrant', g: 'www-data', o: 'nonempty'
       end
     end
   end


### PR DESCRIPTION
This should help people adding sites to their trellis installation. Examples of the problem can be seen at:
 https://discourse.roots.io/t/adding-sites-to-existing-trellis-server/4866/7
https://discourse.roots.io/t/bedrock-ansible-vagrantfile-update-bindfs-issue/3076

Credit to @cunningryan who looks to have figured this out before me. Not sure about the Windows part or if this could cause any kind of issues. Figured it would put this here to get conversation started.