### PR TITLE
Fix #353 - Allow insecure curl reqs for cron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Fixes #353 - Allow insecure curl reqs for cron ([#450](https://github.com/roots/trellis/pull/450))
 * Fixes #374 - Remove composer vendor/bin from $PATH ([#449](https://github.com/roots/trellis/pull/449))
 * Refactor hosts files ([#313](https://github.com/roots/trellis/pull/313))
 * Fixes #436 - Let WP handle 404s for PHP files ([#448](https://github.com/roots/trellis/pull/448))

--- a/roles/wordpress-setup/tasks/main.yml
+++ b/roles/wordpress-setup/tasks/main.yml
@@ -26,7 +26,7 @@
     name: "{{ item.key }} WordPress cron"
     minute: "*/15"
     user: "{{ web_user }}"
-    job: "curl -s {{ item.value.env.wp_siteurl }}/wp-cron.php > /dev/null 2>&1"
+    job: "curl -k -s {{ item.value.env.wp_siteurl }}/wp-cron.php > /dev/null 2>&1"
     cron_file: "wordpress-{{ item.key | replace('.', '_') }}"
   with_dict: wordpress_sites
   when: item.value.env.disable_wp_cron | default(false) and not item.value.multisite.enabled | default(false)


### PR DESCRIPTION
In development with an https site, the curl command for WP cron will
fail due to the "insecure" self-signed certificate.

Adding the `-k` flag means curl will ignore this and continue on.

Note: there's no real downside/risk to using this option on staging/production as well. These are your own sites and internal requests. This curl command should not be the thing that tells you if your SSL setup isn't correct.