### PR TITLE
Define development default for Let's Encrypt variable

### DIFF
--- a/group_vars/development/main.yml
+++ b/group_vars/development/main.yml
@@ -1,3 +1,4 @@
+acme_tiny_challenges_directory: "{{ www_root }}/letsencrypt"
 env: development
 ferm_enabled: false
 mysql_root_password: "{{ vault_mysql_root_password }}" # Define this variable in group_vars/development/vault.yml


### PR DESCRIPTION
Fixes https://discourse.roots.io/t/cant-start-a-new-virtual-machine-after-pull-request-565-was-merged/6475

```
TASK [wordpress-setup : Create Nginx conf for challenges location] *************
AnsibleUndefinedVariable: 'acme_tiny_challenges_directory' is undefined
fatal: [default]: FAILED! => {"changed": false, "failed": true}
```

The `acme_tiny_challenges_directory` default is not defined for the Vagrant VM because `dev.yml` omits the LE role and its default. Adding a default specific to `env=development` seems to be the cleanest solution. 