### PR TITLE
Fix #482 - Multisite is-installed deploy check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Fix #482 - Multisite is-installed deploy check ([#543](https://github.com/roots/trellis/pull/543))
 * Skip setting permalink for multisite installs ([#546](https://github.com/roots/trellis/pull/546))
 * Fix #489 - Add $realpath_root to fastcgi_cache_key ([#542](https://github.com/roots/trellis/pull/542))
 * Move modules and plugins to `lib/trellis` directory ([#538](https://github.com/roots/trellis/pull/538))

--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -1,6 +1,6 @@
 ---
 - name: WordPress Installed?
-  command: wp core is-installed
+  command: wp core is-installed {{ project.multisite.enabled | default(false) | ternary('--network', '') }}
   args:
     chdir: "{{ deploy_helper.new_release_path }}"
   register: wp_installed


### PR DESCRIPTION
Optionally add the `--network` option to properly check if a site is
installed after deploys for both normal and multisite installs.

Ref: http://wp-cli.org/commands/core/is-installed/