### PR TITLE
Updates variables to use curl instead of dig

### DIFF
--- a/group_vars/all/security.yml
+++ b/group_vars/all/security.yml
@@ -4,7 +4,7 @@ ferm_input_list:
     filename: nginx_accept
   - type: dport_accept
     dport: [ssh]
-    saddr: ["{{ lookup('pipe', 'dig +short myip.opendns.com @resolver1.opendns.com') }}"]
+    saddr: ["{{ lookup('pipe', 'curl -4 https://diagnostic.opendns.com/myip') }}"]
   - type: dport_limit
     dport: [ssh]
     seconds: 300

--- a/roles/fail2ban/defaults/main.yml
+++ b/roles/fail2ban/defaults/main.yml
@@ -3,7 +3,7 @@ fail2ban_loglevel: 3
 fail2ban_logtarget: /var/log/fail2ban.log
 fail2ban_socket: /var/run/fail2ban/fail2ban.sock
 
-fail2ban_ignoreip: 127.0.0.1/8 {{ lookup('pipe', 'dig +short myip.opendns.com @resolver1.opendns.com') }}
+fail2ban_ignoreip: 127.0.0.1/8 {{ lookup('pipe', 'curl -4 https://diagnostic.opendns.com/myip') }}
 fail2ban_bantime: 600
 fail2ban_maxretry: 6
 


### PR DESCRIPTION
The present `dig` command will not work on networks that restrict outgoing UDP traffic only to the network's own DNS servers.
This change uses `curl` to query OpenDNS's endpoint (with https to ensure response integrity).