### PR TITLE
Wrap my.cnf password in quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Wrap my.cnf password in quotes ([#577](https://github.com/roots/trellis/pull/577))
 * Update to WP-CLI v0.23.1 ([#576](https://github.com/roots/trellis/pull/576))
 * Fix #563 - Improve remote databases ([#573](https://github.com/roots/trellis/pull/573))
 * Fix #569 - Only skip subdomains for non-www domains ([#570](https://github.com/roots/trellis/pull/570))

--- a/roles/mariadb/templates/disable-binary-logging.cnf
+++ b/roles/mariadb/templates/disable-binary-logging.cnf
@@ -1,2 +1,4 @@
+# {{ ansible_managed }}
+
 [mysqld]
 skip-log-bin

--- a/roles/mariadb/templates/my.cnf.j2
+++ b/roles/mariadb/templates/my.cnf.j2
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+
 [client]
 user=root
-password={{ mysql_root_password }}
+password="{{ mysql_root_password }}"


### PR DESCRIPTION
Randomly generated passwords can contain certain characters
(such as `=`) which cause problems when not within quotes.