### PR TITLE
Fix some deprecation warnings while deploying and use current stable WP-CLI

### DIFF
--- a/roles/deploy/tasks/build.yml
+++ b/roles/deploy/tasks/build.yml
@@ -7,17 +7,17 @@
     src: "{{ item.src }}"
     dest: "{{ deploy_helper.new_release_path }}/{{ item.dest }}"
     mode: "{{ item.mode | default('0644') }}"
-  with_items: project_templates
+  with_items: "{{ project_templates }}"
 
 - name: Check if project folders exist
   stat:
     path: "{{ deploy_helper.current_path }}/{{ item }}"
   register: project_folder_paths
-  with_items: project_copy_folders
+  with_items: "{{ project_copy_folders }}"
 
 - name: Copy project folders
   command: cp -rp {{ deploy_helper.current_path }}/{{ item.item }} {{ deploy_helper.new_release_path }}
-  with_items: project_folder_paths.results
+  with_items: "{{ project_folder_paths.results }}"
   when: item.stat.exists
 
 - include: "{{ deploy_build_after | default('../hooks/example.yml') }}"

--- a/roles/deploy/tasks/share.yml
+++ b/roles/deploy/tasks/share.yml
@@ -7,20 +7,20 @@
     path: "{{ deploy_helper.shared_path }}/{{ item.src }}"
     state: "{{ item.type | default('directory') }}"
     mode: "{{ item.mode | default('0755') }}"
-  with_items: project_shared_children
+  with_items: "{{ project_shared_children }}"
 
 - name: Ensure shared paths are absent
   file:
     path: "{{ deploy_helper.new_release_path }}/{{ item.path }}"
     state: absent
-  with_items: project_shared_children
+  with_items: "{{ project_shared_children }}"
 
 - name: Create shared symlinks
   file:
     path: "{{ deploy_helper.new_release_path }}/{{ item.path }}"
     src: "{{ deploy_helper.shared_path }}/{{ item.src }}"
     state: link
-  with_items: project_shared_children
+  with_items: "{{ project_shared_children }}"
 
 - include: "{{ deploy_share_after | default('../hooks/example.yml') }}"
   tags: deploy-share-after

--- a/roles/wp-cli/defaults/main.yml
+++ b/roles/wp-cli/defaults/main.yml
@@ -1,4 +1,4 @@
 wp_cli_bin_path: /usr/bin/wp
-wp_cli_phar_url: "https://github.com/wp-cli/wp-cli/releases/download/v0.21.1/wp-cli-0.21.1.phar"
+wp_cli_phar_url: "https://github.com/wp-cli/wp-cli/releases/download/v0.23.0/wp-cli-0.23.0.phar"
 wp_cli_completion_url: "https://raw.githubusercontent.com/wp-cli/wp-cli/master/utils/wp-completion.bash"
 wp_cli_completion_path: /etc/bash_completion.d


### PR DESCRIPTION
WP-CLI URL taken from: http://wp-cli.org/#install