### PR TITLE
Let’s Encrypt integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Let's Encrypt integration ([#518](https://github.com/roots/trellis/pull/518))
 * Improve Git repo format validation [#516](https://github.com/roots/trellis/pull/516)
 * Fix #505 - Git ignore \*.retry file
 * Fix Ansible deprecations for bare variables ([#510](https://github.com/roots/trellis/pull/510))

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Trellis will configure a server with the following and more:
 * PHP 7.0
 * MariaDB (a drop-in MySQL replacement)
 * SSL support (scores an A+ on the [Qualys SSL Labs Test](https://www.ssllabs.com/ssltest/))
+* Let's Encrypt integration for free SSL certificates
 * HTTP/2 support (requires SSL)
 * Composer
 * WP-CLI

--- a/group_vars/development/wordpress_sites.yml
+++ b/group_vars/development/wordpress_sites.yml
@@ -15,6 +15,7 @@ wordpress_sites:
       subdomains: false
     ssl:
       enabled: false
+      provider: self-signed
     cache:
       enabled: false
       duration: 30s

--- a/group_vars/production/wordpress_sites.yml
+++ b/group_vars/production/wordpress_sites.yml
@@ -12,8 +12,7 @@ wordpress_sites:
       subdomains: false
     ssl:
       enabled: false
-      # cert: ~/ssl/example.com.crt
-      # key: ~/ssl/example.com.key
+      provider: letsencrypt
     cache:
       enabled: false
       duration: 30s

--- a/group_vars/staging/wordpress_sites.yml
+++ b/group_vars/staging/wordpress_sites.yml
@@ -12,8 +12,7 @@ wordpress_sites:
       subdomains: false
     ssl:
       enabled: false
-      # cert: ~/ssl/example.com.crt
-      # key: ~/ssl/example.com.key
+      provider: letsencrypt
     cache:
       enabled: false
       duration: 30s

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -1,9 +1,15 @@
 ---
 - name: restart memcached
-  service: name=memcached state=restarted
-
-- name: reload nginx
-  service: name=nginx state=reloaded
+  service:
+    name: memcached
+    state: restarted
 
 - name: reload php-fpm
-  service: name=php7.0-fpm state=reloaded
+  service:
+    name: php7.0-fpm
+    state: reloaded
+
+- name: reload nginx
+  service:
+    name: nginx
+    state: reloaded

--- a/roles/letsencrypt/README.md
+++ b/roles/letsencrypt/README.md
@@ -1,0 +1,9 @@
+# Let’s encrypt/acme-tiny role for Ansible
+
+## License
+
+MIT
+
+## Author Information
+
+This role was created by Andreas Wolf. Visit my [website](http://a-w.io) and [Github profile](https://github.com/andreaswolf/) or follow me on [Twitter](https://twitter.com/andreaswo).

--- a/roles/letsencrypt/defaults/main.yml
+++ b/roles/letsencrypt/defaults/main.yml
@@ -1,0 +1,43 @@
+sites_using_letsencrypt: "[{% for name, site in wordpress_sites.iteritems() if site.ssl.enabled and site.ssl.provider | default('manual') == 'letsencrypt' %}'{{ name }}',{% endfor %}]"
+letsencrypt_enabled: "{{ sites_using_letsencrypt | count > 0 }}"
+site_uses_letsencrypt: "{{ item.value.ssl is defined and item.value.ssl.enabled | default(false) and item.value.ssl.provider | default('manual') == 'letsencrypt' }}"
+
+acme_tiny_repo: 'https://github.com/diafygi/acme-tiny.git'
+acme_tiny_commit: '69a457269a6392ac31b629b4e103e8ea7dd282c9'
+
+acme_tiny_software_directory: /usr/local/letsencrypt
+acme_tiny_data_directory: /var/lib/letsencrypt
+acme_tiny_challenges_directory: "{{ www_root }}/letsencrypt"
+
+# Path to the local file containing the account key to copy to the server.
+# Secure this file using Git-crypt for example.
+# Leave this blank to generate a new account key that will need to be registered manually with Letsencrypt.org
+#letsencrypt_account_key_source_file: /my/account.key
+
+# Content of the account key to copy to the server.
+# Secure this key using Ansible Vault for example.
+# Leave this blank to generate a new account key that will need to be registered manually with Letsencrypt.org
+#letsencrypt_account_key_source_content: |
+#  -----BEGIN RSA PRIVATE KEY-----
+#  MIIJKAJBBBKCaGEA63J7t9dqyua5+Q+P6M3iHtLEKpF/AZcZNBHr1F2Oo8+Hfyvl
+#  KWXliiWjUORxDxI1c56Rw2VCIExnFjWJAdSLv6/XaQWo2T7U28bkKbAlCF9=
+#  -----END RSA PRIVATE KEY-----
+
+letsencrypt_ca: 'https://acme-v01.api.letsencrypt.org'
+
+letsencrypt_account_key: '{{ acme_tiny_data_directory }}/account.key'
+
+letsencrypt_intermediate_cert_path: /etc/ssl/certs/lets-encrypt-x1-cross-signed.pem
+letsencrypt_intermediate_cert_url: 'https://letsencrypt.org/certs/lets-encrypt-x1-cross-signed.pem'
+letsencrypt_intermediate_cert_sha256sum: '6c0a324bb803e9d66b8986ea2085bb9d6bdfe33f5c04a03a3f7024f4aa8e7a2d'
+
+letsencrypt_keys_dir: "{{ nginx_ssl_path }}/letsencrypt"
+letsencrypt_certs_dir: "{{ nginx_ssl_path }}/letsencrypt"
+
+# the minimum age (in days) after which a certificate will be renewed
+letsencrypt_min_renewal_age: 60
+
+# the days of a month the cronjob should be run. Make sure to run it rather often, three times per month is a pretty
+# good value. It does not harm to run it often, as it will only regenerate certificates that have passed a certain age
+# (60 days by default).
+letsencrypt_cronjob_daysofmonth: 1,11,21

--- a/roles/letsencrypt/tasks/certificates.yml
+++ b/roles/letsencrypt/tasks/certificates.yml
@@ -1,0 +1,64 @@
+- name: Generate private keys
+  shell: openssl genrsa 4096 > {{ letsencrypt_keys_dir }}/{{ item.key }}.key
+  args:
+    creates: "{{ letsencrypt_keys_dir }}/{{ item.key }}.key"
+  when: site_uses_letsencrypt
+  with_dict: "{{ wordpress_sites }}"
+  tags: [letsencrypt_keys]
+
+- name: Ensure correct permissions on private keys
+  file:
+    path: "{{ letsencrypt_keys_dir }}/{{ item.key }}.key"
+    mode: 0600
+  when: site_uses_letsencrypt
+  with_dict: "{{ wordpress_sites }}"
+  tags: [letsencrypt_keys]
+
+- name: Generate CSRs for single domain keys
+  shell: openssl req -new -sha256 -key "{{ letsencrypt_keys_dir }}/{{ item.key }}.key" -subj "/CN={{ item.value.site_hosts[0] }}" > {{ acme_tiny_data_directory }}/csrs/{{ item.key }}.csr
+  args:
+    creates: "{{ acme_tiny_data_directory }}/csrs/{{ item.key }}.csr"
+  when: site_uses_letsencrypt and item.value.site_hosts | length == 1 and not item.value.www_redirect | default(true)
+  with_dict: "{{ wordpress_sites }}"
+  tags: [letsencrypt_keys]
+
+- name: Generate CSRs for multi domain keys or single domain with "reverse www" domains
+  shell: "openssl req -new -sha256 -key '{{ letsencrypt_keys_dir }}/{{ item.key }}.key' -subj '/' -reqexts SAN -config <(cat /etc/ssl/openssl.cnf <(printf '[SAN]\nsubjectAltName=DNS:{{ item.value.site_hosts | join(',DNS:') }},DNS:{{ item.value.site_hosts | reverse_www | join(',DNS:') }}')) > {{ acme_tiny_data_directory }}/csrs/{{ item.key }}.csr"
+  args:
+    executable: /bin/bash
+    creates: "{{ acme_tiny_data_directory }}/csrs/{{ item.key }}.csr"
+  when: site_uses_letsencrypt and item.value.www_redirect | default(true)
+  with_dict: "{{ wordpress_sites }}"
+  tags: [letsencrypt_keys]
+
+- name: Generate CSRs for multi domain keys without "reverse www" domains
+  shell: "openssl req -new -sha256 -key '{{ letsencrypt_keys_dir }}/{{ item.key }}.key' -subj '/' -reqexts SAN -config <(cat /etc/ssl/openssl.cnf <(printf '[SAN]\nsubjectAltName=DNS:{{ item.value.site_hosts | join(',DNS:') }}')) > {{ acme_tiny_data_directory }}/csrs/{{ item.key }}.csr"
+  args:
+    executable: /bin/bash
+    creates: "{{ acme_tiny_data_directory }}/csrs/{{ item.key }}.csr"
+  when: site_uses_letsencrypt and item.value.site_hosts | length > 1 and not item.value.www_redirect | default(true)
+  with_dict: "{{ wordpress_sites }}"
+  tags: [letsencrypt_keys]
+
+- name: Generate the initial certificate
+  command: ./renew-certs.py
+  args:
+    chdir: "{{ acme_tiny_data_directory }}"
+  register: generate_initial_cert
+  changed_when: generate_initial_cert.stdout is defined and 'Created' in generate_initial_cert.stdout
+
+- name: Disable Nginx site
+  file:
+    path: "{{ nginx_path }}/sites-enabled/letsencrypt-{{ item.key }}.conf"
+    state: absent
+  with_dict: "{{ wordpress_sites }}"
+
+- name: Test nginx conf
+  command: nginx -t
+  changed_when: false
+
+- name: Trigger nginx reload
+  service:
+    name: nginx
+    state: reloaded
+  changed_when: false

--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -1,0 +1,14 @@
+- include: setup.yml
+- include: nginx.yml
+- include: certificates.yml
+
+- name: Install cronjob for key generation
+  cron:
+    cron_file: letsencrypt-certificate-renewal
+    name: letsencrypt certificate renewal
+    user: root
+    job: cd {{ acme_tiny_data_directory }} && ./renew-certs.py
+    day: "{{ letsencrypt_cronjob_daysofmonth }}"
+    hour: 4
+    minute: 30
+    state: present

--- a/roles/letsencrypt/tasks/nginx.yml
+++ b/roles/letsencrypt/tasks/nginx.yml
@@ -1,0 +1,55 @@
+- name: Check for existing certificates
+  stat:
+    path: "{{ letsencrypt_certs_dir }}/{{ item.key }}.cert"
+  register: letsencrypt_existing_certs
+  when: site_uses_letsencrypt
+  with_dict: "{{ wordpress_sites }}"
+
+- name: Create Nginx sites for challenges
+  template:
+    src: nginx-challenge-site.conf.j2
+    dest: "{{ nginx_path }}/sites-available/letsencrypt-{{ item.item.key }}.conf"
+  when: not item | skipped and not item.stat.exists
+  with_items: "{{ letsencrypt_existing_certs.results }}"
+
+- name: Enable Nginx site
+  file:
+    src: "{{ nginx_path }}/sites-available/letsencrypt-{{ item.item.key }}.conf"
+    dest: "{{ nginx_path }}/sites-enabled/letsencrypt-{{ item.item.key }}.conf"
+    state: link
+  when: not item | skipped and not item.stat.exists
+  with_items: "{{ letsencrypt_existing_certs.results }}"
+
+- name: Trigger nginx reload
+  service:
+    name: nginx
+    state: reloaded
+  changed_when: false
+
+- name: Create test Acme Challenge file
+  shell: touch {{ acme_tiny_challenges_directory }}/ping.txt
+  args:
+    creates: "{{ acme_tiny_challenges_directory }}/ping.txt"
+    warn: false
+
+- name: Test Acme Challenges
+  command: curl -s -o /dev/null -w "%{http_code}" http://{{ item.1 }}/.well-known/acme-challenge/ping.txt
+  args:
+    warn: false
+  register: letsencrypt_test_challenges
+  when: item.0.ssl is defined and item.0.ssl.enabled | default(false) and item.0.ssl.provider | default('manual')  == 'letsencrypt'
+  changed_when: false
+  with_subelements:
+    - "{{ wordpress_sites }}"
+    - site_hosts
+
+- name: Notify of challenge failures
+  fail:
+    msg: >
+      Could not access the challenge file for the domain: {{ item.item.1 }}.
+      Let's Encrypt requires every domain/host be publicly accessible.
+      Make sure that a valid DNS record exists for {{ item.item.1 }} and that it points to this server's IP.
+      If you don't want this domain in your SSL certificate, then remove it from `site_hosts`.
+      See https://roots.io/trellis/docs/ssl for more details.
+  when: not item | skipped and item.stdout | int != 200
+  with_items: letsencrypt_test_challenges.results

--- a/roles/letsencrypt/tasks/setup.yml
+++ b/roles/letsencrypt/tasks/setup.yml
@@ -1,0 +1,56 @@
+- name: Create directories and set permissions
+  file:
+    mode: "{{ item.mode | default(omit) }}"
+    path: "{{ item.path }}"
+    state: directory
+  with_items:
+    - path: "{{ acme_tiny_data_directory }}"
+      mode: '0700'
+    - path: "{{ acme_tiny_data_directory }}/csrs"
+    - path: "{{ acme_tiny_software_directory }}"
+    - path: "{{ acme_tiny_challenges_directory }}"
+    - path: "{{ letsencrypt_certs_dir }}"
+      mode: '0700'
+
+- name: Clone acme-tiny repository
+  git:
+    dest: "{{ acme_tiny_software_directory }}"
+    repo: "{{ acme_tiny_repo }}"
+    version: "{{ acme_tiny_commit }}"
+    accept_hostkey: yes
+
+- name: Copy Lets Encrypt account key source file
+  copy:
+    src: "{{ letsencrypt_account_key_source_file }}"
+    dest: "{{ letsencrypt_account_key }}"
+  when: letsencrypt_account_key_source_file is defined
+
+- name: Copy Lets Encrypt account key source contents
+  copy:
+    content: "{{ letsencrypt_account_key_source_content | trim }}"
+    dest: "{{ letsencrypt_account_key }}"
+  when: letsencrypt_account_key_source_content is defined
+
+- name: Generate a new account key
+  shell: openssl genrsa 4096 > {{ letsencrypt_account_key }}
+  args:
+    creates: "{{ letsencrypt_account_key }}"
+  register: generate_account_key
+  when: letsencrypt_account_key_source_content is not defined and letsencrypt_account_key_source_file is not defined
+
+- name: Generate certificate renewal script
+  template:
+    src: renew-certs.py
+    dest: "{{ acme_tiny_data_directory }}/renew-certs.py"
+    mode: 0700
+
+- name: Download intermediate certificate
+  get_url:
+    url: "{{ letsencrypt_intermediate_cert_url }}"
+    dest: "{{ letsencrypt_intermediate_cert_path }}"
+    sha256sum: "{{ letsencrypt_intermediate_cert_sha256sum }}"
+
+- name: Create Nginx conf for challenges location
+  template:
+    src: acme-challenge-location.conf.j2
+    dest: "{{ nginx_path }}/acme-challenge-location.conf"

--- a/roles/letsencrypt/templates/acme-challenge-location.conf.j2
+++ b/roles/letsencrypt/templates/acme-challenge-location.conf.j2
@@ -1,0 +1,4 @@
+location ^~ /.well-known/acme-challenge/ {
+  alias {{ acme_tiny_challenges_directory }}/;
+  try_files $uri =404;
+}

--- a/roles/letsencrypt/templates/nginx-challenge-site.conf.j2
+++ b/roles/letsencrypt/templates/nginx-challenge-site.conf.j2
@@ -1,0 +1,11 @@
+server {
+  listen 80;
+
+  {% if item.item.value.www_redirect | default(true) -%}
+  server_name {{ item.item.value.site_hosts | join(' ') }} {{ item.item.value.site_hosts | reverse_www | join(' ') }};
+  {% else -%}
+  server_name {{ item.item.value.site_hosts | join(' ') }};
+  {% endif %}
+
+  include acme-challenge-location.conf;
+}

--- a/roles/letsencrypt/templates/renew-certs.py
+++ b/roles/letsencrypt/templates/renew-certs.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import time
+
+from subprocess import CalledProcessError, check_output, STDOUT
+
+certs_dir = '{{ letsencrypt_certs_dir }}'
+failed = False
+sites = {{ wordpress_sites }}
+sites = (k for k, v in sites.items() if 'ssl' in v and v['ssl'].get('enabled', False) and v['ssl'].get('provider', 'manual') == 'letsencrypt')
+
+for site in sites:
+    cert_path = os.path.join(certs_dir, site + '.cert')
+    bundled_cert_path = os.path.join(certs_dir, site + '-bundled.cert')
+
+    if os.access(cert_path, os.F_OK):
+        stat = os.stat(cert_path)
+        print 'Certificate file ' + cert_path + ' already exists'
+
+        if time.time() - stat.st_mtime < {{ letsencrypt_min_renewal_age }} * 86400:
+            print '  The certificate is younger than {{ letsencrypt_min_renewal_age }} days. Not creating a new certificate.\n'
+            continue
+
+    print 'Generating certificate for ' + site
+
+    cmd = ('/usr/bin/env python {{ acme_tiny_software_directory }}/acme_tiny.py '
+           '--ca {{ letsencrypt_ca }} '
+           '--account-key {{ letsencrypt_account_key }} '
+           '--csr {{ acme_tiny_data_directory }}/csrs/{0}.csr '
+           '--acme-dir {{ acme_tiny_challenges_directory }}'
+           ).format(site)
+
+    try:
+        cert = check_output(cmd, stderr=STDOUT, shell=True)
+    except CalledProcessError as e:
+        failed = True
+        print 'Error while generating certificate for ' + site
+        print e.output
+    else:
+        with open(cert_path, 'w') as cert_file:
+            cert_file.write(cert)
+
+        with open('{{ letsencrypt_intermediate_cert_path }}') as intermediate_cert_file:
+            intermediate_cert = intermediate_cert_file.read()
+
+        with open(bundled_cert_path, 'w') as bundled_file:
+            bundled_file.write(''.join([cert, intermediate_cert]))
+
+        print 'Created certificate for ' + site
+
+if failed:
+    sys.exit(1)

--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -3,6 +3,7 @@ nginx_path: /etc/nginx
 nginx_logs_root: /var/log/nginx
 nginx_user: www-data
 nginx_fastcgi_buffers: 8 8k
+nginx_ssl_path: "{{ nginx_path }}/ssl"
 
 # HSTS defaults
 nginx_hsts_max_age: 31536000

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -12,7 +12,8 @@
 
 - name: Create SSL directory
   file:
-    dest: "{{ nginx_path }}/ssl"
+    mode: 0700
+    path: "{{ nginx_path }}/ssl"
     state: directory
 
 - name: Generate strong unique Diffie-Hellman group.

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -47,7 +47,7 @@
     user: "{{ item.0.name }}"
     key: "{{ item.1 }}"
   with_subelements:
-    - users | default([])
+    - "{{ users | default([]) }}"
     - keys
 
 - name: Check whether Ansible can connect as admin_user

--- a/roles/wordpress-setup/tasks/main.yml
+++ b/roles/wordpress-setup/tasks/main.yml
@@ -3,8 +3,6 @@
   tags: wordpress-setup-database
 - include: self-signed-certificate.yml
   tags: wordpress-setup-self-signed-certificate
-- include: nginx.yml
-  tags: wordpress-setup-nginx
 
 - name: Create web root
   file:
@@ -23,6 +21,9 @@
     mode: 0755
     state: directory
   with_dict: "{{ wordpress_sites }}"
+
+- include: nginx.yml
+  tags: wordpress-setup-nginx
 
 - name: Setup WP system cron
   cron:

--- a/roles/wordpress-setup/tasks/nginx.yml
+++ b/roles/wordpress-setup/tasks/nginx.yml
@@ -2,22 +2,22 @@
 - name: Copy SSL cert
   copy:
     src: "{{ item.value.ssl.cert }}"
-    dest: /etc/nginx/ssl/{{ item.value.ssl.cert | basename }}
+    dest: "{{ nginx_ssl_path }}/{{ item.value.ssl.cert | basename }}"
     mode: 0640
   with_dict: "{{ wordpress_sites }}"
-  when: item.value.ssl.enabled and item.value.ssl.cert is defined | default(False)
+  when: item.value.ssl.enabled and item.value.ssl.cert is defined
 
 - name: Copy SSL key
   copy:
     src: "{{ item.value.ssl.key }}"
-    dest: /etc/nginx/ssl/{{ item.value.ssl.key | basename }}
+    dest: "{{ nginx_ssl_path }}/{{ item.value.ssl.key | basename }}"
     mode: 0600
   with_dict: "{{ wordpress_sites }}"
-  when: item.value.ssl.enabled and item.value.ssl.key is defined | default(False)
+  when: item.value.ssl.enabled and item.value.ssl.key is defined
 
 - name: Create includes.d directories
   file:
-    path: "/etc/nginx/includes.d/{{ item }}"
+    path: "{{ nginx_path }}/includes.d/{{ item }}"
     state: directory
     mode: 0755
   with_items: "{{ wordpress_sites.keys() }}"
@@ -26,7 +26,7 @@
 - name: Template files out to includes.d
   template:
     src: "includes.d/{{ item }}"
-    dest: "/etc/nginx/includes.d/{{ item[:-3] }}"
+    dest: "{{ nginx_path }}/includes.d/{{ item[:-3] }}"
   with_lines: "cd {{ role_path }}/templates/includes.d && find {{ wordpress_sites.keys() | join(' ') }} -type f -name \\*.conf.j2 2>/dev/null || :"
   register: nginx_includes_managed
   notify: reload nginx
@@ -50,16 +50,25 @@
 - name: Create WordPress configuration for Nginx
   template:
     src: "wordpress-site.conf.j2"
-    dest: "/etc/nginx/sites-available/{{ item.key }}.conf"
+    dest: "{{ nginx_path }}/sites-available/{{ item.key }}.conf"
   with_dict: "{{ wordpress_sites }}"
   notify: reload nginx
 
 - name: Enable WordPress site
   file:
-    src: "/etc/nginx/sites-available/{{ item.key }}.conf"
-    dest: "/etc/nginx/sites-enabled/{{ item.key }}.conf"
+    src: "{{ nginx_path }}/sites-available/{{ item.key }}.conf"
+    dest: "{{ nginx_path }}/sites-enabled/{{ item.key }}.conf"
     owner: root
     group: root
     state: link
   with_dict: "{{ wordpress_sites }}"
-  notify: reload nginx
+
+- name: test nginx conf
+  command: nginx -t
+  changed_when: false
+
+- name: trigger nginx reload
+  service:
+    name: nginx
+    state: reloaded
+  changed_when: false

--- a/roles/wordpress-setup/tasks/self-signed-certificate.yml
+++ b/roles/wordpress-setup/tasks/self-signed-certificate.yml
@@ -1,28 +1,13 @@
 ---
-- name: Get existing self-signed certificates
-  shell: find . -name "*_self_signed.pem"
-  args:
-    chdir: /etc/nginx/ssl/
-  register: self_signed_certs
-  changed_when: false
-
-- name: Get self-signed certificates domains
-  shell: openssl x509 -noout -subject -in {{ item | quote }} | sed -n "/^subject/s/^.*CN=//p"
-  register: self_signed_domains
-  args:
-    chdir: /etc/nginx/ssl/
-  with_items: "{{ self_signed_certs.stdout_lines }}"
-  changed_when: false
-
 - name: Generate self-signed certificates
   shell: >
     openssl req -subj "/CN={{ item.value.site_hosts | first }}" -new
     -newkey rsa:2048 -days 3650 -nodes -x509 -sha256
-    -keyout {{ item.key }}_self_signed.key -out {{ item.key }}_self_signed.pem
+    -keyout {{ item.key }}.key -out {{ item.key }}.cert
   args:
-    chdir: /etc/nginx/ssl/
+    chdir: "{{ nginx_path }}/ssl"
+    creates: "{{ item.key }}.*"
   with_dict: "{{ wordpress_sites }}"
-  when: >
-    item.value.ssl.enabled and item.value.site_hosts | first
-    not in self_signed_domains.results | default([]) | map(attribute='stdout') | list
-  notify: reload nginx
+  when: item.value.ssl.enabled and item.value.ssl.provider | default('manual') == 'self-signed'
+  notify:
+    - reload nginx

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 
 server {
-  {% if item.value.ssl is defined and item.value.ssl.enabled | default(false) %}
+  {% if item.value.ssl is defined and item.value.ssl.enabled | default(false) -%}
   listen 443 ssl http2;
   {% else -%}
   listen 80;
@@ -32,7 +32,7 @@ server {
 
   add_header Fastcgi-Cache $upstream_cache_status;
 
-  {% if item.value.ssl is defined and item.value.ssl.enabled | default(false) %}
+  {% if item.value.ssl is defined and item.value.ssl.enabled | default(false) -%}
     include h5bp/directive-only/ssl.conf;
     include h5bp/directive-only/ssl-stapling.conf;
 
@@ -44,15 +44,17 @@ server {
     {% set hsts_preload = item.value.ssl.hsts_preload | default(nginx_hsts_preload) | ternary('preload', None) %}
     add_header Strict-Transport-Security "max-age={{ [hsts_max_age, hsts_include_subdomains, hsts_preload] | reject('none') | join('; ') }}";
 
-    {% if item.value.ssl.cert is defined and item.value.ssl.key is defined -%}
-      ssl_certificate         /etc/nginx/ssl/{{ item.value.ssl.cert | basename }};
-      ssl_trusted_certificate /etc/nginx/ssl/{{ item.value.ssl.cert | basename }};
-      ssl_certificate_key     /etc/nginx/ssl/{{ item.value.ssl.key | basename }};
-    {% else -%}
-      ssl_certificate         /etc/nginx/ssl/{{ item.key }}_self_signed.pem;
-      ssl_trusted_certificate /etc/nginx/ssl/{{ item.key }}_self_signed.pem;
-      ssl_certificate_key     /etc/nginx/ssl/{{ item.key }}_self_signed.key;
-    {% endif -%}
+    {% if item.value.ssl.provider | default('manual') == 'manual' and item.value.ssl.cert is defined and item.value.ssl.key is defined -%}
+      ssl_certificate         {{ nginx_path }}/ssl/{{ item.value.ssl.cert | basename }};
+      ssl_certificate_key     {{ nginx_path }}/ssl/{{ item.value.ssl.key | basename }};
+    {%- elif item.value.ssl.provider | default('manual') == 'letsencrypt' -%}
+      ssl_certificate         {{ nginx_path }}/ssl/letsencrypt/{{ item.key }}-bundled.cert;
+      ssl_certificate_key     {{ nginx_path }}/ssl/letsencrypt/{{ item.key }}.key;
+    {%- elif item.value.ssl.provider | default('manual') == 'self-signed' -%}
+      ssl_certificate         {{ nginx_path }}/ssl/{{ item.key }}.cert;
+      ssl_trusted_certificate {{ nginx_path }}/ssl/{{ item.key }}.cert;
+      ssl_certificate_key     {{ nginx_path }}/ssl/{{ item.key }}.key;
+    {%- endif -%}
   {% endif %}
 
   include includes.d/{{ item.key }}/*.conf;
@@ -95,8 +97,22 @@ server {
 {% if item.value.ssl is defined and item.value.ssl.enabled | default(False) %}
 server {
   listen 80;
+
+  {% if item.value.www_redirect | default(true) -%}
   server_name {{ item.value.site_hosts | join(' ') }} {{ item.value.site_hosts | reverse_www | join(' ') }};
+  {% else -%}
+  server_name {{ item.value.site_hosts | join(' ') }};
+  {% endif %}
+
+  {% if item.value.ssl.provider | default('manual') == 'letsencrypt' -%}
+  include acme-challenge-location.conf;
+
+  location / {
+    return 301 https://$host$request_uri;
+  }
+  {% else %}
   return 301 https://$host$request_uri;
+  {% endif -%}
 }
 {% endif %}
 

--- a/server.yml
+++ b/server.yml
@@ -28,4 +28,5 @@
     - { role: logrotate, tags: [logrotate] }
     - { role: composer, tags: [composer] }
     - { role: wp-cli, tags: [wp-cli] }
+    - { role: letsencrypt, tags: [letsencrypt], when: letsencrypt_enabled }
     - { role: wordpress-setup, tags: [wordpress, wordpress-setup] }


### PR DESCRIPTION
Issue: https://github.com/roots/trellis/issues/328

This PR adds Let's Encrypt integration. It will automatically create a valid, production-ready SSL certificate through LE and configure your WP site to use it.

These certifications expire every 90 days so there's a cronjob to renew them monthly.

There's a new `provider` option under the `ssl` object for each WP site. Valid options are:

* `self-signed` - used in development
* `manual` - when you already have a key and cert you just want copied over
* `letsencrypt` - invokes automatic LE certificate flow

### Testing

*  You need a publicly accessible server
* Make sure a WP site has
```yaml
ssl:
  enabled: true
  provider: letsencrypt
```
* Optionally remove `letsencrypt_ca` from `group_vars/all/main.yml` if you want a real production cert. Otherwise you are using Let's Encrypt's staging server and the CA isn't verified in browsers. Note: LE production has rate limits. So don't exhaust the limit just testing unless you need a real cert.
* Provision server as usual

Todo:
- [x] Renewal script does not generate bundled certificate
- [x] Improve idempotence
- [x] Only run `letsencrypt` (toggle via variable)
- [x] Add the "reverse" (www or non-www) hosts for multi domain certs
- [x] More testing
- [x] Set default CA to production
- [x] Docs - https://github.com/roots/docs/blob/ssl-docs-add-providers/trellis/ssl.md