### PR TITLE
Fix #563 - Improve remote databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Fix #563 - Improve remote databases ([#573](https://github.com/roots/trellis/pull/573))
 * Fix #569 - Only skip subdomains for non-www domains ([#570](https://github.com/roots/trellis/pull/570))
 * Enable Let's Encrypt to transition http sites to https ([#565](https://github.com/roots/trellis/pull/565))
 

--- a/dev.yml
+++ b/dev.yml
@@ -10,7 +10,7 @@
     - { role: ferm, tags: [ferm] }
     - { role: ntp }
     - { role: sshd, tags: [sshd] }
-    - { role: mariadb, tags: [mariadb], when: not mysql_remote_database }
+    - { role: mariadb, tags: [mariadb] }
     - { role: ssmtp, tags: [ssmtp mail] }
     - { role: mailhog, tags: [mailhog mail] }
     - { role: php, tags: [php] }

--- a/group_vars/all/database.yml
+++ b/group_vars/all/database.yml
@@ -1,3 +1,0 @@
-mariadb_dist: trusty
-mysql_remote_database: false
-mysql_root_user: root

--- a/roles/mariadb/defaults/main.yml
+++ b/roles/mariadb/defaults/main.yml
@@ -1,4 +1,8 @@
-keyserver_fingerprint: "0xcbcb082a1bb943db"
-mirror: nyc2.mirrors.digitalocean.com
-version: "10.0"
-binary_logging_disabled: true
+mariadb_binary_logging_disabled: true
+mariadb_keyserver_fingerprint: "0xcbcb082a1bb943db"
+mariadb_mirror: nyc2.mirrors.digitalocean.com
+mariadb_version: "10.0"
+mariadb_dist: trusty
+mysql_root_user: root
+
+sites_using_remote_db: "[{% for name, site in wordpress_sites.iteritems() if site.env is defined and site.env.db_host | default('localhost') != 'localhost' %}'{{ name }}',{% endfor %}]"

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add MariaDB MySQL apt-key
   apt_key:
-    url: "http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search={{ keyserver_fingerprint }}"
+    url: "http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search={{ mariadb_keyserver_fingerprint }}"
     state: present
 
 - name: Add MariaDB MySQL deb and deb-src
@@ -9,60 +9,68 @@
     repo: "{{ item }}"
     state: present
   with_items:
-  - "deb http://{{ mirror }}/mariadb/repo/{{ version }}/ubuntu {{ mariadb_dist | default(ansible_distribution_release) }} main"
-  - "deb-src http://{{ mirror }}/mariadb/repo/{{ version }}/ubuntu {{ mariadb_dist | default(ansible_distribution_release) }} main"
+    - "deb http://{{ mariadb_mirror }}/mariadb/repo/{{ mariadb_version }}/ubuntu {{ mariadb_dist | default(ansible_distribution_release) }} main"
+    - "deb-src http://{{ mariadb_mirror }}/mariadb/repo/{{ mariadb_version }}/ubuntu {{ mariadb_dist | default(ansible_distribution_release) }} main"
 
-- name: Install MariaDB MySQL server
+- name: Install MySQL client
   apt:
-    name: mariadb-server
+    name: mariadb-client
     state: present
 
-- name: Disable MariaDB binary logging
-  template:
-    src: disable-binary-logging.cnf
-    dest: /etc/mysql/conf.d
-    owner: root
-    group: root
-  when: binary_logging_disabled
+- block:
+  - name: Install MariaDB MySQL server
+    apt:
+      name: mariadb-server
+      state: present
 
-- name: Restart MariaDB MySQL Server
-  service:
-    name: mysql
-    state: restarted
-    enabled: true
+  - name: Disable MariaDB binary logging
+    template:
+      src: disable-binary-logging.cnf
+      dest: /etc/mysql/conf.d
+      owner: root
+      group: root
+    when: mariadb_binary_logging_disabled
 
