### PR TITLE
fixes add-apt-repository installation for VMWare's box

### DIFF
--- a/windows.sh
+++ b/windows.sh
@@ -23,6 +23,7 @@ printf "\033[0m\n\n"
 
 # Check that add-apt-repository is installed for non-standard Vagrant boxes
 if [ ! -f /usr/bin/add-apt-repository ]; then
+  sudo apt-get -y update
   echo "Adding add-apt-repository..."
   sudo apt-get -y install software-properties-common
 fi


### PR DESCRIPTION
apt-get needs updating prior to trying to install add-apt-repository otherwise it fails finding it, which in turn causes ansible not be installed to the correct version, which results in the error 'provided hosts list is empty'

See https://discourse.roots.io/t/error-provided-hosts-list-is-empty/6127/4