### PR TITLE
Switch to mainline Nginx, replaces SPDY with HTTP2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### HEAD
+* Switch to mainline Nginx, replaces SPDY with HTTP2 ([#389](https://github.com/roots/trellis/issues/389))
+
 ### 0.9.3: November 29th, 2015
 * Nginx role improvements: use more h5bp configs ([#428](https://github.com/roots/trellis/pull/428))
 * Add global `deploy_before` and `deploy_after` hooks ([#427](https://github.com/roots/trellis/pull/427))

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Trellis will configure a server with the following and more:
 * PHP 5.6 (or [HHVM](http://hhvm.com/))
 * [MariaDB](https://mariadb.org/) as a drop-in MySQL replacement (but better)
 * SSL support (A+ on https://www.ssllabs.com/ssltest/)
+* HTTP/2 support (requires SSL)
 * Composer
 * WP-CLI
 * sSMTP (mail delivery)
@@ -144,7 +145,7 @@ sSMTP handles outgoing mail. For the `development` environment, emails are sent 
 
 ## SSL
 
-Full SSL support is available for your WordPress sites. Trellis will also *auto-generate* self-signed certificates for development purposes. Our HTTPS implementation has all the best practices for performance and security. (Note: default configuration is HTTPS **only**.) See the [SSL docs](https://roots.io/trellis/docs/ssl/).
+Full SSL support is available for your WordPress sites. Trellis will also *auto-generate* self-signed certificates for development purposes. Our HTTPS implementation utilizes HTTP/2 and has all the best practices for performance and security. (Note: default configuration is HTTPS **only**.) See the [SSL docs](https://roots.io/trellis/docs/ssl/).
 
 ## Caching
 

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add Nginx PPA
   apt_repository:
-    repo: "ppa:nginx/stable"
+    repo: "ppa:nginx/development"
     update_cache: yes
 
 - name: Install Nginx

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -2,7 +2,7 @@
 
 server {
   {% if item.value.ssl is defined and item.value.ssl.enabled | default(false) %}
-  listen 443 ssl spdy;
+  listen 443 ssl http2;
   {% else -%}
   listen 80;
   {% endif %}
@@ -33,7 +33,6 @@ server {
   add_header Fastcgi-Cache $upstream_cache_status;
 
   {% if item.value.ssl is defined and item.value.ssl.enabled | default(false) %}
-    include h5bp/directive-only/spdy.conf;
     include h5bp/directive-only/ssl.conf;
     include h5bp/directive-only/ssl-stapling.conf;
 
@@ -108,7 +107,7 @@ server {
 {% for host in item.value.site_hosts if strip_www %}
 server {
   {% if item.value.ssl is defined and item.value.ssl.enabled | default(false) -%}
-    listen 443 ssl spdy;
+    listen 443 ssl http2;
   {% else -%}
     listen 80;
   {% endif -%}


### PR DESCRIPTION
> ## Which Version Should I Use?
> 
> We recommend that in general you deploy the NGINX mainline branch at all times.

https://www.nginx.com/blog/nginx-1-6-1-7-released/

Because we're using mainline PPA, this also means that SPDY support is being dropped in favor of HTTP2.

#### HTTP2 vs SPDY browser compatibility
* http://caniuse.com/#feat=http2
* http://caniuse.com/#feat=spdy