### PR TITLE
Fix #297 - Use `php_flag` vs `php_admin_flag`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Fixes #297 - Use `php_flag` vs `php_admin_flag` ([#447](https://github.com/roots/trellis/pull/447))
 * Fixes #316 - Set WP permalink structure during install ([#316](https://github.com/roots/trellis/pull/316))
 * Switch to https://api.ipify.org for IP lookup ([#444](https://github.com/roots/trellis/pull/444))
 * Replace `vagrant-hostsupdater` with `vagrant-hostmanager` ([#442](https://github.com/roots/trellis/pull/442))

--- a/roles/php/templates/php-fpm.conf.j2
+++ b/roles/php/templates/php-fpm.conf.j2
@@ -13,8 +13,8 @@ pm.min_spare_servers = 1
 pm.max_spare_servers = 3
 pm.max_requests = 500
 chdir = {{ www_root }}/
-php_admin_flag[log_errors] = on
-php_admin_flag[display_errors] = {{ php_display_errors }}
+php_flag[log_errors] = on
+php_flag[display_errors] = {{ php_display_errors }}
 php_admin_value[open_basedir] = {{ www_root }}/:/tmp
 {% if memcached_sessions %}
 php_value[session.save_handler] = memcached


### PR DESCRIPTION
`php_flag` lets `ini_set` override its value whereas `php_admin_flag`
does not. This restores a bit more control to WordPress and its
debugging constants.