### PR TITLE
Escape salts and keys to avoid templating errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Escape salts and keys to avoid templating errors ([#548](https://github.com/roots/trellis/pull/548))
 * Add plugin to pretty print Ansible msg output ([#544](https://github.com/roots/trellis/pull/544))
 * Fix #482 - Multisite is-installed deploy check ([#543](https://github.com/roots/trellis/pull/543))
 * Skip setting permalink for multisite installs ([#546](https://github.com/roots/trellis/pull/546))

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -6,6 +6,7 @@ force_handlers = True
 inventory = hosts
 library = /usr/share/ansible:lib/trellis/modules
 roles_path = vendor/roles
+vars_plugins = ~/.ansible/plugins/vars_plugins/:/usr/share/ansible_plugins/vars_plugins:lib/trellis/plugins/vars
 
 [ssh_connection]
 ssh_args = -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s

--- a/group_vars/production/vault.yml
+++ b/group_vars/production/vault.yml
@@ -12,7 +12,6 @@ vault_wordpress_sites:
     env:
       db_password: example_dbpassword
       # Generate your keys here: https://api.wordpress.org/secret-key/1.1/salt/
-      # These CANNOT contain the characters "{%" or "{{" in succession
       auth_key: "generateme"
       secure_auth_key: "generateme"
       logged_in_key: "generateme"

--- a/group_vars/staging/vault.yml
+++ b/group_vars/staging/vault.yml
@@ -12,7 +12,6 @@ vault_wordpress_sites:
     env:
       db_password: example_dbpassword
       # Generate your keys here: https://api.wordpress.org/secret-key/1.1/salt/
-      # These CANNOT contain the characters "{%" or "{{" in succession
       auth_key: "generateme"
       secure_auth_key: "generateme"
       logged_in_key: "generateme"

--- a/lib/trellis/plugins/vars/vars.py
+++ b/lib/trellis/plugins/vars/vars.py
@@ -1,0 +1,22 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+class VarsModule(object):
+    ''' Creates and modifies host variables '''
+
+    def __init__(self, inventory):
+        self.inventory = inventory
+        self.inventory_basedir = inventory.basedir()
+
+    # Wrap salts and keys variables in {% raw %} to prevent jinja templating errors
+    def wrap_salts_in_raw(self, host, hostvars):
+        if 'vault_wordpress_sites' in hostvars:
+            for name, site in hostvars['vault_wordpress_sites'].iteritems():
+                for key, value in site['env'].iteritems():
+                    if key.endswith(('_key', '_salt')) and not value.startswith(('{% raw', '{%raw')):
+                        hostvars['vault_wordpress_sites'][name]['env'][key] = ''.join(['{% raw %}', value, '{% endraw %}'])
+            host.vars['vault_wordpress_sites'] = hostvars['vault_wordpress_sites']
+
+    def get_host_vars(self, host, vault_password=None):
+        self.wrap_salts_in_raw(host, host.get_group_vars())
+        return {}


### PR DESCRIPTION
This PR adds a new [vars plugin](http://docs.ansible.com/ansible/developing_plugins.html#vars-plugins) built from Ansible's [noop.py](https://github.com/ansible/ansible/blob/bb6cadefa2d68ed2a668fba14dc027947e043ae5/lib/ansible/inventory/vars_plugins/noop.py) example. The new plugin escapes WP env salts and keys (`group_vars/<environment>/vault.yml`) by wrapping them in [`{% raw %}`](http://jinja.pocoo.org/docs/dev/templates/#escaping) to prevent the problem that arises when the strings include `{{` or `{%` (e.g., #484). 


Here is an excerpt of the remote's `.env` produced by a deploy. No longer causes errors on deploy.
```
AUTH_KEY='gene{%rateme'
AUTH_SALT='g{{enerateme'
LOGGED_IN_KEY='generatem{%e'
LOGGED_IN_SALT='gene{%rateme'
NONCE_KEY='{{generateme'
NONCE_SALT='generateme'
SECURE_AUTH_KEY='generat{{eme'
SECURE_AUTH_SALT='g{%enerateme'
```

This PR adds one vars plugin file, still mirroring Ansible project's structure.
```
lib/
  trellis/
    modules/
    plugins/
      callback/
      filter/
      vars/             <-- new
        vars.py         <-- new
    utils/
```
Note. The [`lib/ansible/plugins/vars`](https://github.com/ansible/ansible/tree/bb6cadefa2d68ed2a668fba14dc027947e043ae5/lib/ansible/plugins/vars) dir is there in Ansible, but the example vars plugin they offer is in [`lib/ansible/inventory/vars_plugins`](https://github.com/ansible/ansible/tree/bb6cadefa2d68ed2a668fba14dc027947e043ae5/lib/ansible/inventory/vars_plugins).

The new plugin uses [`host.vars[key] = value`](https://github.com/ansible/ansible/blob/bb6cadefa2d68ed2a668fba14dc027947e043ae5/lib/ansible/inventory/host.py#L112) to override var, because vars returned by [`host.get_group_vars`](https://github.com/ansible/ansible/blob/bb6cadefa2d68ed2a668fba14dc027947e043ae5/lib/ansible/inventory/host.py#L137) are only [a copy](https://github.com/ansible/ansible/blob/bb6cadefa2d68ed2a668fba14dc027947e043ae5/lib/ansible/inventory/group.py#L151). Changing the latter (the copy) would have no effect.

Note. Don't be alarmed if you test this in a `debug` task and it doesn't work. This works for Trellis usage of `wordpress_sites[site].env` in template module. The `{% raw %}` tags are indeed being added. The debug module can print `vault_wordpress_sites['example.com'].env.nonce_key` but not `item.value.env.nonce_key` using `with_dict`. It seems the debug module sometimes doesn't honor the `{% raw %}` tags (?).