### PR TITLE
Add deploy_build_before example hook for theme assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Add deploy_build_before example hook for theme assets ([#397](https://github.com/roots/trellis/pull/37))
 * Use curl instead of dig for IP lookups ([#390](https://github.com/roots/trellis/pull/390))
 * Update SSL cipher suite ([#386](https://github.com/roots/trellis/pull/386))
 * Support for other Vagrant providers (VirtualBox, VMWare, Parallels) ([#340](https://github.com/roots/trellis/pull/340))

--- a/deploy-hooks/build-before.yml
+++ b/deploy-hooks/build-before.yml
@@ -1,0 +1,29 @@
+# Placeholder `deploy_build_before` hook for building theme assets locally
+# and then copying the files to the remote server
+#
+# Uncomment the lines below and replace `sage` with your theme folder
+#
+# ---
+# - name: Run npm install
+#   command: npm install
+#   connection: local
+#   args:
+#     chdir: "{{ project.local_path }}/web/app/themes/sage"
+# - name: Run bower install
+#   command: bower install
+#   connection: local
+#   args:
+#     chdir: "{{ project.local_path }}/web/app/themes/sage"
+# - name: Run gulp
+#   command: gulp --production
+#   connection: local
+#   args:
+#     chdir: "{{ project.local_path }}/web/app/themes/sage"
+# - name: Copy project local files
+#   template:
+#     src: "{{ item.src }}"
+#     dest: "{{ deploy_helper.new_release_path }}/{{ item.dest }}"
+#     mode: "{{ item.mode | default('0644') }}"
+#     with_items:
+#     - src: "{{ project.local_path }}/web/app/themes/sage/dist"
+#       dest: web/app/themes/sage

--- a/deploy.yml
+++ b/deploy.yml
@@ -4,6 +4,7 @@
   remote_user: "{{ web_user }}"
 
   vars:
+    deploy_build_before: "{{ playbook_dir }}/deploy-hooks/build-before.yml"
     deploy_build_after: "{{ playbook_dir }}/roles/deploy/hooks/build-after.yml"
     deploy_finalize_after: "{{ playbook_dir }}/roles/deploy/hooks/finalize-after.yml"
     project: "{{ wordpress_sites[site] }}"


### PR DESCRIPTION
not everyone using trellis is going to have a theme that needs this, but i would still like this to exist as a placeholder.

see https://discourse.roots.io/t/deployment-with-the-new-trellis-hooks/5016/2?u=benword