### PR TITLE
Add tags to select includes and tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Add tags to select includes and tasks ([#453](https://github.com/roots/trellis/pull/453))
 * Improve Git deploy implementation via `git archive` ([#451](https://github.com/roots/trellis/pull/451))
 * Replace strip_www with optional redirect to www/non-www ([#452](https://github.com/roots/trellis/pull/452))
 * Accommodate file encryption via ansible vault ([#317](https://github.com/roots/trellis/pull/317))

--- a/roles/deploy/tasks/build.yml
+++ b/roles/deploy/tasks/build.yml
@@ -1,5 +1,5 @@
 ---
-- include: "{{ deploy_build_before | default('../hooks/example.yml') }}"
+- include: "{{ deploy_build_before | default('../hooks/example.yml') }} tags=deploy-build-before"
 
 - name: Copy project templates
   template:
@@ -19,4 +19,4 @@
   with_items: project_folder_paths.results
   when: item.stat.exists
 
-- include: "{{ deploy_build_after | default('../hooks/example.yml') }}"
+- include: "{{ deploy_build_after | default('../hooks/example.yml') }} tags=deploy-build-after"

--- a/roles/deploy/tasks/finalize.yml
+++ b/roles/deploy/tasks/finalize.yml
@@ -1,5 +1,5 @@
 ---
-- include: "{{ deploy_finalize_before | default('../hooks/example.yml') }}"
+- include: "{{ deploy_finalize_before | default('../hooks/example.yml') }} tags=deploy-finalize-before"
 
 - name: Finalize the deploy
   deploy_helper:
@@ -7,7 +7,7 @@
     release: "{{ deploy_helper.new_release }}"
     state: finalize
 
-- include: "{{ deploy_finalize_after | default('../hooks/example.yml') }}"
+- include: "{{ deploy_finalize_after | default('../hooks/example.yml') }} tags=deploy-finalize-after"
 
 - debug:
     msg: "{{ project_version }}@{{ git_commit.after | truncate(7, True, '') }} deployed as release {{ deploy_helper.new_release }}"

--- a/roles/deploy/tasks/initialize.yml
+++ b/roles/deploy/tasks/initialize.yml
@@ -1,9 +1,9 @@
 ---
-- include: "{{ deploy_initialize_before | default('../hooks/example.yml') }}"
+- include: "{{ deploy_initialize_before | default('../hooks/example.yml') }} tags=deploy-initialize-before"
 
 - name: Initialize
   deploy_helper:
     path: "{{ project_root }}"
     state: present
 
-- include: "{{ deploy_initialize_after | default('../hooks/example.yml') }}"
+- include: "{{ deploy_initialize_after | default('../hooks/example.yml') }} tags=deploy-initialize-after"

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
-- include: "{{ deploy_before | default('../hooks/example.yml') }}"
+- include: "{{ deploy_before | default('../hooks/example.yml') }} tags=deploy-before"
 - include: initialize.yml
 - include: update.yml
 - include: prepare.yml
 - include: build.yml
 - include: share.yml
 - include: finalize.yml
-- include: "{{ deploy_after | default('../hooks/example.yml') }}"
+- include: "{{ deploy_after | default('../hooks/example.yml') }} tags=deploy-after"

--- a/roles/deploy/tasks/prepare.yml
+++ b/roles/deploy/tasks/prepare.yml
@@ -1,5 +1,5 @@
 ---
-- include: "{{ deploy_prepare_before | default('../hooks/example.yml') }}"
+- include: "{{ deploy_prepare_before | default('../hooks/example.yml') }} tags=deploy-prepare-before"
 
 - name: write unfinished file
   file:
@@ -34,4 +34,4 @@
     chdir: "{{ project_source_path }}"
   when: project_subtree_path != 'False'
 
-- include: "{{ deploy_prepare_after | default('../hooks/example.yml') }}"
+- include: "{{ deploy_prepare_after | default('../hooks/example.yml') }} tags=deploy-prepare-after"

--- a/roles/deploy/tasks/share.yml
+++ b/roles/deploy/tasks/share.yml
@@ -1,5 +1,5 @@
 ---
-- include: "{{ deploy_share_before | default('../hooks/example.yml') }}"
+- include: "{{ deploy_share_before | default('../hooks/example.yml') }} tags=deploy-share-before"
 
 - name: Ensure shared sources are present
   file:
@@ -21,4 +21,4 @@
     state: link
   with_items: project_shared_children
 
-- include: "{{ deploy_share_after | default('../hooks/example.yml') }}"
+- include: "{{ deploy_share_after | default('../hooks/example.yml') }} tags=deploy-share-after"

--- a/roles/deploy/tasks/update.yml
+++ b/roles/deploy/tasks/update.yml
@@ -1,5 +1,5 @@
 ---
-- include: "{{ deploy_update_before | default('../hooks/example.yml') }}"
+- include: "{{ deploy_update_before | default('../hooks/example.yml') }} tags=deploy-update-before"
 
 - name: Check whether project source path is a git repo
   stat:
@@ -28,4 +28,4 @@
     accept_hostkey: yes
   register: git_commit
 
-- include: "{{ deploy_update_after | default('../hooks/example.yml') }}"
+- include: "{{ deploy_update_after | default('../hooks/example.yml') }} tags=deploy-update-after"

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -21,6 +21,7 @@
     chdir: "{{ nginx_path }}/ssl"
     creates: "{{ nginx_path }}/ssl/dhparams.pem"
   notify: reload nginx
+  tags: [diffie-hellman]
 
 - name: Grab h5bp/server-configs-nginx
   git:

--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- include: directories.yml
+- include: directories.yml tags=wordpress-install-directories
 
 - name: Create .env file
   template: src="env.j2"

--- a/roles/wordpress-setup/tasks/main.yml
+++ b/roles/wordpress-setup/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
-- include: database.yml
-- include: self-signed-certificate.yml
-- include: nginx.yml
+- include: database.yml tags=wordpress-setup-database
+- include: self-signed-certificate.yml tags=wordpress-setup-self-signed-certificate
+- include: nginx.yml tags=wordpress-setup-nginx
 
 - name: Create web root
   file:

--- a/server.yml
+++ b/server.yml
@@ -17,7 +17,7 @@
     - { role: swapfile, swapfile_size: 1GB, tags: [swapfile] }
     - { role: fail2ban, tags: [fail2ban] }
     - { role: ferm, tags: [ferm] }
-    - { role: ntp }
+    - { role: ntp, tags: [ntp] }
     - { role: users, tags: [users] }
     - { role: sshd, tags: [sshd] }
     - { role: mariadb, tags: [mariadb], when: not mysql_remote_database }

--- a/variable-check.yml
+++ b/variable-check.yml
@@ -11,3 +11,4 @@
           Environment missing. Use `-e` to define `env`:
           ansible-playbook {{ playbook }} -e {{ extra_vars_command }}
       when: env is not defined
+      tags: [variable-check]


### PR DESCRIPTION
**Tagged tasks.** Enjoy speedier provisioning of a test server by skipping the Diffie-Hellman task:
```
ansible-playbook server.yml -e env=staging --skip-tags diffie-hellman
```
I didn't notice any other single tasks it would be helpful to tag.

**Tagged core includes.** Be a little more targeted in updating your nginx includes:
```
ansible-playbook server.yml -e env=staging --tags wordpress-setup-nginx
```
You could have used `--tags wordpress-setup`. This is just a little more targeted.

**Tagged hooked includes.** Skip the experimental include you hooked into `deploy_update_before`:
```
ansible-playbook deploy.yml -e "env=staging site=example.com" --skip-tags deploy-update-before
```