### PR TITLE
Remove minor reference to Mandrill

### DIFF
--- a/group_vars/all/mail.yml
+++ b/group_vars/all/mail.yml
@@ -1,5 +1,5 @@
 # Documentation: https://github.com/roots/trellis#mail
-mail_smtp_server: smtp.mandrillapp.com:587
+mail_smtp_server: smtp.example.com:587
 mail_admin: admin@example.com
 mail_hostname: example.com
 mail_user: smtp_user


### PR DESCRIPTION
Mandrill's free tier changed a while ago and we removed it from our docs. This just removes a small reference to it in the default mail config.