### PR TITLE
Enable color output for Vagrant shell provisioner windows.sh

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -74,6 +74,7 @@ Vagrant.configure('2') do |config|
     config.vm.provision :shell do |sh|
       sh.path = File.join(ANSIBLE_PATH, 'windows.sh')
       sh.args = [Vagrant::VERSION]
+      sh.keep_color = true
     end
   else
     config.vm.provision :ansible do |ansible|

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,9 +2,11 @@
 callback_plugins = ~/.ansible/plugins/callback_plugins/:/usr/share/ansible_plugins/callback_plugins:lib/trellis/plugins/callback
 stdout_callback = output
 filter_plugins = ~/.ansible/plugins/filter_plugins/:/usr/share/ansible_plugins/filter_plugins:lib/trellis/plugins/filter
+force_color = True
 force_handlers = True
 inventory = hosts
 library = /usr/share/ansible:lib/trellis/modules
+nocows = 1
 roles_path = vendor/roles
 vars_plugins = ~/.ansible/plugins/vars_plugins/:/usr/share/ansible_plugins/vars_plugins:lib/trellis/plugins/vars
 

--- a/windows.sh
+++ b/windows.sh
@@ -6,6 +6,7 @@
 # @version 1.0
 
 ANSIBLE_PATH="$(find /vagrant -name 'windows.sh' -printf '%h' -quit)"
+export PYTHONUNBUFFERED=1
 
 # Create an ssh key if not already created.
 if [ ! -f ~/.ssh/id_rsa ]; then
@@ -31,7 +32,7 @@ fi
 # Install Ansible and its dependencies if not installed.
 if [ ! -f /usr/bin/ansible ]; then
   echo "Adding Ansible repository..."
-  sudo apt-add-repository ppa:ansible/ansible
+  sudo apt-add-repository -y ppa:ansible/ansible
   echo "Updating system..."
   sudo apt-get -y update
   echo "Installing Ansible..."


### PR DESCRIPTION
- Vagrant [`keep_color`](https://www.vagrantup.com/docs/provisioning/shell.html#keep_color)
- Ansible [`force_color`](http://docs.ansible.com/ansible/intro_configuration.html#force-color)
- Ansible [`nocows`](http://docs.ansible.com/ansible/intro_configuration.html#nocows)
- `PYTHONUNBUFFERED=1` as [recommended by Vagrant](https://github.com/mitchellh/vagrant/issues/3891#issuecomment-44048470) to help display color using Vagrant shell provisioner, on Windows host, provisioning with Ansible

Also added `-y` to `apt-add-repository` so `windows.sh` won't halt waiting for response if/when you run it manually from within VM (vs. typical usage of running it via Vagrant command).