### PR TITLE
Fixes #374 - Remove composer vendor/bin from $PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Fixes #374 - Remove composer vendor/bin from $PATH ([#449](https://github.com/roots/trellis/pull/449))
 * Refactor hosts files ([#313](https://github.com/roots/trellis/pull/313))
 * Fixes #436 - Let WP handle 404s for PHP files ([#448](https://github.com/roots/trellis/pull/448))
 * Fixes #297 - Use `php_flag` vs `php_admin_flag` ([#447](https://github.com/roots/trellis/pull/447))

--- a/roles/composer/tasks/main.yml
+++ b/roles/composer/tasks/main.yml
@@ -10,13 +10,6 @@
   register: composer_update_result
   changed_when: composer_update_result | success and 'already using composer version' not in composer_update_result.stderr
 
-- name: add Composer vendor binary path
-  lineinfile:
-    dest: /etc/environment
-    regexp: ^PATH="(((?!:./vendor/bin).)*)"
-    line: PATH="\1:./vendor/bin"
-    backrefs: yes
-
 - name: Composer config github-oauth
   command: composer config -g github-oauth.github.com {{ composer_github_oauth_token }}
   when: composer_github_oauth_token is defined


### PR DESCRIPTION
Removing since it exposes a privilege escalation vulnerability.