### PR TITLE
Enable Let's Encrypt to transition http sites to https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### HEAD
+* Enable Let's Encrypt to transition http sites to https ([#565](https://github.com/roots/trellis/pull/565))
+
 ### 0.9.7: April 10th, 2016
 * Fix #550 - Properly skip permalink setup for MU ([#551](https://github.com/roots/trellis/pull/551))
 * Escape salts and keys to avoid templating errors ([#548](https://github.com/roots/trellis/pull/548))

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -10,6 +10,4 @@
     state: reloaded
 
 - name: reload nginx
-  service:
-    name: nginx
-    state: reloaded
+  include: reload_nginx.yml

--- a/roles/common/tasks/reload_nginx.yml
+++ b/roles/common/tasks/reload_nginx.yml
@@ -1,0 +1,12 @@
+---
+- name: test nginx conf
+  command: nginx -t
+  register: nginx_test
+  changed_when: false
+
+- name: reload nginx
+  service:
+    name: nginx
+    state: reloaded
+  when: nginx_test | success
+  changed_when: false

--- a/roles/letsencrypt/defaults/main.yml
+++ b/roles/letsencrypt/defaults/main.yml
@@ -1,6 +1,7 @@
 sites_using_letsencrypt: "[{% for name, site in wordpress_sites.iteritems() if site.ssl.enabled and site.ssl.provider | default('manual') == 'letsencrypt' %}'{{ name }}',{% endfor %}]"
 letsencrypt_enabled: "{{ sites_using_letsencrypt | count > 0 }}"
 site_uses_letsencrypt: "{{ item.value.ssl is defined and item.value.ssl.enabled | default(false) and item.value.ssl.provider | default('manual') == 'letsencrypt' }}"
+sites_need_confs: "False in [{% for item in nginx_confs.results if 'stat' in item %}{{ item.stat.exists }},{% endfor %}]"
 
 acme_tiny_repo: 'https://github.com/diafygi/acme-tiny.git'
 acme_tiny_commit: '69a457269a6392ac31b629b4e103e8ea7dd282c9'

--- a/roles/letsencrypt/tasks/certificates.yml
+++ b/roles/letsencrypt/tasks/certificates.yml
@@ -37,19 +37,12 @@
     chdir: "{{ acme_tiny_data_directory }}"
   register: generate_initial_cert
   changed_when: generate_initial_cert.stdout is defined and 'Created' in generate_initial_cert.stdout
+  notify: reload nginx
 
 - name: Disable Nginx site
   file:
     path: "{{ nginx_path }}/sites-enabled/letsencrypt-{{ item.key }}.conf"
     state: absent
   with_dict: "{{ wordpress_sites }}"
-
-- name: Test nginx conf
-  command: nginx -t
-  changed_when: false
-
-- name: Trigger nginx reload
-  service:
-    name: nginx
-    state: reloaded
-  changed_when: false
+  when: sites_need_confs
+  notify: reload nginx

--- a/roles/letsencrypt/tasks/nginx.yml
+++ b/roles/letsencrypt/tasks/nginx.yml
@@ -1,30 +1,33 @@
-- name: Check for existing certificates
+- name: Check for existing Nginx conf per site
   stat:
-    path: "{{ letsencrypt_certs_dir }}/{{ item.key }}.cert"
-  register: letsencrypt_existing_certs
+    path: "{{ nginx_path }}/sites-enabled/{{ item.key }}.conf"
+  register: nginx_confs
   when: site_uses_letsencrypt
   with_dict: "{{ wordpress_sites }}"
 
-- name: Create Nginx sites for challenges
+- name: Create Nginx conf for challenges location
+  template:
+    src: acme-challenge-location.conf.j2
+    dest: "{{ nginx_path }}/acme-challenge-location.conf"
+  when: sites_need_confs
+
+- name: Create needed Nginx confs for challenges
   template:
     src: nginx-challenge-site.conf.j2
     dest: "{{ nginx_path }}/sites-available/letsencrypt-{{ item.item.key }}.conf"
   when: not item | skipped and not item.stat.exists
-  with_items: "{{ letsencrypt_existing_certs.results }}"
+  with_items: "{{ nginx_confs.results }}"
 
-- name: Enable Nginx site
+- name: Enable Nginx sites
   file:
     src: "{{ nginx_path }}/sites-available/letsencrypt-{{ item.item.key }}.conf"
     dest: "{{ nginx_path }}/sites-enabled/letsencrypt-{{ item.item.key }}.conf"
     state: link
   when: not item | skipped and not item.stat.exists
-  with_items: "{{ letsencrypt_existing_certs.results }}"
+  with_items: "{{ nginx_confs.results }}"
 
-- name: Trigger nginx reload
-  service:
-    name: nginx
-    state: reloaded
-  changed_when: false
+- include: "{{ playbook_dir }}/roles/common/tasks/reload_nginx.yml"
+  when: sites_need_confs
 
 - name: Create test Acme Challenge file
   shell: touch {{ acme_tiny_challenges_directory }}/ping.txt

--- a/roles/letsencrypt/tasks/setup.yml
+++ b/roles/letsencrypt/tasks/setup.yml
@@ -49,8 +49,3 @@
     url: "{{ letsencrypt_intermediate_cert_url }}"
     dest: "{{ letsencrypt_intermediate_cert_path }}"
     sha256sum: "{{ letsencrypt_intermediate_cert_sha256sum }}"
-
-- name: Create Nginx conf for challenges location
-  template:
-    src: acme-challenge-location.conf.j2
-    dest: "{{ nginx_path }}/acme-challenge-location.conf"

--- a/roles/wordpress-setup/tasks/nginx.yml
+++ b/roles/wordpress-setup/tasks/nginx.yml
@@ -47,6 +47,12 @@
                }}"
   notify: reload nginx
 
