### PR TITLE
Enable sorted iteration over env vars

### DIFF
--- a/roles/wordpress-install/templates/env.j2
+++ b/roles/wordpress-install/templates/env.j2
@@ -1,3 +1,4 @@
-{% for key, value in item.value.env.iteritems() %}
-{{ key | upper }}="{{ value }}"
+{% set env = item.value.env %}
+{% for item in env | dictsort %}
+{{ item.0 | upper }}={{ item.1 }}
 {% endfor %}


### PR DESCRIPTION
Python dictionaries aren't sorted so this enables sorting. Use case: `vlucas/phpdotenv` >= 2.0 enables nested variables referencing other envvars. If the envvar hasn't been declared yet, it'll leave it alone (which isn't desired). By sorting the envvars and iterating over them in the order defined, it enables us to better utilize this functionality.