### PR TITLE
Add ansible playbook for windows-specific vagrant development

### DIFF
--- a/roles/windows-dev/tasks/main.yml
+++ b/roles/windows-dev/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Install "gulp" node.js package
+  npm:
+    name: gulp
+    global: yes
+
+- name: Install "bower" node.js package
+  npm:
+    name: bower
+    global: yes
+

--- a/windows-dev.yml
+++ b/windows-dev.yml
@@ -1,0 +1,9 @@
+---
+- name: "WordPress Server: Install Windows specific packages for vagrant development"
+  hosts: web:&development
+  become: yes
+  remote_user: vagrant
+
+  roles:
+    - { role: nodesource.node, tags: [windows, node] }
+    - { role: windows-dev, tags: [windows] }

--- a/windows.sh
+++ b/windows.sh
@@ -46,3 +46,13 @@ fi
 echo "Running Ansible Playbooks"
 cd ${ANSIBLE_PATH}/
 ansible-playbook dev.yml
+
+# Install Node
+if [ ! -d ${ANSIBLE_PATH}/vendor ]; then
+  echo "Running Ansible Galaxy install for nodesource.node"
+  ansible-galaxy install nodesource.node -p ${ANSIBLE_PATH}/vendor/roles
+fi
+
+echo "Running Windows Specific Ansible Playbooks"
+cd ${ANSIBLE_PATH}/
+ansible-playbook windows-dev.yml


### PR DESCRIPTION
When doing development with Sage on Windows using Trellis, we need at a bare minimum the following installed on the development Vagrant instance:

Node
Gulp (global)
Bower (global)

I've created a simple playbook and modifications to windows.sh to automatically pull these in on vagrant up.