+- name: Create Nginx conf for challenges location
+  template:
+    src: "{{ playbook_dir }}/roles/letsencrypt/templates/acme-challenge-location.conf.j2"
+    dest: "{{ nginx_path }}/acme-challenge-location.conf"
+  notify: reload nginx
+
 - name: Create WordPress configuration for Nginx
   template:
     src: "wordpress-site.conf.j2"
@@ -62,13 +68,4 @@
     group: root
     state: link
   with_dict: "{{ wordpress_sites }}"
-
-- name: test nginx conf
-  command: nginx -t
-  changed_when: false
-
-- name: trigger nginx reload
-  service:
-    name: nginx
-    state: reloaded
-  changed_when: false
+  notify: reload nginx

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -36,6 +36,10 @@ server {
     {{ lookup('template', 'https.conf.j2') }}
   {% endif %}
 
+  {% if item.value.ssl is not defined or not item.value.ssl.enabled | default(false) -%}
+    include acme-challenge-location.conf;
+  {% endif %}
+
   include includes.d/{{ item.key }}/*.conf;
   include wordpress.conf;
 
@@ -102,6 +106,15 @@ server {
   {% endif -%}
 
   server_name {{ host | reverse_www(append=false) }};
-  return 301 $scheme://{{ host }}$request_uri;
+
+  {% if item.value.ssl is not defined or not item.value.ssl.enabled | default(false) -%}
+    include acme-challenge-location.conf;
+
+    location / {
+      return 301 $scheme://{{ host }}$request_uri;
+    }
+  {% else %}
+    return 301 $scheme://{{ host }}$request_uri;
+  {% endif %}
 }
 {% endfor %}

--- a/server.yml
+++ b/server.yml
@@ -29,4 +29,4 @@
     - { role: composer, tags: [composer] }
     - { role: wp-cli, tags: [wp-cli] }
     - { role: letsencrypt, tags: [letsencrypt], when: letsencrypt_enabled }
-    - { role: wordpress-setup, tags: [wordpress, wordpress-setup] }
+    - { role: wordpress-setup, tags: [wordpress, wordpress-setup, letsencrypt] }


### PR DESCRIPTION
**The problem.** When the LE role runs for an existing http site, the site already has an Nginx conf in `sites-enabled/site.com.conf` with a server block that doesn't include a location block for the Acme Challenge. If the LE role [happens to create/load](https://github.com/roots/trellis/blob/0667e4293d86b6920db838064433293be590a7d6/roles/letsencrypt/tasks/nginx.yml#L8-L21) the [`nginx-challenge-site.conf`](https://github.com/roots/trellis/blob/0667e4293d86b6920db838064433293be590a7d6/roles/letsencrypt/templates/nginx-challenge-site.conf.j2), its server block will compete in sorting of the [glob inclusion](https://github.com/roots/trellis/blob/0667e4293d86b6920db838064433293be590a7d6/roles/nginx/templates/nginx.conf.j2#L136) and either the Acme Challenge or the actual site won't be served till the `nginx-challenge-site.conf` [is disabled](https://github.com/roots/trellis/blob/0667e4293d86b6920db838064433293be590a7d6/roles/letsencrypt/tasks/certificates.yml#L41). This means that either the [Acme Challenges](https://github.com/roots/trellis/blob/0667e4293d86b6920db838064433293be590a7d6/roles/letsencrypt/tasks/nginx.yml#L35) will fail, or the regular site will be down for a moment.

**Proposed solution.** This PR resolves the problem of competing server blocks by extending a strategy already in place. The already existing strategy is that when ssl is enabled, the [http->https redirection](https://github.com/roots/trellis/blob/0667e4293d86b6920db838064433293be590a7d6/roles/wordpress-setup/templates/wordpress-site.conf.j2#L83) section also loads the Acme Challenge location block so that LE cert renewals will pass challenge tests. 

It seems relatively harmless to have the Acme Challenge location block there in the conf all the time. This PR adds the Acme Challenge location block to the non-ssl conf. As a result, when the LE role runs on an existing http site, it will use the site's existing conf (or create a new Acme Challenge conf if somehow there is no conf already). Either way, the Acme Challenge tests pass. 

This creates a bit more crossover between the `letsencrypt` role and the `wordpress-setup` role, but I'm not sure it can be avoided.

-----

The one context privileged to not have to deal with the extra Acme Challenges location block is what should be the most common: 1) ssl enabled and 2) no www redirect necessary.