### PR TITLE
wordpress_sites improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Simplify and improve `wordpress_sites` with better defaults ([#528](https://github.com/roots/trellis/pull/528))
 * Improve Let's Encrypt challenge pre-flight tests ([#526](https://github.com/roots/trellis/pull/526))
 * `reverse_www` filter improvements (ignore subdomains) ([#525](https://github.com/roots/trellis/pull/525))
 * Fix #520 - Disable MariaDB binary logging by default ([#521](https://github.com/roots/trellis/pull/521))

--- a/filter_plugins/trellis_filters.py
+++ b/filter_plugins/trellis_filters.py
@@ -38,6 +38,9 @@ def reverse_www(hosts, enabled=True, append=True):
     else:
         raise errors.AnsibleFilterError('The reverse_www filter expects a string or list of strings, got ' + repr(hosts))
 
+def to_env(dict_value):
+    envs = ["{0}='{1}'".format(key.upper(), value) for key, value in dict_value.iteritems()]
+    return "\n".join(envs)
 
 class FilterModule(object):
     ''' Trellis jinja2 filters '''
@@ -45,4 +48,5 @@ class FilterModule(object):
     def filters(self):
         return {
             'reverse_www': reverse_www,
+            'to_env': to_env,
         }

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -6,3 +6,7 @@ default_timezone: Etc/UTC
 www_root: /srv/www
 ip_whitelist:
   - "{{ lookup('pipe', 'curl -4 -s https://api.ipify.org') }}"
+
+wordpress_env_defaults:
+  wp_env: "{{ env }}"
+  disable_wp_cron: true

--- a/group_vars/development/main.yml
+++ b/group_vars/development/main.yml
@@ -1,3 +1,4 @@
+env: development
 ferm_enabled: false
 mysql_root_password: "{{ vault_mysql_root_password }}" # Define this variable in group_vars/development/vault.yml
 sudoer_passwords: "{{ vault_sudoer_passwords }}" # Define this variable in group_vars/development/vault.yml

--- a/group_vars/development/wordpress_sites.yml
+++ b/group_vars/development/wordpress_sites.yml
@@ -4,7 +4,6 @@ wordpress_sites:
     site_hosts:
       - example.dev
     local_path: ../site # path targeting local Bedrock site directory (relative to Ansible root)
-    site_install: true
     site_title: Example Site
     admin_user: admin
     # admin_password: (defined in group_vars/development/vault.yml)
@@ -20,10 +19,8 @@ wordpress_sites:
       enabled: false
       duration: 30s
     env:
-      disable_wp_cron: true
       wp_home: http://example.dev
       wp_siteurl: http://example.dev/wp
-      wp_env: development
       db_name: example_dev
       db_user: example_dbuser
       # db_password: (defined in group_vars/development/vault.yml)

--- a/group_vars/production/wordpress_sites.yml
+++ b/group_vars/production/wordpress_sites.yml
@@ -17,10 +17,8 @@ wordpress_sites:
       enabled: false
       duration: 30s
     env:
-      disable_wp_cron: true
       wp_home: http://example.com
       wp_siteurl: http://example.com/wp
-      wp_env: production
       db_name: example_prod
       db_user: example_dbuser
       # Define the following variables in group_vars/production/vault.yml

--- a/group_vars/staging/wordpress_sites.yml
+++ b/group_vars/staging/wordpress_sites.yml
@@ -17,10 +17,8 @@ wordpress_sites:
       enabled: false
       duration: 30s
     env:
-      disable_wp_cron: true
       wp_home: http://staging.example.com
       wp_siteurl: http://staging.example.com/wp
-      wp_env: staging
       db_name: example_staging
       db_user: example_dbuser
       # Define the following variables in group_vars/staging/vault.yml

--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -39,4 +39,4 @@ project_shared_children:
 # project_environment:
 #   WP_ENV: "production"
 project_environment:
-  WP_ENV: "{{ project.env.wp_env }}"
+  WP_ENV: "{{ env }}"

--- a/roles/deploy/templates/env.j2
+++ b/roles/deploy/templates/env.j2
@@ -1,6 +1,1 @@
-{% for key, value in project.env.iteritems() %}
-{{ key | upper }}="{{ value }}"
-{% endfor %}
-{% for key, value in vault_wordpress_sites[site].env.iteritems() %}
-{{ key | upper }}="{{ value }}"
-{% endfor %}
+{{ wordpress_env_defaults | combine(item.value.env, vault_wordpress_sites[item.key].env) | to_env }}

--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -13,8 +13,8 @@
 - name: Copy .env file into web root
   command: rsync -ac --info=NAME /tmp/{{ item.key }}.env {{ www_root }}/{{ item.key }}/current/.env
   with_dict: "{{ wordpress_sites }}"
-  register: env
-  changed_when: env.stdout == "{{ item.key }}.env"
+  register: env_file
+  changed_when: env_file.stdout == "{{ item.key }}.env"
 
 - name: Install Dependencies with Composer
   command: composer install
@@ -36,7 +36,7 @@
     chdir: "{{ www_root }}/{{ item.key }}/current/"
   register: wp_install_results
   with_dict: "{{ wordpress_sites }}"
-  when: item.value.site_install == True and (item.value.multisite.enabled | default(False) == False)
+  when: item.value.site_install | default(true) and not item.value.multisite.enabled | default(false)
   changed_when: "'WordPress is already installed.' not in wp_install_results.stdout"
 
 - name: Setup Permalink Structure
@@ -61,5 +61,5 @@
     chdir: "{{ www_root }}/{{ item.key }}/current/"
   register: wp_install_results
   with_dict: "{{ wordpress_sites }}"
-  when: item.value.site_install == True and (item.value.multisite.enabled | default(False) == True)
+  when: item.value.site_install | default(true) and item.value.multisite.enabled | default(false)
   changed_when: "'The network already exists.' not in wp_install_results.stdout"

--- a/roles/wordpress-install/templates/env.j2
+++ b/roles/wordpress-install/templates/env.j2
@@ -1,6 +1,1 @@
-{% for key, value in item.value.env.iteritems() %}
-{{ key | upper }}="{{ value }}"
-{% endfor %}
-{% for key, value in vault_wordpress_sites[item.key].env.iteritems() %}
-{{ key | upper }}="{{ value }}"
-{% endfor %}
+{{ wordpress_env_defaults | combine(item.value.env, vault_wordpress_sites[item.key].env) | to_env }}

--- a/roles/wordpress-setup/tasks/main.yml
+++ b/roles/wordpress-setup/tasks/main.yml
@@ -33,4 +33,4 @@
     job: "curl -k -s {{ item.value.env.wp_siteurl }}/wp-cron.php > /dev/null 2>&1"
     cron_file: "wordpress-{{ item.key | replace('.', '_') }}"
   with_dict: "{{ wordpress_sites }}"
-  when: item.value.env.disable_wp_cron | default(false) and not item.value.multisite.enabled | default(false)
+  when: item.value.env.disable_wp_cron | default(true) and not item.value.multisite.enabled | default(false)

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -16,7 +16,7 @@ server {
 
   charset utf-8;
 
-  {% if item.value.env.wp_env == 'development' -%}
+  {% if env == 'development' -%}
   # See Virtualbox section at http://wiki.nginx.org/Pitfalls
   sendfile off;
   {%- endif %}


### PR DESCRIPTION
* Add `to_env` filter
* Use `combine` + `to_env` for better .env templates
* Remove the need for `wp_env` and set automatically based on `env`
* Set `disable_wp_cron` by default