### PR TITLE
Add extra "global" before/after deploy hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Add global `deploy_before` and `deploy_after` hooks ([#427](https://github.com/roots/trellis/pull/427))
 * Fix HSTS headers ([#424](https://github.com/roots/trellis/pull/424))
 * Notify Windows users about SSH forwarding ([#423](https://github.com/roots/trellis/pull/423))
 * Use append_privs for WP DB privileges ([#422](https://github.com/roots/trellis/pull/422))

--- a/roles/deploy/hooks/example.yml
+++ b/roles/deploy/hooks/example.yml
@@ -6,6 +6,7 @@
 #   2. set one of the below hook variables to "{{ playbook_dir }}/path/to/tasks-file.yml" in `deploy.yml`
 #
 #  Available hooks:
+#    - deploy_before
 #    - deploy_initialize_before
 #    - deploy_initialize_after
 #    - deploy_update_before
@@ -18,3 +19,4 @@
 #    - deploy_share_after
 #    - deploy_finalize_before
 #    - deploy_finalize_after
+#    - deploy_after

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -1,7 +1,9 @@
 ---
+- include: "{{ deploy_before | default('../hooks/example.yml') }}"
 - include: initialize.yml
 - include: update.yml
 - include: prepare.yml
 - include: build.yml
 - include: share.yml
 - include: finalize.yml
+- include: "{{ deploy_after | default('../hooks/example.yml') }}"


### PR DESCRIPTION
While these hooks could be a little redundant, they are useful for
"global" actions like notifying Slack of deploys.

Previously if you wanted to have a notification when the deploy
finished, you would have had to copy the `deploy_finalize_after` file
and maintain it which is not ideal.