### PR TITLE
SSH Forwarding From Host to Guest

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -59,6 +59,48 @@ Vagrant.configure('2') do |config|
     end
   end
 
+  # Prevent annoying "stdin: not a tty" errors
+  config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
+  config.ssh.username = "vagrant"
+
+  # Replace insecure Vagrant ssh public key with user generated private/public keys
+  public_key = File.join(Dir.home, ".ssh", "id_rsa.pub")
+  private_key = File.join(Dir.home, ".ssh", "id_rsa")
+
+  if File.exists?(private_key)
+    # A public key MUST be accompanied by a private key
+    if File.exists?(public_key)
+      # Copy user's public key to the vm so it can be validated and applied
+      config.vm.provision "file", source: public_key, destination: "/home/vagrant/.ssh/" + File.basename(public_key)
+
+      # Add user's private key to all Vagrant-usable local private keys so all
+      # required login scenarios will keep functioning as expected:
+      # - initial non-secure vagrant up
+      # - users protecting their box with a personally generated public key
+      config.ssh.private_key_path = [
+        private_key,
+        '~/.vagrant.d/insecure_private_key' 
+      ]
+
+      # Run bash script to replace insecure public key in authorized_keys
+      config.vm.provision :shell do |sh|
+        sh.path = File.join(ANSIBLE_PATH, 'ssh-authentication.sh')
+        sh.args = [ File.basename(public_key), File.basename(private_key) ]
+      end
+
+      # Prevent Vagrant 1.7.x from generating a new private key and inserting
+      # corresponding public key (overwriting our just set custom key).
+      config.ssh.insert_key = false
+
+      # Always display SSH Agent Forwarding sanity checks
+      config.vm.provision :shell do |sh|
+        sh.path = File.join(ANSIBLE_PATH, 'check-ssh-agent.sh')
+        sh.privileged = false
+      end
+    end
+  end
+
+
   if Vagrant::Util::Platform.windows?
     config.vm.provision :shell do |sh|
       sh.path = File.join(ANSIBLE_PATH, 'windows.sh')

--- a/check-ssh-agent.sh
+++ b/check-ssh-agent.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+#credit: https://github.com/alt3/cakebox
+
+printf %63s |tr " " "-"
+printf '\n'
+printf "Sanity checking SSH Agent Forwarding\n"
+printf %63s |tr " " "-"
+printf '\n'
+
+# Show user
+USER=$(whoami 2>&1)
+echo "Running checks as user $USER"
+
+# Show status of SSH Agent
+echo "SSH Agent details:"
+OUTPUT=$(ssh-agent 2>&1)
+IFS=' ' read -a lines <<< "$OUTPUT"
+for line in "${lines[@]}"
+do
+    echo "=> $line"
+done
+
+# Show loaded keys
+echo "SSH Forwarded keys:"
+OUTPUT=$(ssh-add -l 2>&1)
+EXITCODE=$?
+echo "=> $OUTPUT"

--- a/roles/wordpress-setup/tasks/main.yml
+++ b/roles/wordpress-setup/tasks/main.yml
@@ -26,7 +26,7 @@
     name: "{{ item.key }} WordPress cron"
     minute: "*/15"
     user: "{{ web_user }}"
-    job: "curl -s {{ item.value.env.wp_siteurl }}/wp-cron.php > /dev/null 2>&1"
+    job: "curl -s {{ item.value.env.wp_siteurl }}/wp-cron.php"
     cron_file: "wordpress-{{ item.key | replace('.', '_') }}"
   with_dict: wordpress_sites
   when: item.value.env.disable_wp_cron | default(false) and not item.value.multisite.enabled | default(false)

--- a/roles/wordpress-setup/tasks/main.yml
+++ b/roles/wordpress-setup/tasks/main.yml
@@ -26,7 +26,7 @@
     name: "{{ item.key }} WordPress cron"
     minute: "*/15"
     user: "{{ web_user }}"
