### PR TITLE
Fix bug in Vagrantfile where VMware provider wasn't detected properly

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -109,7 +109,7 @@ Vagrant.configure('2') do |config|
 
   # VMware Workstation/Fusion settings
   ['vmware_fusion', 'vmware_workstation'].each do |provider|
-    config.vm.provider 'provider' do |vmw, override|
+    config.vm.provider provider do |vmw, override|
       # Override provider box
       override.vm.box = 'puppetlabs/ubuntu-14.04-64-nocm'
 


### PR DESCRIPTION
Having ' around the VMware config in the Vagrantfile was causing it to not get picked up as a provider. I've tested this on OS X and don't think it's OS specific.