### PR TITLE
add commented out ansible.ask_vault_pass to vagrantfile to allow asking for vault password

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -76,6 +76,9 @@ Vagrant.configure('2') do |config|
     end
   else
     config.vm.provision :ansible do |ansible|
+      # uncomment out the next line if you do not want to store your password
+      # on your machine in a dotfile
+      # ansible.ask_vault_pass = true
       ansible.playbook = File.join(ANSIBLE_PATH, 'dev.yml')
       ansible.groups = {
         'web' => ['default'],


### PR DESCRIPTION
I didn't want to add my vault password in a dotfile -- I wanted to enter it on demand -- I could not achieve this with the extant setup, vagrant told me that the encryption password was wrong.. adding in the line that I added (commented out) prompted me to enter the vault password and all worked as expected.