### PR TITLE
Display system info with fail output

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -73,6 +73,7 @@ Vagrant.configure('2') do |config|
   if Vagrant::Util::Platform.windows?
     config.vm.provision :shell do |sh|
       sh.path = File.join(ANSIBLE_PATH, 'windows.sh')
+      sh.args = [Vagrant::VERSION]
     end
   else
     config.vm.provision :ansible do |ansible|
@@ -82,9 +83,10 @@ Vagrant.configure('2') do |config|
         'development' => ['default']
       }
 
+      ansible.extra_vars = {'vagrant_version' => Vagrant::VERSION}
       if vars = ENV['ANSIBLE_VARS']
         extra_vars = Hash[vars.split(',').map { |pair| pair.split('=') }]
-        ansible.extra_vars = extra_vars
+        ansible.extra_vars.merge(extra_vars)
       end
     end
   end

--- a/lib/trellis/utils/output.py
+++ b/lib/trellis/utils/output.py
@@ -2,11 +2,41 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import os.path
+import platform
+import re
 import textwrap
 
+from ansible import __version__
 from ansible.utils.unicode import to_unicode
 
-def display_output(result, action, display, first, task_failed=False):
+def system(vagrant_version=None):
+    # Get most recent Trellis CHANGELOG entry
+    changelog_msg = ''
+    changelog = os.path.join(os.getcwd(), 'CHANGELOG.md')
+
+    if os.path.isfile(changelog):
+        with open(changelog) as f:
+            str = f.read(200)
+
+        # Retrieve release number if it is most recent entry
+        release = re.search(r'^###\s((?!HEAD).*)', str)
+        if release is not None:
+            changelog_msg = '\n  Trellis {0}'.format(release.group(1))
+
+        # Retrieve most recent changelog entry
+        else:
+            change = re.search(r'.*\n\*\s*([^\(\n\[]+)', str)
+            if change is not None:
+                changelog_msg = '\n  Trellis at "{0}"'.format(change.group(1).strip())
+
+    # Vagrant info, if available
+    vagrant = ' Vagrant {0};'.format(vagrant_version) if vagrant_version else ''
+
+    # Assemble components and return
+    return 'System info:\n  Ansible {0};{1} {2}{3}'.format(__version__, vagrant, platform.system(), changelog_msg)
+
+def display_output(result, action, display, first, task_failed=False, vagrant_version=None):
     msg = ''
     result = result._result
     wrap_width = 77
@@ -39,8 +69,13 @@ def display_output(result, action, display, first, task_failed=False):
     msg = '\n'.join([textwrap.fill(line, wrap_width, replace_whitespace=False)
                      for line in msg.splitlines()])
 
-    # Display msg with horizontal rule between hosts/items
+    # Display system info and msg, with horizontal rule between hosts/items
     hr = '-' * int(wrap_width*.67)
+
+    if task_failed and first:
+        display(system(vagrant_version), 'bright gray')
+        display(hr, 'bright gray')
+
     if msg == '':
         if task_failed and not first:
             display(hr, 'bright gray')

--- a/windows.sh
+++ b/windows.sh
@@ -45,4 +45,4 @@ fi
 
 echo "Running Ansible Playbooks"
 cd ${ANSIBLE_PATH}/
-ansible-playbook dev.yml
+ansible-playbook dev.yml -e vagrant_version=$1


### PR DESCRIPTION
To help with debugging and support requests, this PR augments fail output to include version info for Ansible, Vagrant, and Trellis. Also displays the host machine's platform.
```
TASK [common : Validate Ansible version] ***************************************
System info:
  Ansible 1.9.4; Vagrant 1.8.1; Linux
  Trellis at "Add plugin to pretty print Ansible msg output"
---------------------------------------------------
Your Ansible version is too old. Trellis requires at least 2.x. Your version is 1.9.4
fatal: [host 1]: FAILED! => {"assertion": false, "changed": false, "evaluated_to": false, "failed": true}
---------------------------------------------------
Your Ansible version is too old. Trellis requires at least 2.x. Your version is 1.9.4
fatal: [host 2]: FAILED! => {"assertion": false, "changed": false, "evaluated_to": false, "failed": true}
```

I would have preferred to have the system info in a footer, but displaying it at the top allows simpler code. Having the system info at the top may be better, however, possibly making it more likely that users will include it in the output they paste to the help forum. I can provide details if desired.