### PR TITLE
Tidy up output.py by moving some methods to utils

### DIFF
--- a/lib/trellis/plugins/callback/output.py
+++ b/lib/trellis/plugins/callback/output.py
@@ -9,11 +9,11 @@ from ansible.parsing.dataloader import DataLoader
 from ansible.plugins.callback.default import CallbackModule as CallbackModule_default
 
 try:
-    from trellis.utils.output import display_output
+    from trellis.utils import output as output
 except ImportError:
     if sys.path.append(os.path.join(os.getcwd(), 'lib')) in sys.path: raise
     sys.path.append(sys.path.append(os.path.join(os.getcwd(), 'lib')))
-    from trellis.utils.output import display_output
+    from trellis.utils import output as output
 
 
 class CallbackModule(CallbackModule_default):
@@ -24,62 +24,33 @@ class CallbackModule(CallbackModule_default):
     CALLBACK_NAME = 'output'
 
     def __init__(self):
-
         super(CallbackModule, self).__init__()
-
-        self.action = None
-        self.first_host = True
-        self.first_item = True
-        self.task_failed = False
-        self.vagrant_version = None
-
-    def display_host_output(self, result):
-        if 'results' not in result._result:
-            display_output(result, self.action, self._display.display, self.first_host and self.first_item, self.task_failed, self.vagrant_version)
-            self.first_host = False
-
-    def display_item_output(self, result):
-        display_output(result, self.action, self._display.display, self.first_host and self.first_item, self.task_failed)
-        self.first_item = False
-
-    def reset_task(self, task):
-        self.action = task._get_parent_attribute('action')
-        self.first_host = True
-        self.first_item = True
-        self.task_failed = False
-
-    # Display dict key only, instead of full json dump
-    def replace_item_with_key(self, result):
-        if not self._display.verbosity:
-            if 'key' in result._result['item']:
-                result._result['item'] = result._result['item']['key']
-            elif 'item' in result._result['item'] and 'key' in result._result['item']['item']:
-                result._result['item'] = result._result['item']['item']['key']
+        output.reset_task_info(self)
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
         self.task_failed = True
-        self.display_host_output(result)
+        output.display_host(self, result)
         super(CallbackModule, self).v2_runner_on_failed(result, ignore_errors)
 
     def v2_runner_on_ok(self, result):
-        self.display_host_output(result)
+        output.display_host(self, result)
         super(CallbackModule, self).v2_runner_on_ok(result)
 
     def v2_runner_on_skipped(self, result):
-        self.display_host_output(result)
+        output.display_host(self, result)
         super(CallbackModule, self).v2_runner_on_skipped(result)
 
     def v2_runner_on_unreachable(self, result):
         self.task_failed = True
-        self.display_host_output(result)
+        output.display_host(self, result)
         super(CallbackModule, self).v2_runner_on_unreachable(result)
 
     def v2_playbook_on_task_start(self, task, is_conditional):
-        self.reset_task(task)
+        output.reset_task_info(self, task)
         super(CallbackModule, self).v2_playbook_on_task_start(task, is_conditional)
 
     def v2_playbook_on_handler_task_start(self, task):
-        self.reset_task(task)
+        output.reset_task_info(self, task)
         super(CallbackModule, self).v2_playbook_on_handler_task_start(task)
 
     def v2_playbook_on_play_start(self, play):
@@ -92,17 +63,17 @@ class CallbackModule(CallbackModule_default):
             self.vagrant_version = play_vars['vagrant_version']
 
     def v2_playbook_item_on_ok(self, result):
-        self.display_item_output(result)
-        self.replace_item_with_key(result)
+        output.display_item(self, result)
+        output.replace_item_with_key(self, result)
         super(CallbackModule, self).v2_playbook_item_on_ok(result)
 
     def v2_playbook_item_on_failed(self, result):
         self.task_failed = True
-        self.display_item_output(result)
-        self.replace_item_with_key(result)
+        output.display_item(self, result)
+        output.replace_item_with_key(self, result)
         super(CallbackModule, self).v2_playbook_item_on_failed(result)
 
     def v2_playbook_item_on_skipped(self, result):
-        self.display_item_output(result)
-        self.replace_item_with_key(result)
+        output.display_item(self, result)
+        output.replace_item_with_key(self, result)
         super(CallbackModule, self).v2_playbook_item_on_skipped(result)

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -5,7 +5,7 @@
      - "{{ ansible_version is defined }}"
      - "{{ ansible_version.full | version_compare(minimum_ansible_version, '>=') }}"
     msg: "Your Ansible version is too old. Trellis requires at least {{ minimum_ansible_version }}. Your version is {{ ansible_version.full | default('< 1.6') }}"
-    run_once: true
+  run_once: true
 
 - name: Update Apt
   apt:


### PR DESCRIPTION
This PR changes nothing but organization, moving a few methods from `plugins/callback/output.py` to `utils/output.py`. Now the callback plugin producing the Trellis custom output is particularly tidy and straightforward. This keeps its code manageable and conceptually clear as we add more output features.

Note. This reorganization puts faith in [this comment](http://stackoverflow.com/a/16084773): 
>Instances of `self` get passed to functions (and methods of other classes) all the time.

If someone believes that is bad python practice, let me know.