### PR TITLE
Better deploy error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### HEAD
+* Add pre-flight checks for common deploy problems ([#459](https://github.com/roots/trellis/pull/459))
 * Prevent duplicate hosts entries made by `vagrant-hostsupdater` ([#458](https://github.com/roots/trellis/pull/458))
-* Fix README's `ansible-playbook` command for server.yml ([#456](https://github.com/roots/trellis/pull/456)) 
+* Fix README's `ansible-playbook` command for server.yml ([#456](https://github.com/roots/trellis/pull/456))
 * Fix development hosts file ([#455](https://github.com/roots/trellis/pull/455))
 * Add tags to select includes and tasks ([#453](https://github.com/roots/trellis/pull/453))
 * Improve Git deploy implementation via `git archive` ([#451](https://github.com/roots/trellis/pull/451))

--- a/deploy.yml
+++ b/deploy.yml
@@ -14,5 +14,38 @@
     project: "{{ wordpress_sites[site] }}"
     project_root: "{{ www_root }}/{{ site }}"
 
+  pre_tasks:
+    - name: Ensure site is valid
+      connection: local
+      fail:
+        msg: "Site `{{ site }}` is not valid. Available sites to deploy: {{ wordpress_sites.keys() | join(', ') }}"
+      when: wordpress_sites[site] is not defined
+
+    - name: Ensure repo is valid
+      connection: local
+      fail:
+        msg: |
+          Invalid Git repository.
+          Ensure that your site's `repo` variable is defined in `group_vars/{{ env }}/wordpress_sites.yml` and uses the SSH format (example: git@github.com/roots/bedrock.git)
+          More info:
+          > https://roots.io/trellis/docs/deploys/
+      when: project.repo is not defined or not project.repo | match("git@.*.git")
+
+    - name: Verify remote repo
+      command: git ls-remote {{ project.repo }} HEAD
+      changed_when: false
+      ignore_errors: true
+      no_log: true
+      register: repo_check
+
+    - name: Failed connection to remote repo
+      fail:
+        msg: |
+          Git repo {{ project.repo }} cannot be accessed. Please verify the repository exists and you have SSH forwarding set up correctly.
+          More info:
+          > https://roots.io/trellis/docs/deploys/#ssh-keys
+          > https://roots.io/trellis/docs/ssh-keys/#cloning-remote-repo-using-ssh-agent-forwarding
+      when: repo_check | failed
+
   roles:
     - deploy


### PR DESCRIPTION
This adds `pre_tasks` to the `deploy.yml` playbook before the actual
`deploy` role to check important (and frequent) problems:

1. `site` being deployed is valid
2. `repo` variable for a site is valid
3. the `repo` can be accessed via SSH on the remote server

The idea here is to catch these problems before they occur during the
actual deploy process and also provide helpful error messages (and link
to our docs where applicable).