### PR TITLE
Fix #489 - Add $realpath_root to fastcgi_cache_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Fix #489 - Add $realpath_root to fastcgi_cache_key ([#542](https://github.com/roots/trellis/pull/542))
 * Move modules and plugins to `lib/trellis` directory ([#538](https://github.com/roots/trellis/pull/538))
 * Automatically set `wp_home` and `wp_siteurl` variables ([#533](https://github.com/roots/trellis/pull/533))
 * Switch to Let's Encrypt X3 intermediate certificate and fix chain issues ([#534](https://github.com/roots/trellis/pull/534))

--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -32,7 +32,6 @@ error_log  {{ nginx_logs_root }}/error.log warn;
 pid        /run/nginx.pid;
 
 http {
-
   # Hide nginx version information.
   server_tokens off;
 
@@ -41,7 +40,7 @@ http {
   fastcgi_cache_path {{ nginx_cache_path }} levels=1:2 keys_zone=wordpress:{{ nginx_cache_key_storage_size }} max_size={{ nginx_cache_size }} inactive={{ nginx_cache_inactive }};
   fastcgi_cache_use_stale updating error timeout invalid_header http_500;
   fastcgi_cache_lock on;
-  fastcgi_cache_key $scheme$host$request_uri$request_method;
+  fastcgi_cache_key $realpath_root$scheme$host$request_uri$request_method;
   fastcgi_ignore_headers Cache-Control Expires Set-Cookie;
   fastcgi_pass_header Set-Cookie;
   fastcgi_pass_header Cookie;


### PR DESCRIPTION
This acts as an automatic cache buster when a deploy happens.
`$realpath_root` contains the real/un-symlinked path to the web root.

Example: `/srv/www/example.com/releases/20160101` instead of
`/srv/www/example.com/current`

This will prevent some known bugs where a cached page refers to a now
non-existent "revved" asset like Sage generates (a CSS or JS file with a
hash in the filename).