### PR TITLE
Update version check for Ansible 2.x

### DIFF
--- a/lib/trellis/plugins/vars/vars.py
+++ b/lib/trellis/plugins/vars/vars.py
@@ -1,6 +1,12 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+from ansible import __version__
+from ansible.errors import AnsibleError
+
+if __version__.startswith('1'):
+    raise AnsibleError('Trellis no longer supports Ansible 1.x. Please upgrade to Ansible 2.x.')
+
 class VarsModule(object):
     ''' Creates and modifies host variables '''
 

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,2 +1,2 @@
-minimum_ansible_version: 1.9.2
+minimum_ansible_version: 2.0.0.2
 default_timezone: Etc/UTC

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -4,7 +4,8 @@
     that:
      - "{{ ansible_version is defined }}"
      - "{{ ansible_version.full | version_compare(minimum_ansible_version, '>=') }}"
-    msg: "Your Ansible version is too old. Trellis require at least {{ minimum_ansible_version }}. Your version is {{ ansible_version.full | default('< 1.6') }}"
+    msg: "Your Ansible version is too old. Trellis requires at least {{ minimum_ansible_version }}. Your version is {{ ansible_version.full | default('< 1.6') }}"
+    run_once: true
 
 - name: Update Apt
   apt:


### PR DESCRIPTION
* Bumps `minimum_ansible_version` var and version check from `1.9.2` to `2.0.0.2`.
* Adds [`run_once`](http://docs.ansible.com/ansible/playbooks_delegation.html#run-once) to version check so error prints only once, even if multiple hosts.
* Edits `vars.py` to check and warn if Ansible 1.x. Otherwise the plugin executes and produces a traceback before the above version check executes. Trellis Ansible plugins rely on the structure of the Ansible 2.x refactor.