### PR TITLE
Add reverse_www filter to fix www_redirect

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.py]
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vault_pass
 .vagrant
 vendor/roles
+*.py[co]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Add `reverse_www` filter to fix `www_redirect` ([#486](https://github.com/roots/trellis/pull/486))
 * Add IP address variable, move some variables to top of Vagrantfile ([#494](https://github.com/roots/trellis/pull/494))
 * Keep Composer updated ([#493](https://github.com/roots/trellis/pull/493))
 * Use prestissimo Composer plugin ([#492](https://github.com/roots/trellis/pull/492))

--- a/filter_plugins/trellis_filters.py
+++ b/filter_plugins/trellis_filters.py
@@ -1,0 +1,38 @@
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import types
+
+from ansible import errors
+from ansible.compat.six import string_types
+
+def reverse_www(value):
+    ''' Add or remove www subdomain '''
+
+    # Check if value is a list and parse each item
+    if isinstance(value, (list, tuple, types.GeneratorType)):
+        values = []
+        for item in value:
+            values.append(reverse_www(item))
+        return values
+
+    # Add or remove www
+    elif isinstance(value, string_types):
+        if value.startswith('www.'):
+            return value[4:]
+        else:
+            return 'www.{0}'.format(value)
+
+    # Handle invalid input type
+    else:
+        raise errors.AnsibleFilterError('The reverse_www filter expects a string or list of strings, got ' + repr(value))
+
+
+class FilterModule(object):
+    ''' Trellis jinja2 filters '''
+
+    def filters(self):
+        return {
+            'reverse_www': reverse_www,
+        }

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -95,7 +95,7 @@ server {
 {% if item.value.ssl is defined and item.value.ssl.enabled | default(False) %}
 server {
   listen 80;
-  server_name {{ item.value.site_hosts | join(' ') }};
+  server_name {{ item.value.site_hosts | join(' ') }} {{ item.value.site_hosts | reverse_www | join(' ') }};
   return 301 https://$host$request_uri;
 }
 {% endif %}
@@ -108,7 +108,7 @@ server {
     listen 80;
   {% endif -%}
 
-  server_name {{ host | match('^www\\.(.*)') | ternary(host | regex_replace('^www\\.(.*)', '\\1'), 'www.' + host ) }};
+  server_name {{ host | reverse_www }};
   return 301 $scheme://{{ host }}$request_uri;
 }
 {% endfor %}


### PR DESCRIPTION
@QWp6t pointed out that **when SSL is enabled**, `wordpress-site.conf.j2` will fail to forward http://www.example.com => https://example.com. The current template produces the conf below. 

```
server {
  listen 80;
  server_name example.com;
  return 301 https://$host$request_uri;
}

server {
  listen 443 ssl http2;
  server_name www.example.com;
  return 301 $scheme://example.com$request_uri;
}
```
- The first server block doesn't match http://www.example.com because it doesn't include a match for www. 
- The second server block doesn't match http://www.example.com because it listens only on 443.

This PR enables the first server block to also match www, taking the first step of forwarding http://www.example.com => https://www.example.com. Then the second server block will pick it up and strip the www.

I created and implemented a custom `reverse_www` filter to make the templating simpler.