### PR TITLE
Windows: Sync hosts dir with proper permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Windows: Sync `hosts` dir with proper permissions ([#460](https://github.com/roots/trellis/pull/460))
 * Fix `inventory_file` variable in connection tests ([#470](https://github.com/roots/trellis/pull/470))
 * Fix conditional logic for permalink setup task ([#467](https://github.com/roots/trellis/pull/467))
 * Fix permalink setup during WordPress Install ([#466](https://github.com/roots/trellis/pull/466))

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,6 +54,7 @@ Vagrant.configure('2') do |config|
     wordpress_sites.each_pair do |name, site|
       config.vm.synced_folder local_site_path(site), remote_site_path(name), owner: 'vagrant', group: 'www-data', mount_options: ['dmode=776', 'fmode=775']
     end
+    config.vm.synced_folder File.join(ANSIBLE_PATH, 'hosts'), File.join(ANSIBLE_PATH.sub(__dir__, '/vagrant'), 'hosts'), mount_options: ['dmode=755', 'fmode=644']
   else
     if !Vagrant.has_plugin? 'vagrant-bindfs'
       fail_with_message "vagrant-bindfs missing, please install the plugin with this command:\nvagrant plugin install vagrant-bindfs"

--- a/hosts/development
+++ b/hosts/development
@@ -1,3 +1,14 @@
+# This file is only used for Windows hosts.
+#
+# Windows
+# -------------------------------------------------------------
+# If you want to run `dev.yml` manually you can SSH into the VM
+# to the directory with the `dev.yml` playbook and run:
+
+# `ansible-playbook dev.yml`
+#
+# Non-Windows
+# -------------------------------------------------------------
 # If you want to run `dev.yml` manually via the `ansible-playbook`
 # command (vs. `vagrant up` or `vagrant provision`), you might be
 # inclined to define your development host information in this file.
@@ -14,6 +25,8 @@
 # your `Vagrantfile`. If not, you will need to adjust this path in the
 # command.
 #
+# Why run `dev.yml` manually?
+# -------------------------------------------------------------
 # One reason you may want to run `dev.yml` via the `ansible-playbook`
 # command is for the convenience of adding Ansible options via the
 # command line (e.g., `--tags`, `--skip-tags`, or `-vvvv`). In contrast,
@@ -22,7 +35,7 @@
 # into the Vagrantfile's `config.vm.provision` section.
 
 [development]
-192.168.50.5
+192.168.50.5 ansible_connection=local
 
 [web]
-192.168.50.5
+192.168.50.5 ansible_connection=local

--- a/windows.sh
+++ b/windows.sh
@@ -6,7 +6,6 @@
 # @version 1.0
 
 ANSIBLE_PATH="$(find /vagrant -name 'windows.sh' -printf '%h' -quit)"
-TEMP_HOSTS="/tmp/ansible_hosts"
 
 # Create an ssh key if not already created.
 if [ ! -f ~/.ssh/id_rsa ]; then
@@ -43,13 +42,6 @@ if [ ! -d ${ANSIBLE_PATH}/vendor ]; then
   ansible-galaxy install -r ${ANSIBLE_PATH}/requirements.yml -p ${ANSIBLE_PATH}/vendor/roles
 fi
 
-if [ -d ${TEMP_HOSTS} ]; then
-  echo "Cleaning old Ansible Hosts"
-  rm -rf ${TEMP_HOSTS}
-fi
-
-cp -R ${ANSIBLE_PATH}/hosts ${TEMP_HOSTS} && chmod -x ${TEMP_HOSTS}/*
 echo "Running Ansible Playbooks"
 cd ${ANSIBLE_PATH}/
-ansible-playbook ${ANSIBLE_PATH}/dev.yml -i ${TEMP_HOSTS}/development --sudo --user=vagrant --connection=local
-rm -rf ${TEMP_HOSTS}
+ansible-playbook dev.yml


### PR DESCRIPTION
To run Ansible commands directly, Windows users have had to adjust permissions for files in the synced `hosts` directory. This PR implements @QWp6t's approach of [syncing `hosts` with the proper permissions](https://discourse.roots.io/t/remote-server-setup-on-windows/5594/2).

I bumped the Vagrant requirement to 1.8 to take advantage of the [shell provisioner](https://docs.vagrantup.com/v2/provisioning/shell.html)'s new `env` option which enables us to pass the `ANSIBLE_PATH_ON_VM` to `windows.sh`.

Could a Windows user test and confirm that this works?  