### PR TITLE
Tidy up sudoer password definitions and comments

### DIFF
--- a/group_vars/all/security.yml
+++ b/group_vars/all/security.yml
@@ -12,6 +12,6 @@ ferm_input_list:
 
 # Documentation: https://roots.io/trellis/docs/security/
 # If sshd_permit_root_login: false, admin_user must be in 'users' (`group_vars/all/users.yml`) with sudo group
-# and in 'sudoer_passwords' (`group_vars/<environment>/main.yml`)
+# and in 'vault_sudoer_passwords' (`group_vars/staging/vault.yml`, `group_vars/production/vault.yml`)
 sshd_permit_root_login: true
 sshd_password_authentication: false

--- a/group_vars/all/users.yml
+++ b/group_vars/all/users.yml
@@ -1,7 +1,7 @@
 # Documentation: https://roots.io/trellis/docs/ssh-keys/
 admin_user: admin
 
-# Also define sudoer_passwords in group_vars/<environment>/main.yml
+# Also define 'vault_sudoer_passwords' (`group_vars/staging/vault.yml`, `group_vars/production/vault.yml`)
 users:
   - name: "{{ web_user }}"
     groups:

--- a/group_vars/development/main.yml
+++ b/group_vars/development/main.yml
@@ -1,5 +1,4 @@
 env: development
 ferm_enabled: false
 mysql_root_password: "{{ vault_mysql_root_password }}" # Define this variable in group_vars/development/vault.yml
-sudoer_passwords: "{{ vault_sudoer_passwords }}" # Define this variable in group_vars/development/vault.yml
 web_user: vagrant

--- a/group_vars/development/vault.yml
+++ b/group_vars/development/vault.yml
@@ -1,10 +1,6 @@
 # Documentation: https://roots.io/trellis/docs/vault/
 vault_mysql_root_password: devpw
 
-# Documentation: https://roots.io/trellis/docs/security/
-vault_sudoer_passwords:
-  admin: $6$rounds=100000$JUkj1d3hCa6uFp6R$3rZ8jImyCpTP40e4I5APx7SbBvDCM8fB6GP/IGOrsk/GEUTUhl1i/Q2JNOpj9ashLpkgaCxqMqbFKdZdmAh26/
-
 # Variables to accompany `group_vars/development/wordpress_sites.yml`
 # Note: the site name (`example.com`) must match up with the site name in the above file.
 vault_wordpress_sites:


### PR DESCRIPTION
Removes sudoer password definitions from `group_vars/development` because `dev.yml` doesn't run the `users` role.

Edits comments to more directly instruct users to edit `vault_sudoer_passwords` in `vault.yml`, instead of pointing them to `group_vars/<environment>/main.yml` which in turn points them to `vault.yml`.