### PR TITLE
Specify ansible_connection=local for 127.0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Specify `ansible_connection=local` for 127.0.0.1 ([#454](https://github.com/roots/trellis/pull/454))
 * Add tags to select includes and tasks ([#453](https://github.com/roots/trellis/pull/453))
 * Improve Git deploy implementation via `git archive` ([#451](https://github.com/roots/trellis/pull/451))
 * Replace strip_www with optional redirect to www/non-www ([#452](https://github.com/roots/trellis/pull/452))

--- a/hosts/development
+++ b/hosts/development
@@ -1,7 +1,7 @@
 # No edits are necessary
 
 [development]
-127.0.0.1
+127.0.0.1 ansible_connection=local
 
 [web]
-127.0.0.1
+127.0.0.1 ansible_connection=local

--- a/windows.sh
+++ b/windows.sh
@@ -51,5 +51,5 @@ fi
 cp -R ${ANSIBLE_PATH}/hosts ${TEMP_HOSTS} && chmod -x ${TEMP_HOSTS}/*
 echo "Running Ansible Playbooks"
 cd ${ANSIBLE_PATH}/
-ansible-playbook ${ANSIBLE_PATH}/dev.yml -i ${TEMP_HOSTS}/development --sudo --user=vagrant --connection=local
+ansible-playbook ${ANSIBLE_PATH}/dev.yml -i ${TEMP_HOSTS}/development --sudo --user=vagrant
 rm -rf ${TEMP_HOSTS}


### PR DESCRIPTION
Fixes failed deploys during [Copy project local files](https://github.com/roots/trellis/blob/97a9c05e3479af370a551682d9a689e6763b5d2f/deploy-hooks/build-before.yml#L25-L26)
```
TASK: [deploy | Copy project local files] *************************************
<127.0.0.1> ESTABLISH CONNECTION FOR USER: web
fatal: [xxx.xxx.xxx.xxx -> 127.0.0.1] => SSH Error: Permission denied (publickey,keyboard-interactive).
while connecting to 127.0.0.1:22
```

After #313, the host named `127.0.0.1` is known to an `ansible-playbook` run on staging or production because the [default inventory](https://github.com/roots/trellis/blob/97a9c05e3479af370a551682d9a689e6763b5d2f/ansible.cfg#L4) is the entire hosts dir. Consequently, during deploys, the synchronize module began attempting an SSH connection to the `127.0.0.1` as the `web_user`, and failing because this user typically does not exist on the local machine. (Discussion at [ansible/ansible#5702](https://github.com/ansible/ansible/issues/5702#issuecomment-33608936).)

A fix is to specify `ansible_connection=local` for `127.0.0.1` in the inventory. This should also obviate the need for the [`--connection=local`](https://github.com/roots/trellis/blob/97a9c05e3479af370a551682d9a689e6763b5d2f/windows.sh#L54) option in `windows.sh`.