### PR TITLE
Add `wp core update-db` to finalize hook

### DIFF
--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -11,7 +11,24 @@
   command: wp eval 'wp_clean_themes_cache(); switch_theme(get_stylesheet());'
   args:
     chdir: "{{ deploy_helper.new_release_path }}"
-  when: wp_installed.rc == 0
+  when: wp_installed | success
+
+- name: Update WP database
+  command: wp core update-db
+  args:
+    chdir: "{{ deploy_helper.new_release_path }}"
+  when: wp_installed | success and not project.multisite.enabled | default(false)
+
+- name: Warn about updating network database.
+  debug:
+    msg: "Updating the network database could take a long time with a large number of sites."
+  when: wp_installed | success and project.multisite.enabled | default(false)
+
+- name: Update WP network database
+  command: wp core update-db --network
+  args:
+    chdir: "{{ deploy_helper.new_release_path }}"
+  when: wp_installed | success and project.multisite.enabled | default(false)
 
 - name: Reload php5-fpm
   shell: sudo service php5-fpm reload


### PR DESCRIPTION
Fixes #398.

~~Couple things: first, I think this is where this is supposed to go, but if I'm reading this right, it doesn't look like this file is actually run during the deployment process and works more like an example? And second, the reason I don't know the answer to that is I haven't fully tested it because I'm running an old version of Trellis that I need to upgrade to the latest variable configuration (you'll notice my fork is still named `bedrock-ansible`).~~

~~That said,~~ I'm opening this up for comments, since this is my first Ansible task (which, as a side note, is a really neat benefit of the deployment hooks: it allows you to dip your toes into writing Ansible tasks without needing to understand everything at once).

Thoughts?