### PR TITLE
Add plugin to pretty print Ansible msg output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Add plugin to pretty print Ansible msg output ([#544](https://github.com/roots/trellis/pull/544))
 * Fix #482 - Multisite is-installed deploy check ([#543](https://github.com/roots/trellis/pull/543))
 * Skip setting permalink for multisite installs ([#546](https://github.com/roots/trellis/pull/546))
 * Fix #489 - Add $realpath_root to fastcgi_cache_key ([#542](https://github.com/roots/trellis/pull/542))

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,4 +1,6 @@
 [defaults]
+callback_plugins = ~/.ansible/plugins/callback_plugins/:/usr/share/ansible_plugins/callback_plugins:lib/trellis/plugins/callback
+stdout_callback = output
 filter_plugins = ~/.ansible/plugins/filter_plugins/:/usr/share/ansible_plugins/filter_plugins:lib/trellis/plugins/filter
 force_handlers = True
 inventory = hosts

--- a/lib/trellis/__init__.py
+++ b/lib/trellis/__init__.py
@@ -1,0 +1,3 @@
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type

--- a/lib/trellis/plugins/callback/output.py
+++ b/lib/trellis/plugins/callback/output.py
@@ -1,0 +1,97 @@
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os.path
+import sys
+
+from ansible.plugins.callback.default import CallbackModule as CallbackModule_default
+
+try:
+    from trellis.utils.output import display_output
+except ImportError:
+    if sys.path.append(os.path.join(os.getcwd(), 'lib')) in sys.path: raise
+    sys.path.append(sys.path.append(os.path.join(os.getcwd(), 'lib')))
+    from trellis.utils.output import display_output
+
+
+class CallbackModule(CallbackModule_default):
+    ''' Customizes the default Ansible output '''
+
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'stdout'
+    CALLBACK_NAME = 'output'
+
+    def __init__(self):
+
+        super(CallbackModule, self).__init__()
+
+        self.action = None
+        self.first_host = True
+        self.first_item = True
+        self.task_failed = False
+
+    def display_host_output(self, result):
+        if 'results' not in result._result:
+            display_output(result, self.action, self._display.display, self.first_host and self.first_item, self.task_failed)
+            self.first_host = False
+
+    def display_item_output(self, result):
+        display_output(result, self.action, self._display.display, self.first_host and self.first_item, self.task_failed)
+        self.first_item = False
+
+    def reset_task(self, task):
+        self.action = task._get_parent_attribute('action')
+        self.first_host = True
+        self.first_item = True
+        self.task_failed = False
+
+    # Display dict key only, instead of full json dump
+    def replace_item_with_key(self, result):
+        if not self._display.verbosity:
+            if 'key' in result._result['item']:
+                result._result['item'] = result._result['item']['key']
+            elif 'item' in result._result['item'] and 'key' in result._result['item']['item']:
+                result._result['item'] = result._result['item']['item']['key']
+
+    def v2_runner_on_failed(self, result, ignore_errors=False):
+        self.task_failed = True
+        self.display_host_output(result)
+        super(CallbackModule, self).v2_runner_on_failed(result, ignore_errors)
+
+    def v2_runner_on_ok(self, result):
+        self.display_host_output(result)
+        super(CallbackModule, self).v2_runner_on_ok(result)
+
+    def v2_runner_on_skipped(self, result):
+        self.display_host_output(result)
+        super(CallbackModule, self).v2_runner_on_skipped(result)
+
+    def v2_runner_on_unreachable(self, result):
+        self.task_failed = True
+        self.display_host_output(result)
+        super(CallbackModule, self).v2_runner_on_unreachable(result)
+
+    def v2_playbook_on_task_start(self, task, is_conditional):
+        self.reset_task(task)
+        super(CallbackModule, self).v2_playbook_on_task_start(task, is_conditional)
+
+    def v2_playbook_on_handler_task_start(self, task):
+        self.reset_task(task)
+        super(CallbackModule, self).v2_playbook_on_handler_task_start(task)
+
+    def v2_playbook_item_on_ok(self, result):
+        self.display_item_output(result)
+        self.replace_item_with_key(result)
+        super(CallbackModule, self).v2_playbook_item_on_ok(result)
+
+    def v2_playbook_item_on_failed(self, result):
+        self.task_failed = True
+        self.display_item_output(result)
+        self.replace_item_with_key(result)
+        super(CallbackModule, self).v2_playbook_item_on_failed(result)
+
+    def v2_playbook_item_on_skipped(self, result):
+        self.display_item_output(result)
+        self.replace_item_with_key(result)
+        super(CallbackModule, self).v2_playbook_item_on_skipped(result)

--- a/lib/trellis/utils/__init__.py
+++ b/lib/trellis/utils/__init__.py
@@ -1,0 +1,3 @@
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type

--- a/lib/trellis/utils/output.py
+++ b/lib/trellis/utils/output.py
@@ -1,0 +1,52 @@
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import textwrap
+
+from ansible.utils.unicode import to_unicode
+
+def display_output(result, action, display, first, task_failed=False):
+    msg = ''
+    result = result._result
+    wrap_width = 77
+    failed = 'failed' in result or 'unreachable' in result
+
+    # Only display msg if debug module or if failed (some modules have undesired 'msg' on 'ok')
+    if 'msg' in result and (failed or action == 'debug'):
+        msg = result.pop('msg', '')
+
+        # Disable Ansible's verbose setting for debug module to avoid the CallbackBase._dump_results()
+        if '_ansible_verbose_always' in result:
+            del result['_ansible_verbose_always']
+
+    # Display additional info when failed
+    if failed:
+        items = (item for item in ['module_stderr', 'module_stdout', 'stderr'] if item in result and to_unicode(result[item]) != '')
+        for item in items:
+            msg = result[item] if msg == '' else '\n'.join([msg, result.pop(item, '')])
+
+        # Add blank line between this fail message and the json dump Ansible displays next
+        msg = '\n'.join([msg, ''])
+
+    # Must pass unicode strings to Display.display() to prevent UnicodeError tracebacks
+    if isinstance(msg, list):
+        msg = '\n'.join([to_unicode(x) for x in msg])
+    elif not isinstance(msg, unicode):
+        msg = to_unicode(msg)
+
+    # Wrap text
+    msg = '\n'.join([textwrap.fill(line, wrap_width, replace_whitespace=False)
+                     for line in msg.splitlines()])
+
+    # Display msg with horizontal rule between hosts/items
+    hr = '-' * int(wrap_width*.67)
+    if msg == '':
+        if task_failed and not first:
+            display(hr, 'bright gray')
+        else:
+            return
+    else:
+        if not first:
+            display(hr, 'bright gray')
+        display(msg, 'red' if failed else 'bright purple')


### PR DESCRIPTION
This PR proposes a new ['stdout_callback'](http://docs.ansible.com/ansible/intro_configuration.html#stdout-callback) named `output.py` to augment Ansible's [`default.py`](https://github.com/ansible/ansible/blob/bb6cadefa2d68ed2a668fba14dc027947e043ae5/lib/ansible/plugins/callback/default.py). It extracts and displays the `msg` attribute, interpreting newline characters and applying textwrap.

This PR adds a couple .py files, still mirroring Ansible project's structure.
```
lib/
  trellis/
    modules/
      deploy_helper.py
    plugins/
      callback/         <-- new
        output.py       <-- new
      filter/
        filters.py
    utils/              <-- new
      output.py         <-- new
```

Run the playbook below on Trellis master then again on this PR's branch to see the different formatting.
```
- name: Output demo 
  gather_facts: false
  hosts: localhost
  vars_files:
    - group_vars/staging/wordpress_sites.yml
  tasks:
    - debug:
        msg: If `with_dict`, `item` below displays dict key only (unless `-v`)
      register: results
      with_dict: "{{ wordpress_sites }}"

    - debug:
        msg: If `with_items` based on dict, attempts to display only key (unless `-v`)
      with_items: "{{ results.results }}"

    - assert:
        that: "{{ item.name == 'bar' }}"
        msg: |
          {{ item.msg }}

          {{ item.msg }}

          {{ item.msg*2 }}
      with_items:
        - {'name': 'foo', 'msg': 'Fail for item zero.  '}
        - {'name': 'bar', 'msg': 'Example ok/skipped item'}
        - {'name': 'foo', 'msg': 'The horizontal rule between hosts/items helps distinguish between multiple hosts/items, especially when messages have blank lines. Blank lines would no longer clearly mark the start/end of the message per host/item.  '}
```
This is an improved piece of #531.