### PR TITLE
Added append_privs to WP setup - databases.

### DIFF
--- a/roles/wordpress-setup/tasks/database.yml
+++ b/roles/wordpress-setup/tasks/database.yml
@@ -11,6 +11,7 @@
 - name: Create/assign database user to db and grant permissions
   mysql_user: name="{{ item.value.env.db_user }}"
               password="{{ item.value.env.db_password }}"
+              append_privs=yes
               priv="{{ item.value.env.db_name | default(item.key) }}.*:ALL"
               state=present
               login_host="{{ item.value.env.db_host | default('localhost') }}"


### PR DESCRIPTION
This change allows that multiple WP installations share the same db
user.

Check the docs here: http://docs.ansible.com/ansible/mysql_user_module.html

For example I might have multiple WP installations, but a common scenario is to have a 1 DB user which will have access to multiple WP databases.