### PR TITLE
Handle skipped items in "Notify of challenge failures"

### DIFF
--- a/roles/letsencrypt/tasks/nginx.yml
+++ b/roles/letsencrypt/tasks/nginx.yml
@@ -48,5 +48,5 @@
       Make sure that a valid DNS record exists for {{ item.failed_hosts | join(', ') }} and that they point to this server's IP.
       If you don't want these domains in your SSL certificate, then remove them from `site_hosts`.
       See https://roots.io/trellis/docs/ssl for more details.
-  when: letsencrypt_test_challenges | failed
+  when: not item | skipped and letsencrypt_test_challenges | failed
   with_items: "{{ letsencrypt_test_challenges.results }}"


### PR DESCRIPTION
**Problem:**
```
TASK [letsencrypt : Notify of challenge failures] ********
ERROR! 'dict object' has no attribute 'failed_hosts'
```
**Steps to reproduce:** Create two sites in `wordpress_sites`, one with SSL enabled with `letsencrypt` and the other with SSL not enabled. Run `server.yml`. Admittedly a bit of an edge case.

**Why this happens:** 
* The `Test Acme Challenges` task skips the site that doesn't have SSL enabled. The task produces the registered var `letsencrypt_test_challenges`. 
* The `Notify of challenge failures` task loops through `letsencrypt_test_challenges.results`, evaluating the `failed_hosts` attribute for each item. The problem is that skipped items don't have a `failed_hosts` attribute.

**Resolution:** This PR adds a check `when: not item | skipped` so the task no longer fails.