### PR TITLE
Automatically set `wp_home` and `wp_siteurl`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Automatically set `wp_home` and `wp_siteurl` variables ([#533](https://github.com/roots/trellis/pull/533))
 * Switch to Let's Encrypt X3 intermediate certificate and fix chain issues ([#534](https://github.com/roots/trellis/pull/534))
 * Supply better defaults for `db_name` and `db_user` ([#529](https://github.com/roots/trellis/pull/529))
 * Fix deploy env template to use valid ansible vars ([#530](https://github.com/roots/trellis/pull/530))

--- a/deploy.yml
+++ b/deploy.yml
@@ -13,6 +13,15 @@
     deploy_finalize_after: "{{ playbook_dir }}/roles/deploy/hooks/finalize-after.yml"
     project: "{{ wordpress_sites[site] }}"
     project_root: "{{ www_root }}/{{ site }}"
+    wordpress_env_defaults:
+      db_host: localhost
+      db_name: "{{ site | underscore }}_{{ env }}"
+      db_user: "{{ site | underscore }}"
+      disable_wp_cron: true
+      wp_env: "{{ env }}"
+      wp_home: "{{ project.ssl.enabled | default(false) | ternary('https', 'http') }}://${HTTP_HOST}"
+      wp_siteurl: "${WP_HOME}/wp"
+    site_env: "{{ wordpress_env_defaults | combine(project.env | default({}), vault_wordpress_sites[site].env) }}"
 
   pre_tasks:
     - name: Ensure site is valid

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -6,3 +6,14 @@ default_timezone: Etc/UTC
 www_root: /srv/www
 ip_whitelist:
   - "{{ lookup('pipe', 'curl -4 -s https://api.ipify.org') }}"
+
+wordpress_env_defaults:
+  db_host: localhost
+  db_name: "{{ item.key | underscore }}_{{ env }}"
+  db_user: "{{ item.key | underscore }}"
+  disable_wp_cron: true
+  wp_env: "{{ env }}"
+  wp_home: "{{ item.value.ssl.enabled | default(false) | ternary('https', 'http') }}://${HTTP_HOST}"
+  wp_siteurl: "${WP_HOME}/wp"
+
+site_env: "{{ wordpress_env_defaults | combine(item.value.env | default({}), vault_wordpress_sites[item.key].env) }}"

--- a/group_vars/development/vault.yml
+++ b/group_vars/development/vault.yml
@@ -6,6 +6,7 @@ vault_sudoer_passwords:
   admin: $6$rounds=100000$JUkj1d3hCa6uFp6R$3rZ8jImyCpTP40e4I5APx7SbBvDCM8fB6GP/IGOrsk/GEUTUhl1i/Q2JNOpj9ashLpkgaCxqMqbFKdZdmAh26/
 
 # Variables to accompany `group_vars/development/wordpress_sites.yml`
+# Note: the site name (`example.com`) must match up with the site name in the above file.
 vault_wordpress_sites:
   example.com:
     admin_password: admin

--- a/group_vars/development/wordpress_sites.yml
+++ b/group_vars/development/wordpress_sites.yml
@@ -1,24 +1,15 @@
 # Documentation: https://roots.io/trellis/docs/local-development-setup/
+# Define accompanying passwords/secrets in group_vars/development/vault.yml
+
 wordpress_sites:
   example.com:
     site_hosts:
       - example.dev
     local_path: ../site # path targeting local Bedrock site directory (relative to Ansible root)
-    site_title: Example Site
-    admin_user: admin
-    # admin_password: (defined in group_vars/development/vault.yml)
     admin_email: admin@example.dev
-    initial_permalink_structure: /%postname%/ # applied only at time of WP install and when `site_install: true`
     multisite:
       enabled: false
-      subdomains: false
     ssl:
       enabled: false
-      provider: self-signed
     cache:
       enabled: false
-      duration: 30s
-    env:
-      wp_home: http://example.dev
-      wp_siteurl: http://example.dev/wp
-      # db_password: (defined in group_vars/development/vault.yml)

--- a/group_vars/production/vault.yml
+++ b/group_vars/production/vault.yml
@@ -6,6 +6,7 @@ vault_sudoer_passwords:
   admin: $6$rounds=100000$JUkj1d3hCa6uFp6R$3rZ8jImyCpTP40e4I5APx7SbBvDCM8fB6GP/IGOrsk/GEUTUhl1i/Q2JNOpj9ashLpkgaCxqMqbFKdZdmAh26/
 
 # Variables to accompany `group_vars/production/wordpress_sites.yml`
+# Note: the site name (`example.com`) must match up with the site name in the above file.
 vault_wordpress_sites:
   example.com:
     env:

--- a/group_vars/production/wordpress_sites.yml
+++ b/group_vars/production/wordpress_sites.yml
@@ -1,31 +1,18 @@
 # Documentation: https://roots.io/trellis/docs/remote-server-setup/
+# Define accompanying passwords/secrets in group_vars/production/vault.yml
+
 wordpress_sites:
   example.com:
     site_hosts:
       - example.com
     local_path: ../site # path targeting local Bedrock site directory (relative to Ansible root)
     repo: git@github.com:example/example.com.git # replace with your Git repo URL
-    branch: master
     repo_subtree_path: site # relative path to your Bedrock/WP directory in your repo
+    branch: master
     multisite:
       enabled: false
-      subdomains: false
     ssl:
       enabled: false
       provider: letsencrypt
     cache:
       enabled: false
-      duration: 30s
-    env:
-      wp_home: http://example.com
-      wp_siteurl: http://example.com/wp
-      # Define the following variables in group_vars/production/vault.yml
-      # db_password:
-      # auth_key:
-      # secure_auth_key:
-      # logged_in_key:
-      # nonce_key:
-      # auth_salt:
-      # secure_auth_salt:
-      # logged_in_salt:
-      # nonce_salt:

--- a/group_vars/staging/vault.yml
+++ b/group_vars/staging/vault.yml
@@ -6,6 +6,7 @@ vault_sudoer_passwords:
   admin: $6$rounds=100000$JUkj1d3hCa6uFp6R$3rZ8jImyCpTP40e4I5APx7SbBvDCM8fB6GP/IGOrsk/GEUTUhl1i/Q2JNOpj9ashLpkgaCxqMqbFKdZdmAh26/
 
 # Variables to accompany `group_vars/staging/wordpress_sites.yml`
+# Note: the site name (`example.com`) must match up with the site name in the above file.
 vault_wordpress_sites:
   example.com:
     env:

--- a/group_vars/staging/wordpress_sites.yml
+++ b/group_vars/staging/wordpress_sites.yml
@@ -1,31 +1,17 @@
 # Documentation: https://roots.io/trellis/docs/remote-server-setup/
+# Define accompanying passwords/secrets in group_vars/staging/vault.yml
+
 wordpress_sites:
   example.com:
     site_hosts:
       - staging.example.com
     local_path: ../site # path targeting local Bedrock site directory (relative to Ansible root)
     repo: git@github.com:example/example.com.git # replace with your Git repo URL
-    branch: master
     repo_subtree_path: site # relative path to your Bedrock/WP directory in your repo
+    branch: master
     multisite:
       enabled: false
-      subdomains: false
     ssl:
       enabled: false
-      provider: letsencrypt
     cache:
       enabled: false
-      duration: 30s
-    env:
-      wp_home: http://staging.example.com
-      wp_siteurl: http://staging.example.com/wp
-      # Define the following variables in group_vars/staging/vault.yml
-      # db_password:
-      # auth_key:
-      # secure_auth_key:
-      # logged_in_key:
-      # nonce_key:
-      # auth_salt:
-      # secure_auth_salt:
-      # logged_in_salt:
-      # nonce_salt:

--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -40,9 +40,3 @@ project_shared_children:
 #   WP_ENV: "production"
 project_environment:
   WP_ENV: "{{ env }}"
-
-wordpress_env_defaults:
-  db_name: "{{ site | underscore }}_{{ env }}"
-  db_user: "{{ site | underscore }}"
-  disable_wp_cron: true
-  wp_env: "{{ env }}"

--- a/roles/deploy/templates/env.j2
+++ b/roles/deploy/templates/env.j2
@@ -1,1 +1,1 @@
-{{ wordpress_env_defaults | combine(project.env, vault_wordpress_sites[site].env) | to_env }}
+{{ site_env | to_env }}

--- a/roles/wordpress-install/defaults/main.yml
+++ b/roles/wordpress-install/defaults/main.yml
@@ -1,5 +1,0 @@
-wordpress_env_defaults:
-  db_name: "{{ item.key | underscore }}_{{ env }}"
-  db_user: "{{ item.key | underscore }}"
-  disable_wp_cron: true
-  wp_env: "{{ env }}"

--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -27,7 +27,7 @@
 - name: Install WP
   command: wp core install
            --allow-root
-           --url="{{ item.value.env.wp_home }}"
+           --url="{{ site_env.wp_home }}"
            --title="{{ item.value.site_title | default(item.key) }}"
            --admin_user="{{ item.value.admin_user }}"
            --admin_password="{{ vault_wordpress_sites[item.key].admin_password }}"
@@ -50,7 +50,7 @@
 - name: Install WP Multisite
   command: wp core multisite-install
            --allow-root
-           --url="{{ item.value.env.wp_home }}"
+           --url="{{ site_env.wp_home }}"
            --base="{{ item.value.multisite.base_path | default('/') }}"
            --subdomains="{{ item.value.multisite.subdomains | default('false') }}"
            --title="{{ item.value.site_title | default(item.key) }}"

--- a/roles/wordpress-install/templates/env.j2
+++ b/roles/wordpress-install/templates/env.j2
@@ -1,1 +1,1 @@
-{{ wordpress_env_defaults | combine(item.value.env, vault_wordpress_sites[item.key].env) | to_env }}
+{{ site_env | to_env }}

--- a/roles/wordpress-setup/defaults/main.yml
+++ b/roles/wordpress-setup/defaults/main.yml
@@ -1,2 +1,0 @@
-db_name: "{{ item.value.env.db_name | default(item.key + '_' + env) | underscore }}"
-db_user: "{{ item.value.env.db_user | default(item.key) | underscore }}"

--- a/roles/wordpress-setup/tasks/database.yml
+++ b/roles/wordpress-setup/tasks/database.yml
@@ -1,9 +1,9 @@
 ---
 - name: Create database of sites
   mysql_db:
-    name: "{{ db_name }}"
+    name: "{{ site_env.db_name }}"
     state: present
-    login_host: "{{ item.value.env.db_host | default('localhost') }}"
+    login_host: "{{ site_env.db_host }}"
     login_user: "{{ mysql_root_user }}"
     login_password: "{{ mysql_root_password }}"
   with_dict: "{{ wordpress_sites }}"
@@ -11,12 +11,12 @@
 
 - name: Create/assign database user to db and grant permissions
   mysql_user:
-    name: "{{ db_user }}"
-    password: "{{ vault_wordpress_sites[item.key].env.db_password }}"
+    name: "{{ site_env.db_user }}"
+    password: "{{ site_env.db_password }}"
     append_privs: yes
-    priv: "{{ db_name }}.*:ALL"
+    priv: "{{ site_env.db_name }}.*:ALL"
     state: present
-    login_host: "{{ item.value.env.db_host | default('localhost') }}"
+    login_host: "{{ site_env.db_host }}"
     login_user: "{{ mysql_root_user }}"
     login_password: "{{ mysql_root_password }}"
   with_dict: "{{ wordpress_sites }}"
@@ -31,12 +31,12 @@
 
 - name: Import database
   mysql_db:
-    name: "{{ db_name }}"
+    name: "{{ site_env.db_name }}"
     state: import
     target: "/tmp/{{ item.value.db_import | basename }}"
-    login_host: "{{ item.value.env.db_host | default('localhost') }}"
-    login_user: "{{ db_user }}"
-    login_password: "{{ vault_wordpress_sites[item.key].env.db_password }}"
+    login_host: "{{ site_env.db_host }}"
+    login_user: "{{ site_env.db_user }}"
+    login_password: "{{ site_env.db_password }}"
   with_dict: "{{ wordpress_sites }}"
   when: item.value.db_import | default(False)
   notify: reload nginx

--- a/roles/wordpress-setup/tasks/main.yml
+++ b/roles/wordpress-setup/tasks/main.yml
@@ -30,7 +30,7 @@
     name: "{{ item.key }} WordPress cron"
     minute: "*/15"
     user: "{{ web_user }}"
-    job: "curl -k -s {{ item.value.env.wp_siteurl }}/wp-cron.php > /dev/null 2>&1"
+    job: "curl -k -s {{ site_env.wp_siteurl }}/wp-cron.php > /dev/null 2>&1"
     cron_file: "wordpress-{{ item.key | replace('.', '_') }}"
   with_dict: "{{ wordpress_sites }}"
-  when: item.value.env.disable_wp_cron | default(true) and not item.value.multisite.enabled | default(false)
+  when: site_env.disable_wp_cron and not item.value.multisite.enabled | default(false)


### PR DESCRIPTION
Using the "dynamic" HTTP_HOST/SERVER_NAME is a good enough default. In
the majority of cases users should have to worry about setting these
variables and overriding them.

This also allows for a more seamless transition to HTTPS since there's
one less place to configure or potentially forget. It also just reduces
the chances of misconfiguration in general and a mismatch of values
(site hosts and wp home/siteurl).