### PR TITLE
Pass vault cli args to remote-user ping task

### DIFF
--- a/lib/trellis/plugins/vars/vars.py
+++ b/lib/trellis/plugins/vars/vars.py
@@ -7,12 +7,17 @@ from ansible.errors import AnsibleError
 if __version__.startswith('1'):
     raise AnsibleError('Trellis no longer supports Ansible 1.x. Please upgrade to Ansible 2.x.')
 
+# This import will produce Traceback in Ansible 1.x, so place after version check
+from __main__ import cli
+
+
 class VarsModule(object):
     ''' Creates and modifies host variables '''
 
     def __init__(self, inventory):
         self.inventory = inventory
         self.inventory_basedir = inventory.basedir()
+        self._options = cli.options if cli else None
 
     # Wrap salts and keys variables in {% raw %} to prevent jinja templating errors
     def wrap_salts_in_raw(self, host, hostvars):
@@ -23,6 +28,15 @@ class VarsModule(object):
                         hostvars['vault_wordpress_sites'][name]['env'][key] = ''.join(['{% raw %}', value, '{% endraw %}'])
             host.vars['vault_wordpress_sites'] = hostvars['vault_wordpress_sites']
 
+    def cli_args_vault(self):
+        if self._options.ask_vault_pass:
+            return '--ask-vault-pass'
+        elif self._options.vault_password_file:
+            return '--vault-password-file {0}'.format(self._options.vault_password_file)
+        else:
+            return ''
+
     def get_host_vars(self, host, vault_password=None):
         self.wrap_salts_in_raw(host, host.get_group_vars())
+        host.vars['cli_args_vault'] = self.cli_args_vault()
         return {}

--- a/roles/remote-user/tasks/main.yml
+++ b/roles/remote-user/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Determine whether to connect as root or admin_user
-  local_action: command ansible {{ inventory_hostname }} -m ping{{ (inventory_file == None) | ternary('', ' -i ' + inventory_file | string) }} -u root
+  local_action: command ansible {{ inventory_hostname }} -m ping{{ (inventory_file == None) | ternary('', ' -i ' + inventory_file | string) }} -u root {{ cli_args_vault | default('') }}
   failed_when: false
   changed_when: false
   register: root_status


### PR DESCRIPTION
**What works.** When files are encrypted and the `remote-user` task's ad hoc command pings the host, it succeeds in using the `vault_password_file = .vault_pass` specified in `ansible.cfg`. 

**What fails.** If a user chooses against this setting in `ansible.cfg`, opting instead to specify the vault password via the cli with an option such as `--ask-vault-pass` or `--vault-password-file`, the `remote-user` task's ping command will lack these options. In this case, the task yields an `ERROR! Decryption failed` and leads the `admin_user` to be selected instead of `root`.

**Solution.** The `vars.py` plugin can detect vault-related options passed to the cli and load them up in a new `cli_args_vault` variable appended to the `ping` command.