### PR TITLE
Adding dbus to essentials

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -22,6 +22,7 @@
   - python-mysqldb
   - curl
   - git-core
+  - dbus
 
 - name: Validate timezone variable
   stat:


### PR DESCRIPTION
When the timezone is being set, hostnamectl is called, but it needs dbus to function.

This is one of the first things to error when you try to use trellis with Debian servers, so adding to the essentials should slightly lower the bar for Debian users. It comes installed on Ubuntu as of 14.04.

Tried this on Debian 8.3. Fixed the issue. 