-- name: Set root user password
-  mysql_user:
-    name: root
-    host: "{{ item }}"
-    password: "{{ mysql_root_password }}"
-    check_implicit_admin: yes
-    state: present
-  with_items:
-    - "{{ inventory_hostname }}"
-    - 127.0.0.1
-    - ::1
-    - localhost
+  - name: Restart MariaDB MySQL Server
+    service:
+      name: mysql
+      state: restarted
+      enabled: true
 
-- name: Copy .my.cnf file with root password credentials.
-  template:
-    src: my.cnf.j2
-    dest: ~/.my.cnf
-    owner: root
-    group: root
-    mode: 0600
+  - name: Set root user password
+    mysql_user:
+      name: root
+      host: "{{ item }}"
+      password: "{{ mysql_root_password }}"
+      check_implicit_admin: yes
+      state: present
+    with_items:
+      - "{{ inventory_hostname }}"
+      - 127.0.0.1
+      - ::1
+      - localhost
 
-- name: Delete anonymous MySQL server users
-  mysql_user:
-    user: ""
-    host: "{{ item }}"
-    state: absent
-  with_items:
-    - localhost
-    - "{{ inventory_hostname }}"
-    - "{{ ansible_hostname }}"
+  - name: Copy .my.cnf file with root password credentials.
+    template:
+      src: my.cnf.j2
+      dest: ~/.my.cnf
+      owner: root
+      group: root
+      mode: 0600
 
-- name: Remove the test database
-  mysql_db:
-    name: test
-    state: absent
+  - name: Delete anonymous MySQL server users
+    mysql_user:
+      user: ""
+      host: "{{ item }}"
+      state: absent
+    with_items:
+      - localhost
+      - "{{ inventory_hostname }}"
+      - "{{ ansible_hostname }}"
+
+  - name: Remove the test database
+    mysql_db:
+      name: test
+      state: absent
+
+  when: not sites_using_remote_db | count

--- a/roles/wordpress-setup/defaults/main.yml
+++ b/roles/wordpress-setup/defaults/main.yml
@@ -1,0 +1,1 @@
+site_uses_local_db: "{{ site_env.db_host == 'localhost' }}"

--- a/roles/wordpress-setup/tasks/database.yml
+++ b/roles/wordpress-setup/tasks/database.yml
@@ -7,7 +7,7 @@
     login_user: "{{ mysql_root_user }}"
     login_password: "{{ mysql_root_password }}"
   with_dict: "{{ wordpress_sites }}"
-  when: not mysql_remote_database and item.value.db_create | default(True)
+  when: site_uses_local_db and item.value.db_create | default(True)
 
 - name: Create/assign database user to db and grant permissions
   mysql_user:
@@ -20,7 +20,7 @@
     login_user: "{{ mysql_root_user }}"
     login_password: "{{ mysql_root_password }}"
   with_dict: "{{ wordpress_sites }}"
-  when: not mysql_remote_database and item.value.db_create | default(True)
+  when: site_uses_local_db and item.value.db_create | default(True)
 
 - name: Copy database dump
   copy:

--- a/server.yml
+++ b/server.yml
@@ -20,7 +20,7 @@
     - { role: ntp, tags: [ntp] }
     - { role: users, tags: [users] }
     - { role: sshd, tags: [sshd] }
-    - { role: mariadb, tags: [mariadb], when: not mysql_remote_database }
+    - { role: mariadb, tags: [mariadb] }
     - { role: ssmtp, tags: [ssmtp, mail] }
     - { role: php, tags: [php] }
     - { role: memcached, tags: [memcached] }


### PR DESCRIPTION
Previously you had to manually toggle the remote database option via
`mysql_remote_database` (which also didn't fully work).

Now Trellis automatically detects if the sites are using a remote
`db_host` or not (aka not `localhost`) and handles things accordingly.

This also installs the mysql-client now regardless.