### PR TITLE
Fix Nginx includes for Ansible 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Fix Nginx includes for Ansible 2.0 ([#473](https://github.com/roots/trellis/pull/473))
 * Use `ondrej/php` PPA since `ondrej/php-7.0` is deprecated ([#479](https://github.com/roots/trellis/pull/479))
 * Fix Ansible 2.x deploys and require version 2.x ([#478](https://github.com/roots/trellis/pull/478))
 * Update to PHP 7.0 and remove HHVM ([#432](https://github.com/roots/trellis/pull/432))

--- a/roles/wordpress-setup/tasks/nginx.yml
+++ b/roles/wordpress-setup/tasks/nginx.yml
@@ -19,7 +19,7 @@
 - name: Template files out to includes.d
   template: src="includes.d/{{ item }}"
             dest="/etc/nginx/includes.d/{{ item[:-3] }}"
-  with_lines: "cd ../templates/includes.d && find {{ wordpress_sites.keys() | join(' ') }} -type f -name \\*.conf.j2 2>/dev/null || :"
+  with_lines: "cd {{ role_path }}/templates/includes.d && find {{ wordpress_sites.keys() | join(' ') }} -type f -name \\*.conf.j2 2>/dev/null || :"
   register: nginx_includes_managed
   notify: reload nginx
 
@@ -31,7 +31,11 @@
 - name: Remove unmanaged files from includes.d
   file: path="{{ item }}"
         state=absent
-  with_items: "{{ nginx_includes_existing.stdout_lines | difference(nginx_includes_managed.results | default([]) | map(attribute='item') | map('regex_replace', '(.*)\\.j2', '/etc/nginx/includes.d/\\\\1') | list) }}"
+  with_items: "{{ nginx_includes_existing.stdout_lines |
+                  difference(nginx_includes_managed.results | default([]) | map(attribute='item') |
+                    map('regex_replace', '(.*)\\.j2', '/etc/nginx/includes.d/\\1') | list
+                  )
+               }}"
   notify: reload nginx
 
 - name: Create WordPress configuration for Nginx


### PR DESCRIPTION
1) In Ansible 1.9 the template task's `cwd` was the directory of the task file. In Ansible 2.0, it is the directory of the role. This PR enables the template task to accommodate either by using the `role_path` variable—an absolute path—instead of a relative path.

2) Ansible 2.0 changes [backreference escaping](https://github.com/ansible/ansible/commit/7f5080f64ab4a82648cb746990587c1aaff3f61d) for the [`regex_replace` filter](http://docs.ansible.com/ansible/playbooks_filters.html#other-useful-filters), needing only [2 backslashes instead of 4](https://docs.ansible.com/ansible/porting_guide_2.0.html#playbook), and in fact has a problem with 4. (Discussion at [ansible/ansible#13426](https://github.com/ansible/ansible/issues/13426#issuecomment-162249992).) ~~This PR uses a `ternary` filter to give two vs. four backslashes depending on Ansible version.~~