### PR TITLE
Fix conditional logic for permalink setup task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Fix conditional logic for permalink setup task ([#467](https://github.com/roots/trellis/pull/467))
 * Fix permalink setup during WordPress Install ([#466](https://github.com/roots/trellis/pull/466))
 * Fix deploy pre-flight check for verifying repo ([#463](https://github.com/roots/trellis/pull/463))
 * Add pre-flight checks for common deploy problems ([#459](https://github.com/roots/trellis/pull/459))

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ For example: configure the sites on your Vagrant development VM by editing `grou
 * `admin_user` - WP admin user name (*development* only, required)
 * `admin_email` - WP admin email address (*development* only, required)
 * `admin_password` - WP admin user password (*development* only, required, in `vault.yml`)
+* `initial_permalink_structure` - permalink structure applied at time of WP install (*development* only, default: `/%postname%/`)
 * `multisite` - hash of multisite options. See the [Multisite docs](https://roots.io/trellis/docs/multisite/).
   * `enabled` - Multisite enabled flag (required, set to `false`)
   * `subdomains` - subdomains option

--- a/group_vars/development/wordpress_sites.yml
+++ b/group_vars/development/wordpress_sites.yml
@@ -9,7 +9,7 @@ wordpress_sites:
     admin_user: admin
     # admin_password: (defined in group_vars/development/vault.yml)
     admin_email: admin@example.dev
-    permalink_structure: "/%postname%/"
+    initial_permalink_structure: /%postname%/ # applied only at time of WP install and when `site_install: true`
     multisite:
       enabled: false
       subdomains: false

--- a/group_vars/production/wordpress_sites.yml
+++ b/group_vars/production/wordpress_sites.yml
@@ -7,7 +7,6 @@ wordpress_sites:
     repo: git@github.com:roots/bedrock.git
     branch: master
     # repo_subtree_path: site # relative path to your Bedrock/WP directory in your repo (above) if it is not the root (like the roots-example-project structure)
-    permalink_structure: "/%postname%/"
     multisite:
       enabled: false
       subdomains: false

--- a/group_vars/staging/wordpress_sites.yml
+++ b/group_vars/staging/wordpress_sites.yml
@@ -7,7 +7,6 @@ wordpress_sites:
     repo: git@github.com:roots/bedrock.git
     branch: master
     # repo_subtree_path: site # relative path to your Bedrock/WP directory in your repo (above) if it is not the root (like the roots-example-project structure)
-    permalink_structure: "/%postname%/"
     multisite:
       enabled: false
       subdomains: false

--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -38,26 +38,13 @@
   when: item.value.site_install == True and (item.value.multisite.enabled | default(False) == False)
   changed_when: "'WordPress is already installed.' not in wp_install_results.stdout"
 
-- name: Check Existing Permalink Structure
-  command: wp rewrite list --format=count
-           --allow-root
-           --url="{{ item.value.env.wp_home }}"
-  args:
-    chdir: "{{ www_root }}/{{ item.key }}/current/"
-  register: wp_permalink_check_results
-  with_dict: wordpress_sites
-  when: item.value.site_install and not item.value.multisite.enabled | default(false)
-  changed_when: False
-
 - name: Setup Permalink Structure
-  command: wp rewrite structure {{ item.value.permalink_structure | default("/%postname%/") }}
+  command: wp rewrite structure {{ item.value.initial_permalink_structure | default("/%postname%/") }}
            --allow-root
-           --url="{{ item.value.env.wp_home }}"
   args:
     chdir: "{{ www_root }}/{{ item.key }}/current/"
-  register: wp_permalink_results
   with_dict: wordpress_sites
-  when: "wp_permalink_check_results.changed and 'No rewrite rules' in wp_permalink_check_results.results.0.stderr"
+  when: wp_install_results | changed
 
 - name: Install WP Multisite
   command: wp core multisite-install
@@ -75,7 +62,6 @@
   with_dict: wordpress_sites
   when: item.value.site_install == True and (item.value.multisite.enabled | default(False) == True)
   changed_when: "'The network already exists.' not in wp_install_results.stdout"
-
 
 - name: Restart HHVM
   service: name=hhvm state=restarted


### PR DESCRIPTION
The "Setup Permalink Structure" task currently runs `when: "wp_permalink_check_results.changed`. However, `wp_permalink_check_results` will never be `changed` because of the `changed_when` rule:
```yaml
# Check Existing Permalink Structure
register: wp_permalink_check_results
changed_when: False
```
This PR updates the conditional logic.

Same as original: Sets permalink structure only if `site_install: true` and non-multisite.

Different from original: Runs only in conjunction with new install. Will never run when WP is already installed (even if permalink structure is not set). The rationale is that if WP is already installed, we don't want to potentially override configs users may have set via other means (WP GUI, via wp-cli). As an example, if a user has flushed their rewrite rules, we don't want to reset the rules. 