### PR TITLE
Add 'reason' to attr extracted for pretty-print

### DIFF
--- a/lib/trellis/utils/output.py
+++ b/lib/trellis/utils/output.py
@@ -70,7 +70,7 @@ def display(obj, result):
 
     # Display additional info when failed
     if failed:
-        items = (item for item in ['module_stderr', 'module_stdout', 'stderr'] if item in result and to_unicode(result[item]) != '')
+        items = (item for item in ['reason', 'module_stderr', 'module_stdout', 'stderr'] if item in result and to_unicode(result[item]) != '')
         for item in items:
             msg = result[item] if msg == '' else '\n'.join([msg, result.pop(item, '')])
 


### PR DESCRIPTION
An improvement to the error messages that warn about yaml formatting problems in include files.

One way to produce the error is to compromise the yaml formatting of [this `template` task](https://github.com/roots/trellis/blob/0667e4293d86b6920db838064433293be590a7d6/roles/wordpress-setup/tasks/nginx.yml#L51) by removing the indentation.

```diff
  - name: Create WordPress configuration for Nginx
-   template:
+ template:
      src: "wordpress-site.conf.j2"
      dest: "{{ nginx_path }}/sites-available/{{ item.key }}.conf"
    with_dict: "{{ wordpress_sites }}"
    notify: reload nginx
```
When you run `server.yml` (e.g., this brief command on an already-provisioned server)
`ansible-playbook server.yml -e env=production --tags wordpress-nginx`
you get an unpretty output like this:

```
fatal: [54.213.206.26]: FAILED! => {"failed": true, "reason": "Syntax Error while loading YAML.\n\n\nThe error appears to have been in '/Users/philip/projects/roots/example.com/ansible/roles/wordpress-setup/tasks/nginx.yml': line 51, column 1, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n- name: Create WordPress configuration for Nginx\ntemplate:\n^ here\n"}
```

This PR makes the output look like this instead:
```
Syntax Error while loading YAML.


The error appears to have been in
'/Users/philip/projects/roots/example.com/ansible/roles/wordpress-
setup/tasks/nginx.yml': line 51, column 1, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

- name: Create WordPress configuration for Nginx
template:
^ here

fatal: [54.213.206.26]: FAILED! => {"failed": true, "reason": "Syntax Error while loading YAML.\n\n\nThe error appears to have been in '/Users/philip/projects/roots/example.com/ansible/roles/wordpress-setup/tasks/nginx.yml': line 51, column 1, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n- name: Create WordPress configuration for Nginx\ntemplate:\n^ here\n"}
```
all for a very small (and risk-free) price in terms of added code.