### PR TITLE
Multiple SSL sites redirect problem

### DIFF
--- a/roles/wordpress-setup/templates/https.conf.j2
+++ b/roles/wordpress-setup/templates/https.conf.j2
@@ -1,0 +1,22 @@
+include h5bp/directive-only/ssl.conf;
+include h5bp/directive-only/ssl-stapling.conf;
+
+ssl_dhparam /etc/nginx/ssl/dhparams.pem;
+ssl_buffer_size 1400; # 1400 bytes to fit in one MTU
+
+{% set hsts_max_age = item.value.ssl.hsts_max_age | default(nginx_hsts_max_age) %}
+{% set hsts_include_subdomains = item.value.ssl.hsts_include_subdomains | default(nginx_hsts_include_subdomains) | ternary('includeSubdomains', None) %}
+{% set hsts_preload = item.value.ssl.hsts_preload | default(nginx_hsts_preload) | ternary('preload', None) %}
+add_header Strict-Transport-Security "max-age={{ [hsts_max_age, hsts_include_subdomains, hsts_preload] | reject('none') | join('; ') }}";
+
+{% if item.value.ssl.provider | default('manual') == 'manual' and item.value.ssl.cert is defined and item.value.ssl.key is defined -%}
+  ssl_certificate         {{ nginx_path }}/ssl/{{ item.value.ssl.cert | basename }};
+  ssl_certificate_key     {{ nginx_path }}/ssl/{{ item.value.ssl.key | basename }};
+{%- elif item.value.ssl.provider | default('manual') == 'letsencrypt' -%}
+  ssl_certificate         {{ nginx_path }}/ssl/letsencrypt/{{ item.key }}-bundled.cert;
+  ssl_certificate_key     {{ nginx_path }}/ssl/letsencrypt/{{ item.key }}.key;
+{%- elif item.value.ssl.provider | default('manual') == 'self-signed' -%}
+  ssl_certificate         {{ nginx_path }}/ssl/{{ item.key }}.cert;
+  ssl_trusted_certificate {{ nginx_path }}/ssl/{{ item.key }}.cert;
+  ssl_certificate_key     {{ nginx_path }}/ssl/{{ item.key }}.key;
+{%- endif -%}

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -33,28 +33,7 @@ server {
   add_header Fastcgi-Cache $upstream_cache_status;
 
   {% if item.value.ssl is defined and item.value.ssl.enabled | default(false) -%}
-    include h5bp/directive-only/ssl.conf;
-    include h5bp/directive-only/ssl-stapling.conf;
-
-    ssl_dhparam /etc/nginx/ssl/dhparams.pem;
-    ssl_buffer_size 1400; # 1400 bytes to fit in one MTU
-
-    {% set hsts_max_age = item.value.ssl.hsts_max_age | default(nginx_hsts_max_age) %}
-    {% set hsts_include_subdomains = item.value.ssl.hsts_include_subdomains | default(nginx_hsts_include_subdomains) | ternary('includeSubdomains', None) %}
-    {% set hsts_preload = item.value.ssl.hsts_preload | default(nginx_hsts_preload) | ternary('preload', None) %}
-    add_header Strict-Transport-Security "max-age={{ [hsts_max_age, hsts_include_subdomains, hsts_preload] | reject('none') | join('; ') }}";
-
-    {% if item.value.ssl.provider | default('manual') == 'manual' and item.value.ssl.cert is defined and item.value.ssl.key is defined -%}
-      ssl_certificate         {{ nginx_path }}/ssl/{{ item.value.ssl.cert | basename }};
-      ssl_certificate_key     {{ nginx_path }}/ssl/{{ item.value.ssl.key | basename }};
-    {%- elif item.value.ssl.provider | default('manual') == 'letsencrypt' -%}
-      ssl_certificate         {{ nginx_path }}/ssl/letsencrypt/{{ item.key }}-bundled.cert;
-      ssl_certificate_key     {{ nginx_path }}/ssl/letsencrypt/{{ item.key }}.key;
-    {%- elif item.value.ssl.provider | default('manual') == 'self-signed' -%}
-      ssl_certificate         {{ nginx_path }}/ssl/{{ item.key }}.cert;
-      ssl_trusted_certificate {{ nginx_path }}/ssl/{{ item.key }}.cert;
-      ssl_certificate_key     {{ nginx_path }}/ssl/{{ item.key }}.key;
-    {%- endif -%}
+    {{ lookup('template', 'https.conf.j2') }}
   {% endif %}
 
   include includes.d/{{ item.key }}/*.conf;
@@ -116,6 +95,8 @@ server {
 server {
   {% if item.value.ssl is defined and item.value.ssl.enabled | default(false) -%}
     listen 443 ssl http2;
+
+    {{ lookup('template', 'https.conf.j2') }}
   {% else -%}
     listen 80;
   {% endif -%}


### PR DESCRIPTION
So I had a problem with two sites using SSL wildcard certs. Site 2 would not redirect the www version because it was using Site 1 wildcard. If I specify the certs and include ssl conf files in redirect block then everything works fine. Discourse: [here](https://discourse.roots.io/t/2-different-ssl-wildcards-issue-on-same-server/6333). Not sure if I did this exactly right because ansible/jinja syntax and my trellis is on an older version with less configs.
