### PR TITLE
Use all public keys available by the SSH agent

### DIFF
--- a/group_vars/all/users.yml
+++ b/group_vars/all/users.yml
@@ -6,13 +6,13 @@ users:
     groups:
       - "{{ web_group }}"
     keys:
-      - "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
+      - "{{ lookup('pipe', 'ssh-add -L') }}"
       # - https://github.com/username.keys
   - name: "{{ admin_user }}"
     groups:
       - sudo
     keys:
-      - "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
+      - "{{ lookup('pipe', 'ssh-add -L') }}"
       # - https://github.com/username.keys
 
 web_user: web


### PR DESCRIPTION
From the developer's perspective, this won't change anything if you're on Linux/OS X (feel free to test to confirm). On Windows, this will be able to retrieve forwarded SSH keys from outside the VM.