### PR TITLE
Add custom output options to ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,6 +1,7 @@
 [defaults]
 callback_plugins = ~/.ansible/plugins/callback_plugins/:/usr/share/ansible_plugins/callback_plugins:lib/trellis/plugins/callback
 stdout_callback = output
+display_skipped_hosts = False
 filter_plugins = ~/.ansible/plugins/filter_plugins/:/usr/share/ansible_plugins/filter_plugins:lib/trellis/plugins/filter
 force_handlers = True
 inventory = hosts
@@ -10,3 +11,9 @@ vars_plugins = ~/.ansible/plugins/vars_plugins/:/usr/share/ansible_plugins/vars_
 
 [ssh_connection]
 ssh_args = -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s
+
+[trellis_output]
+display_include_tasks = False
+display_skipped_items = False
+truncate_items = True
+wrap_width = 80

--- a/lib/trellis/plugins/callback/output.py
+++ b/lib/trellis/plugins/callback/output.py
@@ -7,6 +7,7 @@ import sys
 
 from ansible.parsing.dataloader import DataLoader
 from ansible.plugins.callback.default import CallbackModule as CallbackModule_default
+from ansible.utils.unicode import to_unicode
 
 try:
     from trellis.utils import output as output
@@ -25,6 +26,7 @@ class CallbackModule(CallbackModule_default):
 
     def __init__(self):
         super(CallbackModule, self).__init__()
+        output.load_configs(self)
         output.reset_task_info(self)
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
@@ -47,7 +49,8 @@ class CallbackModule(CallbackModule_default):
 
     def v2_playbook_on_task_start(self, task, is_conditional):
         output.reset_task_info(self, task)
-        super(CallbackModule, self).v2_playbook_on_task_start(task, is_conditional)
+        if self.display_include_tasks or task._get_parent_attribute('action') != 'include':
+            super(CallbackModule, self).v2_playbook_on_task_start(task, is_conditional)
 
     def v2_playbook_on_handler_task_start(self, task):
         output.reset_task_info(self, task)
@@ -62,18 +65,28 @@ class CallbackModule(CallbackModule_default):
         if 'vagrant_version' in play_vars:
             self.vagrant_version = play_vars['vagrant_version']
 
+    def v2_playbook_on_stats(self, stats):
+        super(CallbackModule, self).v2_playbook_on_stats(stats)
+        self._display.display('To manage Trellis CLI output, see https://roots.io/trellis/docs/cli-output/\n', 'bright gray')
+
+    def v2_playbook_on_include(self, included_file):
+        if self.display_include_tasks:
+            super(CallbackModule, self).v2_playbook_on_include(included_file)
+
     def v2_playbook_item_on_ok(self, result):
         output.display_item(self, result)
         output.replace_item_with_key(self, result)
+        output.truncate_item(self, result)
         super(CallbackModule, self).v2_playbook_item_on_ok(result)
 
     def v2_playbook_item_on_failed(self, result):
         self.task_failed = True
         output.display_item(self, result)
-        output.replace_item_with_key(self, result)
         super(CallbackModule, self).v2_playbook_item_on_failed(result)
 
     def v2_playbook_item_on_skipped(self, result):
-        output.display_item(self, result)
-        output.replace_item_with_key(self, result)
-        super(CallbackModule, self).v2_playbook_item_on_skipped(result)
+        if self.display_skipped_items:
+            output.display_item(self, result)
+            output.replace_item_with_key(self, result)
+            output.truncate_item(self, result)
+            super(CallbackModule, self).v2_playbook_item_on_skipped(result)

--- a/lib/trellis/utils/output.py
+++ b/lib/trellis/utils/output.py
@@ -8,7 +8,17 @@ import re
 import textwrap
 
 from ansible import __version__
+from ansible import constants as C
 from ansible.utils.unicode import to_unicode
+
+def load_configs(obj):
+    obj.wrap_width = int(C.get_config(C.p, 'trellis_output', 'wrap_width', 'TRELLIS_WRAP_WIDTH', 80))
+    obj.display_include_tasks = (obj._display.verbosity or
+        C.get_config(C.p, 'trellis_output', 'display_include_tasks', 'TRELLIS_DISPLAY_INCLUDE_TASKS', False, boolean=True))
+    obj.display_skipped_items = (obj._display.verbosity or
+        C.get_config(C.p, 'trellis_output', 'display_skipped_items', 'TRELLIS_DISPLAY_SKIPPED_ITEMS', False, boolean=True))
+    obj.truncate_items = (not obj._display.verbosity and
+        C.get_config(C.p, 'trellis_output', 'truncate_items', 'TRELLIS_TRUNCATE_ITEMS', True, boolean=True))
 
 def system(vagrant_version=None):
     # Get most recent Trellis CHANGELOG entry
@@ -45,17 +55,26 @@ def reset_task_info(obj, task=None):
 
 # Display dict key only, instead of full json dump
 def replace_item_with_key(obj, result):
-    if not obj._display.verbosity:
+    if obj.truncate_items:
         if 'key' in result._result['item']:
             result._result['item'] = result._result['item']['key']
         elif 'item' in result._result['item'] and 'key' in result._result['item']['item']:
             result._result['item'] = result._result['item']['item']['key']
 
+# Display item's first line only
+def truncate_item(obj, result):
+    if obj.truncate_items:
+        status = 'changed' if result._result.get('changed', False) else 'ok'
+        pre = '{0}: [{1}] => (item=)'.format(status, result._host.get_name())
+        item = to_unicode(obj._get_item(result._result))
+        if (len(pre) + len(item)) > obj.wrap_width:
+            result._result['item'] = '{0}...'.format(item[:(obj.wrap_width - len(pre) - 3)])
+
 def display(obj, result):
     msg = ''
     result = result._result
     display = obj._display.display
-    wrap_width = 77
+    wrap_width = obj.wrap_width
     first = obj.first_host and obj.first_item
     failed = 'failed' in result or 'unreachable' in result
 


### PR DESCRIPTION
See how output differs while toggling the new `[trellis_output]` settings in `ansible.cfg` and running `server.yml` (or just add/omit `-v`). A couple roles whose output is quite affected: `--tags users,wordpress`

Settings are explained in the docs: roots/docs#32