### PR TITLE
Fix inventory_file variable in connection tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Fix `inventory_file` variable in connection tests ([#470](https://github.com/roots/trellis/pull/470))
 * Fix conditional logic for permalink setup task ([#467](https://github.com/roots/trellis/pull/467))
 * Fix permalink setup during WordPress Install ([#466](https://github.com/roots/trellis/pull/466))
 * Fix deploy pre-flight check for verifying repo ([#463](https://github.com/roots/trellis/pull/463))

--- a/roles/remote-user/tasks/main.yml
+++ b/roles/remote-user/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Determine whether to connect as root or admin_user
-  local_action: command ansible {{ inventory_hostname }} -m ping -i {{ inventory_file }} -u root
+  local_action: command ansible {{ inventory_hostname }} -m ping{{ (inventory_file == None) | ternary('', ' -i ' + inventory_file | string) }} -u root
   failed_when: false
   changed_when: false
   register: root_status

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -45,7 +45,7 @@
     - keys
 
 - name: Check whether Ansible can connect as admin_user
-  local_action: command ansible {{ inventory_hostname }} -m ping -i {{ inventory_file }} -u {{ admin_user }}
+  local_action: command ansible {{ inventory_hostname }} -m ping{{ (inventory_file == None) | ternary('', ' -i ' + inventory_file | string) }} -u {{ admin_user }}
   failed_when: false
   changed_when: false
   become: no


### PR DESCRIPTION
The default `inventory = hosts` (in `ansible.cfg`) is a directory.

Whereas in Ansible <= 1.9.4 the [`inventory_file` variable](https://github.com/ansible/ansible/blob/7de237c5a1742660bc240c15e97a1f5b0d1611a8/lib/ansible/vars/__init__.py#L382) returned `hosts`, in Ansible 2.0+ it returns `null`. The definition comes from `self._inventory.src()`, whose [`is_file()`](https://github.com/ansible/ansible/blob/7de237c5a1742660bc240c15e97a1f5b0d1611a8/lib/ansible/inventory/__init__.py#L661) check apparently returned true [in 1.9.4](https://github.com/ansible/ansible/blob/5af1cda7c93375bc84296c641ace49bca8657e6c/lib/ansible/inventory/__init__.py#L557-L558) but no longer does [in 2.0+](https://github.com/ansible/ansible/blob/7de237c5a1742660bc240c15e97a1f5b0d1611a8/lib/ansible/inventory/__init__.py#L631-L632).

I initially thought we could just omit the `-i inventory` options from the affected commands and let the commands just use the default inventory specified in `ansible.cfg`. However, if a user specifies an actual _file_ via the cli, the `inventory_file` variable will be non-null and our ssh connection tests should use that inventory. So, this PR adjusts commands to use the `inventory_file` variable only when it is not null.

The `inventory_file` needs the `string` filter so that when it is null the playbook will not fail with `"ERROR! an unexpected type error occurred. Error was cannot concatenate 'str' and 'NoneType' objects"`. 