### PR TITLE
Add option to add known_hosts on remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Add option to add `known_hosts` on remote ([#475](https://github.com/roots/trellis/pull/475))
 * Update to PHP 7.0 and remove HHVM ([#432](https://github.com/roots/trellis/pull/432))
 * Windows: Sync `hosts` dir with proper permissions ([#460](https://github.com/roots/trellis/pull/460))
 * Fix `inventory_file` variable in connection tests ([#470](https://github.com/roots/trellis/pull/470))

--- a/group_vars/all/known_hosts.yml
+++ b/group_vars/all/known_hosts.yml
@@ -1,0 +1,10 @@
+# Documentation: https://roots.io/trellis/docs/security/#known-hosts
+
+# Host keys to add to known_hosts, e.g.,
+#   - git host for Bedrock-based project (`repo` variable in `wordpress_sites`)
+#   - git hosts in Bedrock project's composer.json
+known_hosts:
+  - name: github.com
+    key: github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
+  - name: bitbucket.org
+    key: bitbucket.org ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==

--- a/group_vars/all/security.yml
+++ b/group_vars/all/security.yml
@@ -1,3 +1,14 @@
+# Documentation: https://roots.io/trellis/docs/security/
+
+# If sshd_permit_root_login: false, admin_user must be in 'users' (`group_vars/all/users.yml`) with sudo group
+# and in 'sudoer_passwords' (`group_vars/<environment>/main.yml`)
+sshd_permit_root_login: true
+sshd_password_authentication: false
+
+# Whether `git clone` and `composer install` should accept host keys into known_hosts
+# If `no`, manually add host keys to `group_vars/all/known_hosts.yml`
+accept_hostkeys: yes
+
 ferm_input_list:
   - type: dport_accept
     dport: [http, https]
@@ -9,9 +20,3 @@ ferm_input_list:
     dport: [ssh]
     seconds: 300
     hits: 20
-
-# Documentation: https://roots.io/trellis/docs/security/
-# If sshd_permit_root_login: false, admin_user must be in 'users' (`group_vars/all/users.yml`) with sudo group
-# and in 'sudoer_passwords' (`group_vars/<environment>/main.yml`)
-sshd_permit_root_login: true
-sshd_password_authentication: false

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -36,3 +36,12 @@
 - name: Set timezone
   command: timedatectl set-timezone {{ default_timezone }}
   when: current_timezone.stdout != default_timezone
+
+- name: Add known_hosts
+  known_hosts:
+    name: "{{ item.name }}"
+    key: "{{ item.key | default(omit) }}"
+    path: "{{ item.path | default('/home/' + web_user + '/.ssh/known_hosts') }}"
+    state: "{{ item.state | default('present') }}"
+  with_items: known_hosts | default([])
+  tags: known-hosts

--- a/roles/deploy/hooks/build-after.yml
+++ b/roles/deploy/hooks/build-after.yml
@@ -9,6 +9,20 @@
     msg: "Unable to find a `composer.json` file in the root of '{{ deploy_helper.new_release_path }}'. Make sure your repo has a `composer.json` file in its root or edit `repo_subtree_path` for '{{ site }}' in `wordpress_sites.yml` so it points to the directory with a `composer.json` file."
   when: not composer_json.stat.exists
 
+- name: Retrieve ssh hosts from composer.json
+  shell: egrep 'url.*@.*:.*' {{ deploy_helper.new_release_path }}/composer.json |
+         sed 's/.*@\(.*\):.*/\1/' | sort | uniq
+  register: composer_ssh_hosts
+  when: accept_hostkeys
+  changed_when: false
+
+- name: Add known_hosts from composer.json
+  known_hosts:
+    name: "{{ item }}"
+    key: "{{ lookup('pipe', 'ssh-keyscan -t rsa ' + item) }}"
+    path: "/home/{{ web_user }}/.ssh/known_hosts"
+  with_items: composer_ssh_hosts.stdout_lines | default([])
+
 - name: Install Composer dependencies
   command: composer install --no-ansi --no-dev --no-interaction --no-progress --optimize-autoloader --no-scripts
   args:

--- a/roles/deploy/tasks/update.yml
+++ b/roles/deploy/tasks/update.yml
@@ -26,7 +26,7 @@
     repo: "{{ project_git_repo }}"
     dest: "{{ project_source_path }}"
     version: "{{ project_version }}"
-    accept_hostkey: yes
+    accept_hostkey: "{{ accept_hostkeys }}"
   ignore_errors: true
   no_log: true
   register: git_clone

--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -15,13 +15,29 @@
   register: env
   changed_when: env.stdout == "{{ item.key }}.env"
 
+- name: Retrieve ssh hosts from composer.json
+  shell: egrep 'url.*@.*:.*' {{ www_root }}/{{ item.key }}/current/composer.json |
+         sed 's/.*@\(.*\):.*/\1/' | sort | uniq
+  with_dict: wordpress_sites
+  register: composer_ssh_hosts
+  when: accept_hostkeys
+  changed_when: false
+
+- name: Add known_hosts from composer.json
+  known_hosts:
+    name: "{{ item }}"
+    key: "{{ lookup('pipe', 'ssh-keyscan -t rsa ' + item) }}"
+    path: "/home/{{ web_user }}/.ssh/known_hosts"
+  with_items: accept_hostkeys | ternary(composer_ssh_hosts.results | map(attribute='stdout_lines') | list, [])
+
 - name: Install Dependencies with Composer
   command: composer install
   args:
     chdir: "{{ www_root }}/{{ item.key }}/current/"
   register: composer_results
   with_dict: wordpress_sites
-  changed_when: "'Nothing to install or update' not in composer_results.stderr"
+  become: no
+  changed_when: "'Nothing to install or update' not in composer_results.stderr | default('')"
 
 - name: Install WP
   command: wp core install


### PR DESCRIPTION
Trellis automatically adds the key for the host contacted during `git clone` ([`accept_hostkey: yes`](https://github.com/roots/trellis/blob/11516d12e42355d0304eb4fb8c15be7ca8fcf6d4/roles/deploy/tasks/update.yml#L29)) but doesn't add keys for hosts contacted during [`composer install`](https://github.com/roots/trellis/blob/11516d12e42355d0304eb4fb8c15be7ca8fcf6d4/roles/deploy/hooks/build-after.yml#L13), so Ansible could hang/fail while waiting on this hidden message ([example](https://discourse.roots.io/t/provision-fails-on-install-dependencies-with-composer-task/5741/3)):

```
The authenticity of host ... can't be established.
RSA key fingerprint is [xyz]
Are you sure you want to continue connecting (yes/no)?
``` 

This PR extracts ssh hosts from composer.json and adds their host keys to `known_hosts`.

The `ssh-keyscan`—run by the git module and by tasks in this PR—is vulnerable to a man-in-the-middle attack. To reduce this vulnerability, the security docs will encourage users to set `accept_hostkeys: no` (a config added by this PR). Users can manually list trusted host keys in the new `group_vars/all/known_hosts.yml`.

Docs in roots/docs#15 

The ternary in the `with_items` is needed because ansible 1.9.4 doesn't have `stdout_lines` defined for vars registered in skipped tasks. Ansible will fail with error `with_items expects a list or a set`. I wasn't able to avoid the error by adding ` | default([])` at the end nor by adding `when: false`. Only the ternary seemed to work.