### PR TITLE
Suppress curl output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Fix bad `curl` output ([#490](https://github.com/roots/trellis/pull/490))
 * Fixes #410 - Default to 1 CPU in Vagrant ([#487](https://github.com/roots/trellis/pull/487))
 
 ### 0.9.5: February 10th, 2016

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -2,4 +2,4 @@ apt_cache_valid_time: 86400
 default_timezone: Etc/UTC
 www_root: /srv/www
 ip_whitelist:
-  - "{{ lookup('pipe', 'curl -4 https://api.ipify.org') }}"
+  - "{{ lookup('pipe', 'curl -4 -s https://api.ipify.org') }}"


### PR DESCRIPTION
This was causing output from `curl` to be output throughout the playbook
run. It would look like this:

```
% Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    14  100    14    0     0     34      0 --:--:-- --:--:-- --:--:--    34
```