### PR TITLE
Fix deploy env template to use valid ansible vars

### DIFF
--- a/roles/deploy/templates/env.j2
+++ b/roles/deploy/templates/env.j2
@@ -1,1 +1,1 @@
-{{ wordpress_env_defaults | combine(item.value.env, vault_wordpress_sites[item.key].env) | to_env }}
+{{ wordpress_env_defaults | combine(project.env, vault_wordpress_sites[site].env) | to_env }}


### PR DESCRIPTION
When running deploy.sh, ansible fails with an error similar to the following:
```
failed: [staging.example.com] => (item={u'dest': u'.env', u'src': u'roles/deploy/templates/env.j2', u'name': u'.env config'}) => {"failed": true, "item": {"dest": ".env", "name": ".env config", "src": "roles/deploy/templates/env.j2"}, "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'value'"}
```

It apepars that PR #528 introduced an error with some invalid ansible keys.  This should fix them.

Thanks to @fullyint for helping with Ansible conventions.  I'm new to Trellis (and Ansible), and you make it easy!