### PR TITLE
Fix ansible.cfg and Ansible plugins for moved Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,8 +9,13 @@ memory = 1024 # in MB
 
 ANSIBLE_PATH = __dir__ # absolute path to Ansible directory
 
-# Set Ansible roles_path relative to Ansible directory
+# Set Ansible paths relative to Ansible directory
+ENV['ANSIBLE_CONFIG'] = ANSIBLE_PATH
+ENV['ANSIBLE_CALLBACK_PLUGINS'] = "~/.ansible/plugins/callback_plugins/:/usr/share/ansible_plugins/callback_plugins:#{File.join(ANSIBLE_PATH, 'lib/trellis/plugins/callback')}"
+ENV['ANSIBLE_FILTER_PLUGINS'] = "~/.ansible/plugins/filter_plugins/:/usr/share/ansible_plugins/filter_plugins:#{File.join(ANSIBLE_PATH, 'lib/trellis/plugins/filter')}"
+ENV['ANSIBLE_LIBRARY'] = "/usr/share/ansible:#{File.join(ANSIBLE_PATH, 'lib/trellis/modules')}"
 ENV['ANSIBLE_ROLES_PATH'] = File.join(ANSIBLE_PATH, 'vendor', 'roles')
+ENV['ANSIBLE_VARS_PLUGINS'] = "~/.ansible/plugins/vars_plugins/:/usr/share/ansible_plugins/vars_plugins:#{File.join(ANSIBLE_PATH, 'lib/trellis/plugins/vars')}"
 
 config_file = File.join(ANSIBLE_PATH, 'group_vars', 'development', 'wordpress_sites.yml')
 

--- a/lib/trellis/plugins/callback/output.py
+++ b/lib/trellis/plugins/callback/output.py
@@ -11,8 +11,9 @@ from ansible.plugins.callback.default import CallbackModule as CallbackModule_de
 try:
     from trellis.utils import output as output
 except ImportError:
-    if sys.path.append(os.path.join(os.getcwd(), 'lib')) in sys.path: raise
-    sys.path.append(sys.path.append(os.path.join(os.getcwd(), 'lib')))
+    ansible_path = os.getenv('ANSIBLE_CONFIG', os.getcwd())
+    if sys.path.append(os.path.join(ansible_path, 'lib')) in sys.path: raise
+    sys.path.append(sys.path.append(os.path.join(ansible_path, 'lib')))
     from trellis.utils import output as output
 
 

--- a/lib/trellis/utils/output.py
+++ b/lib/trellis/utils/output.py
@@ -13,7 +13,8 @@ from ansible.utils.unicode import to_unicode
 def system(vagrant_version=None):
     # Get most recent Trellis CHANGELOG entry
     changelog_msg = ''
-    changelog = os.path.join(os.getcwd(), 'CHANGELOG.md')
+    ansible_path = os.getenv('ANSIBLE_CONFIG', os.getcwd())
+    changelog = os.path.join(ansible_path, 'CHANGELOG.md')
 
     if os.path.isfile(changelog):
         with open(changelog) as f:


### PR DESCRIPTION
**Background**
Ansible reads `ansible.cfg` from the runtime current directory. This means that Ansible does not read `ansible.cfg` for users who move the `Vagrantfile` to a parent directory, like this:
```
example.com/
  site/
  trellis/
  Vagrantfile
```
The [Vagrant docs](https://www.vagrantup.com/docs/provisioning/ansible_intro.html#ANSIBLE_CONFIG) emphasize that 
>`ansible-playbook` **never** looks for `ansible.cfg` in the directory that contains the main playbook file

At first, that statement may seem false, but the point is that Ansible looks in the `cwd`, which may not necessarily be the same dir as the playbook. So, when a user moves the `Vagrantfile` to a parent dir and runs `vagrant up` from that parent dir, Ansible looks for `ansible.cfg` in that parent dir, not in the subdir.

Until recent updates, `roles_path` has been the only config critical for the Trellis Vagrant VM. In the case of a moved `Vagrantfile`, its builtin `ENV['ANSIBLE_ROLES_PATH'] = File.join(ANSIBLE_PATH, 'vendor', 'roles')` still loads third-party roles even though `ansible.cfg` is not read.

**The problem**
Trellis has recently added configs to `ansible.cfg` that are critical even to the Vagrant VM. When the `Vagrantfile` is moved, the `dev.yml` playbook fails because it lacks plugin path info from the `ansible.cfg` file it is not reading. 

**The solution**
This PR copies the `roles_path` solution to other path configs that need to adjust according the the `ANSIBLE_PATH` constant. It also sets the `ANSIBLE_CONFIG` env var so Ansible can still find the `ansible.cfg` file and read the configs that aren't pathlists. The pathlists are overridden by the env vars set in the `Vagrantfile`, enabling relative dirs to account for `ANSIBLE_PATH`.