### PR TITLE
Fix #436 - Let WP handle 404s for PHP files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Fixes #436 - Let WP handle 404s for PHP files ([#448](https://github.com/roots/trellis/pull/448))
 * Fixes #297 - Use `php_flag` vs `php_admin_flag` ([#447](https://github.com/roots/trellis/pull/447))
 * Fixes #316 - Set WP permalink structure during install ([#316](https://github.com/roots/trellis/pull/316))
 * Switch to https://api.ipify.org for IP lookup ([#444](https://github.com/roots/trellis/pull/444))

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -60,6 +60,7 @@ server {
 
   location ~ \.php$ {
     try_files $uri =404;
+    error_page 404 /index.php;
 
     {% if item.value.cache is defined and item.value.cache.enabled | default(false) -%}
       set $skip_cache 0;


### PR DESCRIPTION
This ensures WP's 404 page is also displayed for PHP files/URLs that do not exist.