### PR TITLE
WP-CLI role improvements - fixes #391

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Use WP-CLI 0.21.1 ([#392](https://github.com/roots/trellis/pull/392))
 * Add variable for whitelisted IPs ([#435](https://github.com/roots/trellis/pull/435))
 
 ### 0.9.3: November 29th, 2015

--- a/roles/wp-cli/defaults/main.yml
+++ b/roles/wp-cli/defaults/main.yml
@@ -1,4 +1,4 @@
-phar_url: https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
-bin_path: /usr/bin/wp
-wp_cli_completion_url: https://raw.githubusercontent.com/wp-cli/wp-cli/master/utils/wp-completion.bash
+wp_cli_bin_path: /usr/bin/wp
+wp_cli_phar_url: "https://github.com/wp-cli/wp-cli/releases/download/v0.21.1/wp-cli-0.21.1.phar"
+wp_cli_completion_url: "https://raw.githubusercontent.com/wp-cli/wp-cli/master/utils/wp-completion.bash"
 wp_cli_completion_path: /etc/bash_completion.d

--- a/roles/wp-cli/tasks/main.yml
+++ b/roles/wp-cli/tasks/main.yml
@@ -1,9 +1,12 @@
 ---
 - name: Install WP-CLI
-  get_url: url="{{ phar_url }}" dest="{{ bin_path }}" mode=0755
+  get_url:
+    url: "{{ wp_cli_phar_url }}"
+    dest: "{{ wp_cli_bin_path }}"
+    mode: 0755
 
 - name: Install WP-CLI tab completions
   get_url:
-    url="{{ wp_cli_completion_url }}"
-    dest="{{ wp_cli_completion_path }}"
-    mode=0644
+    url: "{{ wp_cli_completion_url }}"
+    dest: "{{ wp_cli_completion_path }}"
+    mode: 0644


### PR DESCRIPTION
* Switch to better syntax
* Improve variable names with `wp_cli_` prefix
* Use WP-CLI nightly