### PR TITLE
Fixes #410 - Default to 1 CPU in Vagrant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### HEAD
+* Fixes #410 - Default to 1 CPU in Vagrant ([#487](https://github.com/roots/trellis/pull/487))
+
 ### 0.9.5: February 10th, 2016
 * Fix Nginx includes for Ansible 2.0 ([#473](https://github.com/roots/trellis/pull/473))
 * Use `ondrej/php` PPA since `ondrej/php-7.0` is deprecated ([#479](https://github.com/roots/trellis/pull/479))

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -85,57 +85,36 @@ Vagrant.configure('2') do |config|
     end
   end
 
-  # Give VM access to all cpu cores on the host
-  cpus = case RbConfig::CONFIG['host_os']
-    when ENV['NUMBER_OF_PROCESSORS'] then ENV['NUMBER_OF_PROCESSORS'].to_i
-    when /darwin/ then `sysctl -n hw.ncpu`.to_i
-    when /linux/ then `nproc`.to_i
-    else 2
-  end
-
-  # Give VM more memory
-  memory = 1024
+  cpus = 1
+  memory = 1024 # in MB
 
   # Virtualbox settings
   config.vm.provider 'virtualbox' do |vb|
-    # Customize  VM settings
-    vb.customize ['modifyvm', :id, '--memory', memory]
+    vb.name = config.vm.hostname
     vb.customize ['modifyvm', :id, '--cpus', cpus]
+    vb.customize ['modifyvm', :id, '--memory', memory]
 
     # Fix for slow external network connections
     vb.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
     vb.customize ['modifyvm', :id, '--natdnsproxy1', 'on']
-
-    # Set VM name
-    vb.name = config.vm.hostname
   end
 
   # VMware Workstation/Fusion settings
   ['vmware_fusion', 'vmware_workstation'].each do |provider|
     config.vm.provider provider do |vmw, override|
-      # Override provider box
       override.vm.box = 'puppetlabs/ubuntu-14.04-64-nocm'
-
-      # Customize  VM settings
-      vmw.vmx['memsize'] = memory
-      vmw.vmx['numvcpus'] = cpus
-
-      # Set VM name
       vmw.name = config.vm.hostname
+      vmw.vmx['numvcpus'] = cpus
+      vmw.vmx['memsize'] = memory
     end
   end
 
   # Parallels settings
   config.vm.provider 'parallels' do |prl, override|
-    # Override provider box
     override.vm.box = 'parallels/ubuntu-14.04'
-
-    # Customize  VM settings
-    prl.memory = memory
-    prl.cpus = cpus
-
-    # Set VM name
     prl.name = config.vm.hostname
+    prl.cpus = cpus
+    prl.memory = memory
   end
 
 end


### PR DESCRIPTION
While it seems logical to allow Vagrant to use more than 1 CPU if the
host machine has them, it seems to cause performance issues.