### PR TITLE
Fix #569 Only skip subdomains for non-www domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Fix #569 - Only skip subdomains for non-www domains ([#570](https://github.com/roots/trellis/pull/570))
 * Enable Let's Encrypt to transition http sites to https ([#565](https://github.com/roots/trellis/pull/565))
 
 ### 0.9.7: April 10th, 2016

--- a/lib/trellis/plugins/filter/filters.py
+++ b/lib/trellis/plugins/filter/filters.py
@@ -26,13 +26,13 @@ def reverse_www(hosts, enabled=True, append=True):
     elif isinstance(hosts, string_types):
         host = hosts
 
-        if len(host.split('.')) > 2:
-            return host
-
         if host.startswith('www.'):
             return host[4:]
         else:
-            return 'www.{0}'.format(host)
+            if len(host.split('.')) > 2:
+                return host
+            else:
+                return 'www.{0}'.format(host)
 
     # Handle invalid input type
     else:


### PR DESCRIPTION
The logic to skip the reversing functionality for subdomains was also
affecting domains starting with `www`. Now it correctly leaves `www`
domains alone and only skips other subdomains.