### PR TITLE
Replace strip_www with optional redirect to www/non-www

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Replace strip_www with optional redirect to www/non-www ([#452](https://github.com/roots/trellis/pull/452))
 * Accommodate file encryption via ansible vault ([#317](https://github.com/roots/trellis/pull/317))
 * Fixes #353 - Allow insecure curl reqs for cron ([#450](https://github.com/roots/trellis/pull/450))
 * Fixes #374 - Remove composer vendor/bin from $PATH ([#449](https://github.com/roots/trellis/pull/449))

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ For example: configure the sites on your Vagrant development VM by editing `grou
 `wordpress_sites` is the top-level dictionary used to define the WordPress sites, databases, Nginx vhosts, etc that will be created. Each site's variables are nested under a site "key" (e.g., `example.com`). This key is just a descriptive name and serves as the default value for some variables. See our [example project](https://github.com/roots/roots-example-project.com/blob/master/ansible/group_vars/development/wordpress_sites.yml) for a complete working example.
 
 * `site_hosts` - array of hosts that Nginx will listen on (required, include main domain at least)
+* `www_redirect` - whether to redirect `www/non-www` counterparts of `site_hosts` (default: `true`)
 * `local_path` - path targeting Bedrock-based site directory (required for development)
 * `repo` - URL of the Git repo of your Bedrock project (required, used when deploying)
 * `branch` - the branch name, tag name, or commit SHA1 you want to deploy (default: `master`)

--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -2,7 +2,6 @@
 nginx_path: /etc/nginx
 nginx_logs_root: /var/log/nginx
 nginx_user: www-data
-strip_www: true
 nginx_fastcgi_buffers: 8 8k
 
 # HSTS defaults

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -105,7 +105,7 @@ server {
 }
 {% endif %}
 
-{% for host in item.value.site_hosts if strip_www %}
+{% for host in item.value.site_hosts if item.value.www_redirect | default(true) %}
 server {
   {% if item.value.ssl is defined and item.value.ssl.enabled | default(false) -%}
     listen 443 ssl http2;
@@ -113,7 +113,7 @@ server {
     listen 80;
   {% endif -%}
 
-  server_name www.{{ host }};
+  server_name {{ host | match('^www\\.(.*)') | ternary(host | regex_replace('^www\\.(.*)', '\\1'), 'www.' + host ) }};
   return 301 $scheme://{{ host }}$request_uri;
 }
 {% endfor %}


### PR DESCRIPTION
Discussion in #312.

This `www_redirect` is on a per-site basis whereas `strip_www` was for all sites or none.

This includes extra logic to avoid redirecting subdomains, based on comments in #312. However, I wonder if some people would actually want `www.sub.example.com` to redirect to `sub.example.com`. If we can allow the redirect for subdomains, we could drop this portion of the conditional logic:
```
... and host.split('.') | difference('www') | count <= 2
```
(refs: [split](http://stackoverflow.com/a/30517735), [difference](http://docs.ansible.com/ansible/playbooks_filters.html#set-theory-filters), [count/length](http://jinja.pocoo.org/docs/dev/templates/#length))