### PR TITLE
Use https://api.ipify.org for IP lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Switch to https://api.ipify.org for IP lookup ([#444](https://github.com/roots/trellis/pull/444))
 * Replace `vagrant-hostsupdater` with `vagrant-hostmanager` ([#442](https://github.com/roots/trellis/pull/442))
 * Switch to mainline Nginx, replaces SPDY with HTTP2 ([#389](https://github.com/roots/trellis/issues/389))
 * Add `wp core update-db` to deploy finalize hook ([#411](https://github.com/roots/trellis/pull/411))

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -3,4 +3,4 @@ default_timezone: Etc/UTC
 hhvm: false
 www_root: /srv/www
 ip_whitelist:
-  - "{{ lookup('pipe', 'curl -4 https://diagnostic.opendns.com/myip') }}"
+  - "{{ lookup('pipe', 'curl -4 https://api.ipify.org') }}"


### PR DESCRIPTION
Ansible 2.0 will introduce a `ipify_facts` module. In the meantime we'll
switch to using the default service that Ansible will use.

This service should be more reliable than Open DNS' one and it will
resolves IPv6 addresses.