### PR TITLE
Composer config github-oauth

### DIFF
--- a/roles/composer/tasks/main.yml
+++ b/roles/composer/tasks/main.yml
@@ -16,3 +16,7 @@
     regexp: ^PATH="(((?!:./vendor/bin).)*)"
     line: PATH="\1:./vendor/bin"
     backrefs: yes
+
+- name: Composer config github-oauth
+  command: composer config -g github-oauth.github.com {{ composer_githuboauth }}
+  when: composer_githuboauth is defined

--- a/roles/composer/tasks/main.yml
+++ b/roles/composer/tasks/main.yml
@@ -18,5 +18,5 @@
     backrefs: yes
 
 - name: Composer config github-oauth
-  command: composer config -g github-oauth.github.com {{ composer_githuboauth }}
-  when: composer_githuboauth is defined
+  command: composer config -g github-oauth.github.com {{ composer_github_oauth_token }}
+  when: composer_github_oauth_token is defined


### PR DESCRIPTION
Add the possibility of including the token used on Github.

According to the instructions here: https://getcomposer.org/doc/articles/troubleshooting.md#api-rate-limit-and-oauth-tokens