### PR TITLE
Let's Encrypt: use new X3 intermediate certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Switch to Let's Encrypt X3 intermediate certificate and fix chain issues ([#534](https://github.com/roots/trellis/pull/534))
 * Supply better defaults for `db_name` and `db_user` ([#529](https://github.com/roots/trellis/pull/529))
 * Fix deploy env template to use valid ansible vars ([#530](https://github.com/roots/trellis/pull/530))
 * Simplify and improve `wordpress_sites` with better defaults ([#528](https://github.com/roots/trellis/pull/528))

--- a/roles/letsencrypt/defaults/main.yml
+++ b/roles/letsencrypt/defaults/main.yml
@@ -27,9 +27,9 @@ letsencrypt_ca: 'https://acme-v01.api.letsencrypt.org'
 
 letsencrypt_account_key: '{{ acme_tiny_data_directory }}/account.key'
 
-letsencrypt_intermediate_cert_path: /etc/ssl/certs/lets-encrypt-x1-cross-signed.pem
-letsencrypt_intermediate_cert_url: 'https://letsencrypt.org/certs/lets-encrypt-x1-cross-signed.pem'
-letsencrypt_intermediate_cert_sha256sum: '6c0a324bb803e9d66b8986ea2085bb9d6bdfe33f5c04a03a3f7024f4aa8e7a2d'
+letsencrypt_intermediate_cert_path: /etc/ssl/certs/lets-encrypt-x3-cross-signed.pem
+letsencrypt_intermediate_cert_url: 'https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem'
+letsencrypt_intermediate_cert_sha256sum: 'e446c5e9dbef9d09ac9f7027c034602492437a05ff6c40011d7235fca639c79a'
 
 letsencrypt_keys_dir: "{{ nginx_ssl_path }}/letsencrypt"
 letsencrypt_certs_dir: "{{ nginx_ssl_path }}/letsencrypt"


### PR DESCRIPTION
LE recently "upgraded" to their new 2nd-gen X3 authority which has
better Windows XP support. This also means a new X3 intermediate
certificate.

This was causing certificate chain issues since the authority was X3 and
the intermediate cert was X1. Now they match and everything is good in
the world again.