### PR TITLE
Add variable for list of whitelisted IPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### 0.9.3: November 29th, 2015
+* Add variable for whitelisted IPs ([#435](https://github.com/roots/trellis/pull/435))
 * Nginx role improvements: use more h5bp configs ([#428](https://github.com/roots/trellis/pull/428))
 * Add global `deploy_before` and `deploy_after` hooks ([#427](https://github.com/roots/trellis/pull/427))
 * Fix HSTS headers ([#424](https://github.com/roots/trellis/pull/424))

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -2,3 +2,5 @@ apt_cache_valid_time: 86400
 default_timezone: Etc/UTC
 hhvm: false
 www_root: /srv/www
+ip_whitelist:
+  - "{{ lookup('pipe', 'curl -4 https://diagnostic.opendns.com/myip') }}"

--- a/group_vars/all/security.yml
+++ b/group_vars/all/security.yml
@@ -4,7 +4,7 @@ ferm_input_list:
     filename: nginx_accept
   - type: dport_accept
     dport: [ssh]
-    saddr: ["{{ lookup('pipe', 'curl -4 https://diagnostic.opendns.com/myip') }}"]
+    saddr: "{{ ip_whitelist }}"
   - type: dport_limit
     dport: [ssh]
     seconds: 300

--- a/roles/fail2ban/defaults/main.yml
+++ b/roles/fail2ban/defaults/main.yml
@@ -3,7 +3,7 @@ fail2ban_loglevel: 3
 fail2ban_logtarget: /var/log/fail2ban.log
 fail2ban_socket: /var/run/fail2ban/fail2ban.sock
 
-fail2ban_ignoreip: 127.0.0.1/8 {{ lookup('pipe', 'curl -4 https://diagnostic.opendns.com/myip') }}
+fail2ban_ignoreip: 127.0.0.1/8 {{ ip_whitelist | join(' ') }}
 fail2ban_bantime: 600
 fail2ban_maxretry: 6
 


### PR DESCRIPTION
Trellis does an IP lookup for the Ansible control machine, whitelisting it in the `ferm` and `fail2ban` roles.

This PR moves the ip lookup to a default `ip_whitelist` variable (DRY). This exposes a config for users to adjust the lookup if they have issues with network configuration (#390) or connectivity (#434). Users could also manually list IPs (vs. use lookups).

Note: To handle a temporary connectivity issue, users could define `ip_whitelist` [as quoted JSON](http://docs.ansible.com/ansible/playbooks_variables.html#passing-variables-on-the-command-line) in extra-vars on the CLI, instead of having to edit `group_vars/all/main.yml`, like this...

```
ansible-playbook server.yml -i hosts/staging -e '{"ip_whitelist":["xx.xxx.xx.xxx"]}'
```