### PR TITLE
Fix #346: Keep headers in server block to fix HSTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Fix HSTS headers ([#424](https://github.com/roots/trellis/pull/424))
 * Add Composer config `github-oauth` variable ([#402](https://github.com/roots/trellis/pull/402))
 * Fix copy project local files in example hook ([#404](https://github.com/roots/trellis/pull/404))
 * Update cron variable to match Bedrock ([#394](https://github.com/roots/trellis/pull/394))

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -35,23 +35,23 @@ server {
   add_header X-Xss-Protection "1; mode=block" always;
 
   {% if item.value.ssl is defined and item.value.ssl.enabled | default(false) %}
-  include ssl.conf;
-  include ssl-stapling.conf;
+    include ssl.conf;
+    include ssl-stapling.conf;
 
-  {% set hsts_max_age = item.value.ssl.hsts_max_age | default(nginx_hsts_max_age) %}
-  {% set hsts_include_subdomains = item.value.ssl.hsts_include_subdomains | default(nginx_hsts_include_subdomains) | ternary('includeSubdomains', None) %}
-  {% set hsts_preload = item.value.ssl.hsts_preload | default(nginx_hsts_preload) | ternary('preload', None) %}
-  add_header Strict-Transport-Security "max-age={{ [hsts_max_age, hsts_include_subdomains, hsts_preload] | reject('none') | join('; ') }}";
+    {% set hsts_max_age = item.value.ssl.hsts_max_age | default(nginx_hsts_max_age) %}
+    {% set hsts_include_subdomains = item.value.ssl.hsts_include_subdomains | default(nginx_hsts_include_subdomains) | ternary('includeSubdomains', None) %}
+    {% set hsts_preload = item.value.ssl.hsts_preload | default(nginx_hsts_preload) | ternary('preload', None) %}
+    add_header Strict-Transport-Security "max-age={{ [hsts_max_age, hsts_include_subdomains, hsts_preload] | reject('none') | join('; ') }}";
 
-  {% if item.value.ssl.cert is defined and item.value.ssl.key is defined %}
-  ssl_certificate         /etc/nginx/ssl/{{ item.value.ssl.cert | basename }};
-  ssl_trusted_certificate /etc/nginx/ssl/{{ item.value.ssl.cert | basename }};
-  ssl_certificate_key     /etc/nginx/ssl/{{ item.value.ssl.key | basename }};
-  {% else %}
-  ssl_certificate         /etc/nginx/ssl/{{ item.key }}_self_signed.pem;
-  ssl_trusted_certificate /etc/nginx/ssl/{{ item.key }}_self_signed.pem;
-  ssl_certificate_key     /etc/nginx/ssl/{{ item.key }}_self_signed.key;
-  {% endif %}
+    {% if item.value.ssl.cert is defined and item.value.ssl.key is defined -%}
+      ssl_certificate         /etc/nginx/ssl/{{ item.value.ssl.cert | basename }};
+      ssl_trusted_certificate /etc/nginx/ssl/{{ item.value.ssl.cert | basename }};
+      ssl_certificate_key     /etc/nginx/ssl/{{ item.value.ssl.key | basename }};
+    {% else -%}
+      ssl_certificate         /etc/nginx/ssl/{{ item.key }}_self_signed.pem;
+      ssl_trusted_certificate /etc/nginx/ssl/{{ item.key }}_self_signed.pem;
+      ssl_certificate_key     /etc/nginx/ssl/{{ item.key }}_self_signed.key;
+    {% endif -%}
   {% endif %}
 
   include includes.d/{{ item.key }}/*.conf;
@@ -59,36 +59,39 @@ server {
 
   location ~ \.php$ {
     try_files $uri =404;
+
     {% if item.value.cache is defined and item.value.cache.enabled | default(false) -%}
-    add_header Fastcgi-Cache $upstream_cache_status;
-    set $skip_cache 0;
+      add_header Fastcgi-Cache $upstream_cache_status;
+      set $skip_cache 0;
 
-    if ($query_string != "") {
-      set $skip_cache 1;
-    }
+      if ($query_string != "") {
+        set $skip_cache 1;
+      }
 
-    # Don't cache uris containing the following segments
-    if ($request_uri ~* "{{ item.value.cache.skip_cache_uri | default(nginx_skip_cache_uri) }}") {
-      set $skip_cache 1;
-    }
+      # Don't cache uris containing the following segments
+      if ($request_uri ~* "{{ item.value.cache.skip_cache_uri | default(nginx_skip_cache_uri) }}") {
+        set $skip_cache 1;
+      }
 
-    # Don't use the cache if cookies includes the following
-    if ($http_cookie ~* "{{ item.value.cache.skip_cache_cookie | default(nginx_skip_cache_cookie) }}") {
-      set $skip_cache 1;
-    }
+      # Don't use the cache if cookies includes the following
+      if ($http_cookie ~* "{{ item.value.cache.skip_cache_cookie | default(nginx_skip_cache_cookie) }}") {
+        set $skip_cache 1;
+      }
 
-    fastcgi_cache wordpress;
-    fastcgi_cache_valid {{ item.value.cache.duration | default(nginx_cache_duration) }};
-    fastcgi_cache_bypass $skip_cache;
-    fastcgi_no_cache $skip_cache;
+      fastcgi_cache wordpress;
+      fastcgi_cache_valid {{ item.value.cache.duration | default(nginx_cache_duration) }};
+      fastcgi_cache_bypass $skip_cache;
+      fastcgi_no_cache $skip_cache;
     {% endif -%}
+
     include fastcgi_params;
     fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
     fastcgi_param DOCUMENT_ROOT $realpath_root;
+
     {% if hhvm -%}
-    fastcgi_pass unix:/var/run/hhvm/hhvm.sock;
+      fastcgi_pass unix:/var/run/hhvm/hhvm.sock;
     {% else -%}
-    fastcgi_pass unix:/var/run/php5-fpm-wordpress.sock;
+      fastcgi_pass unix:/var/run/php5-fpm-wordpress.sock;
     {% endif -%}
   }
 }
@@ -108,7 +111,8 @@ server {
   {% else -%}
     listen 80;
   {% endif -%}
-    server_name www.{{ host }};
-    return 301 $scheme://{{ host }}$request_uri;
+
+  server_name www.{{ host }};
+  return 301 $scheme://{{ host }}$request_uri;
 }
 {% endfor %}

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -30,6 +30,7 @@ server {
     {%- endif %}
   {%- endif %}
 
+  add_header Fastcgi-Cache $upstream_cache_status;
   add_header X-Content-Type-Options "nosniff" always;
   add_header X-Frame-Options SAMEORIGIN;
   add_header X-Xss-Protection "1; mode=block" always;
@@ -61,7 +62,6 @@ server {
     try_files $uri =404;
 
     {% if item.value.cache is defined and item.value.cache.enabled | default(false) -%}
-      add_header Fastcgi-Cache $upstream_cache_status;
       set $skip_cache 0;
 
       if ($query_string != "") {


### PR DESCRIPTION
Nginx only inherits headers if there are NO `add_header` declarations in
the child (`location` block in this case).

From Nginx docs:

> There could be several add_header directives. These directives are
inherited from the previous level if and only if there are no add_header
directives defined on the current level.

See https://github.com/roots/trellis/commit/7f0402140bc172214eb8aadb0456f676af3778ba for the fix only.