### PR TITLE
Allow option for using WinNFSD as sync folder provider on Windows

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,7 +54,7 @@ Vagrant.configure('2') do |config|
     fail_with_message "vagrant-hostmanager missing, please install the plugin with this command:\nvagrant plugin install vagrant-hostmanager"
   end
 
-  if Vagrant::Util::Platform.windows?
+  if Vagrant::Util::Platform.windows? and !Vagrant.has_plugin? 'vagrant-winnfsd'
     wordpress_sites.each_pair do |name, site|
       config.vm.synced_folder local_site_path(site), remote_site_path(name), owner: 'vagrant', group: 'www-data', mount_options: ['dmode=776', 'fmode=775']
     end


### PR DESCRIPTION
This speeds up Sage development on Windows with Virtualbox significantly (at least an order of magnitude in my case).  Virtualbox synced folders are incredibly slow with large numbers of files on Windows.

By default, image will still use standard synced folders on Windows unless vagrant-winnfsd is actually installed.  Standard sync should probably stay the default for now as WinNFSD isn't being actively maintained anymore, and there doesn't seem to be a good replacement yet.

That being said, the performance boost is incredible after the switch.

To switch to using WinNFSd:
```bash
vagrant halt
vagrant plugin install vagrant-winnfsd
vagrant plugin install vagrant-bindfs
vagrant up
```

Note on usage: 'vagrant up' must be run with Admin privileges the first time it is run for it to set up the exports correctly.  Subsequent calls to vagrant up do not appear to need Admin privileges.  Tested on Windows 10.