### PR TITLE
Adds HSTS configuration variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Update SSL cipher suite ([#386](https://github.com/roots/trellis/pull/386))
 * Support for other Vagrant providers (VirtualBox, VMWare, Parallels) ([#340](https://github.com/roots/trellis/pull/340))
 * Specify versions for Ansible Galaxy requirements ([#385](https://github.com/roots/trellis/pull/385))
+* Adds ability to configure [HSTS headers](https://developer.mozilla.org/en-US/docs/Web/Security/HTTP_strict_transport_security) with site variables. ([#388](https://github.com/roots/trellis/pull/388))
 
 ### 0.9.2: October 15th, 2015
 * Add dev's IP to ferm whitelist ([#381](https://github.com/roots/trellis/pull/381))

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ For example: configure the sites on your Vagrant development VM by editing `grou
   * `enabled` - `true` or `false` (required, set to `false`. Set to `true` without the `key` and `cert` options [to generate a *self-signed* certificate](https://roots.io/trellis/docs/ssl/) )
   * `key` - local relative path to private key
   * `cert` - local relative path to certificate
+  * `hsts_max_age` - time, in seconds, that the browser should remember that this site is only to be accessed using HTTPS (default: `31536000`)
+  * `hsts_include_subdomains` - if true, the HSTS rules apply to all of the site's subdomains as well (default: `true`)
+  * `hsts_preload` - required to opt into [Google's HSTS preload list](https://hstspreload.appspot.com/) (default: `true`)
 * `site_install` - whether to install WordPress or not (*development* only, required)
 * `site_title` - WP site title (*development* only, default: project name)
 * `db_create` - whether to auto create a database or not (default: `true`)

--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -4,6 +4,11 @@ nginx_user: www-data
 strip_www: true
 nginx_fastcgi_buffers: 8 8k
 
+# HSTS defaults
+nginx_hsts_max_age: 31536000
+nginx_hsts_include_subdomains: true
+nginx_hsts_preload: true
+
 # Fastcgi cache params
 nginx_cache_path: /var/cache/nginx
 nginx_cache_duration: 30s

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -38,7 +38,10 @@ server {
   include ssl.conf;
   include ssl-stapling.conf;
 
-  add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; preload";
+  {% set hsts_max_age = item.value.ssl.hsts_max_age | default(nginx_hsts_max_age) %}
+  {% set hsts_include_subdomains = item.value.ssl.hsts_include_subdomains | default(nginx_hsts_include_subdomains) | ternary('includeSubdomains', None) %}
+  {% set hsts_preload = item.value.ssl.hsts_preload | default(nginx_hsts_preload) | ternary('preload', None) %}
+  add_header Strict-Transport-Security "max-age={{ [hsts_max_age, hsts_include_subdomains, hsts_preload] | reject('none') | join('; ') }}";
 
   {% if item.value.ssl.cert is defined and item.value.ssl.key is defined %}
   ssl_certificate         /etc/nginx/ssl/{{ item.value.ssl.cert | basename }};


### PR DESCRIPTION
Adds the following WordPress site variables

ssl.nginx_hsts_max_age
ssl.nginx_hsts_include_subdomains
ssl.nginx_hsts_preload

Adds the following nginx global defaults

nginx_hsts_max_age: 31536000
nginx_hsts_include_subdomains: true
nginx_hsts_preload: true

