### PR TITLE
updates ppa:ondrej/php-7.0 to ppa:ondrej/php

### DIFF
--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add PHP 7.0 PPA
   apt_repository:
-    repo: "ppa:ondrej/php-7.0"
+    repo: "ppa:ondrej/php"
     update_cache: yes
 
 - name: Install PHP 7.0


### PR DESCRIPTION
Ondřej Surý's PPA now reads: "(deprecated use pap:ondrej/php)" in the description, and I can see that he modified the php7.0 packages a couple of hours ago. Apt had trouble resolving them for me when I provisioned a machine this morning but didn't have the issue when I tried again a little later. Regardless, we ought to update a deprecated PPA, no?