-    job: "curl -s {{ item.value.env.wp_siteurl }}/wp-cron.php"
+    job: "curl -s {{ item.value.env.wp_siteurl }}/wp-cron.php > /dev/null 2>&1"
     cron_file: "wordpress-{{ item.key | replace('.', '_') }}"
   with_dict: wordpress_sites
   when: item.value.env.disable_wp_cron | default(false) and not item.value.multisite.enabled | default(false)

--- a/ssh-authentication.sh
+++ b/ssh-authentication.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# --------------------------------------------------------------------
+# Creates a new authorized_keys file for the vagrant user with (only)
+# the yaml-specified public key. Thus effectively:
+# - disabling the Vagrant insecure key
+# - requiring all SSH logins to require the yaml-specified private key
+#
+# Please note that the public key (e.g. cakebox_rsa.pub) has already
+# been copied from the local machine to the /home/vagrant/.ssh/ folder
+# inside the vm before this script executes. Private key is used for
+# user feedback only, never leaves local machine.
+#
+# Also note creation of the flag file generated so the default Vagrant
+# 1.7.x private key on the local machine will only be removed once this
+# script has successfully replaced the public key on the vm (to prevent
+# SSH timeouts running vagrant reload --provision against a running vm )
+# --------------------------------------------------------------------
+
+#credit: https://github.com/alt3/cakebox
+
+
+# Convenience variables
+PUBLIC_KEY=$1
+PRIVATE_KEY=$2
+SSH_DIR='/home/vagrant/.ssh'
+AUTHORIZED_KEYS="$SSH_DIR/authorized_keys"
+#VAGRANT_FLAG_FILE='.cakebox/remove-vagrant-key.flag'
+VAGRANT_17X_KEY='/vagrant/machines/default/virtualbox/private_key'
+
+printf %63s |tr " " "-"
+printf '\n'
+printf "Restricting Trellis SSH logins\n"
+printf %63s |tr " " "-"
+printf '\n'
+
+# Do nothing if Vagrantfile-specified public key is already the only key in authorized_keys
+if diff "$AUTHORIZED_KEYS" "$SSH_DIR/$PUBLIC_KEY" >/dev/null ; then
+	echo "* Skipping: SSH logins already require Vagrantfile-specified private key ($PRIVATE_KEY)"
+	exit 0
+fi
+
+# Still here, verify the public key is valid before applying (to prevent locking out user)
+echo "* Validating Vagrantfile-specified public key ($PUBLIC_KEY)"
+OUTPUT=$(ssh-keygen -l -f "$SSH_DIR/$PUBLIC_KEY" 2>&1)
+EXITCODE=$?
+if [ "$EXITCODE" -ne 0 ]; then
+	echo $OUTPUT
+	echo "FATAL: key did not pass validation, make sure it is in OpenSSH format"
+	exit 1
+fi
+
+# Make Vagrantfile-specified public key the only key in authorized_keys
+echo "* Replacing current public keys in $AUTHORIZED_KEYS"
+cat "$SSH_DIR/$PUBLIC_KEY" > "$AUTHORIZED_KEYS"
+
+# Remove Vagrant 1.7.x secure private key on host using Synced Folder
+if [ -f "$VAGRANT_17X_KEY" ]; then
+	echo "* Removing Vagrant 1.7.x generated private key"
+	OUTPUT=$(rm "$VAGRANT_17X_KEY" 2>&1)
+	EXITCODE=$?
+	if [ "$EXITCODE" -ne 0 ]; then
+		echo $OUTPUT
+		echo "FATAL: error removing key"
+		exit 1
+	fi
+fi
+
+# All done
+echo "* SSH logins now require Vagrantfile-specified private key ($PRIVATE_KEY)"
+echo "Command completed successfully"


### PR DESCRIPTION
References #415 discussion.

Added two scripts and tweaked the Vagrantfile to check for host machines public and private key. If it's found, it will copy the public key to the guest so the user can login with this key. Since SSH forwarding is enabled, this should allow the user to connect to external machines/account that are aware of this public key.

It works on Mac, Linux, and Windows. Windows users must also:

* "Allow agent forwarding" in PuTTY under Connection-->SSH-->Auth
* Point to their id_rsa.ppk in the same Auth window
* Have Pageant running with their id_rsa.ppk key added before logging into the guest.

