### PR TITLE
Notify Windows users about SSH forwarding

### DIFF
--- a/windows.sh
+++ b/windows.sh
@@ -13,6 +13,15 @@ if [ ! -f ~/.ssh/id_rsa ]; then
   echo -e "\n\n\n" | ssh-keygen -t rsa
 fi
 
+# Check SSH forwarding agent
+echo '
+printf "\033[1;33m"
+if ! ssh-add -l >/dev/null; then
+    printf "See: https://roots.io/trellis/docs/windows/#ssh-forwarding"
+fi
+printf "\033[0m\n\n"
+' >> /home/vagrant/.profile
+
 # Check that add-apt-repository is installed for non-standard Vagrant boxes
 if [ ! -f /usr/bin/add-apt-repository ]; then
   echo "Adding add-apt-repository..."


### PR DESCRIPTION
During `vagrant ssh`, Windows users will see a warning message if `ssh-add -l` fails, indicating that SSH forwarding will not work. The warning includes a link to Trellis docs for Windows.

Example:
```
Could not open a connection to your authentication agent.
See: https://roots.io/trellis/docs/windows/#ssh-forwarding
```

The first line is the output of `ssh-add -l`, so the notification will change depending on the error.