### PR TITLE
Update to latest ansible-role-mailhog version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Update to latest ansible-role-mailhog version ([#497](https://github.com/roots/trellis/pull/497))
 * Add `reverse_www` filter to fix `www_redirect` ([#486](https://github.com/roots/trellis/pull/486))
 * Add IP address variable, move some variables to top of Vagrantfile ([#494](https://github.com/roots/trellis/pull/494))
 * Keep Composer updated ([#493](https://github.com/roots/trellis/pull/493))

--- a/requirements.yml
+++ b/requirements.yml
@@ -16,4 +16,4 @@
 
 - name: mailhog
   src: geerlingguy.mailhog
-  version: 1.0.3
+  version: 1.0.5


### PR DESCRIPTION
older version was causing issues. see https://discourse.roots.io/t/mailhog-fails-to-start-daemonize-not-found/5970