### PR TITLE
Suppress vagrant-hostsupdater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Prevent duplicate hosts entries made by `vagrant-hostsupdater` ([#458](https://github.com/roots/trellis/pull/458))
 * Fix README's `ansible-playbook` command for server.yml ([#456](https://github.com/roots/trellis/pull/456)) 
 * Fix development hosts file ([#455](https://github.com/roots/trellis/pull/455))
 * Add tags to select includes and tasks ([#453](https://github.com/roots/trellis/pull/453))

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,7 +36,7 @@ Vagrant.configure('2') do |config|
   config.ssh.shell = %{bash -c 'BASH_ENV=/etc/profile exec bash'}
 
   # Required for NFS to work, pick any local IP
-  config.vm.network :private_network, ip: '192.168.50.5'
+  config.vm.network :private_network, ip: '192.168.50.5', hostsupdater: 'skip'
 
   hostname, *aliases = wordpress_sites.flat_map { |(_name, site)| site['site_hosts'] }
   config.vm.hostname = hostname


### PR DESCRIPTION
Since we're using `vagrant-hostmanager`, we can safely suppress `vagrant-hostsupdater` to prevent duplicate hosts entries when users have both plugins installed.

This is untested, but [it's consistent with their documentation](https://github.com/cogitatio/vagrant-hostsupdater#skipping-hostupdater).