### PR TITLE
Add connection-related cli options to ping command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Add connection-related cli options to ping command ([#578](https://github.com/roots/trellis/pull/578))
 * Wrap my.cnf password in quotes ([#577](https://github.com/roots/trellis/pull/577))
 * Update to WP-CLI v0.23.1 ([#576](https://github.com/roots/trellis/pull/576))
 * Fix #563 - Improve remote databases ([#573](https://github.com/roots/trellis/pull/573))

--- a/lib/trellis/plugins/vars/vars.py
+++ b/lib/trellis/plugins/vars/vars.py
@@ -7,8 +7,9 @@ from ansible.errors import AnsibleError
 if __version__.startswith('1'):
     raise AnsibleError('Trellis no longer supports Ansible 1.x. Please upgrade to Ansible 2.x.')
 
-# This import will produce Traceback in Ansible 1.x, so place after version check
+# These imports will produce Traceback in Ansible 1.x, so place after version check
 from __main__ import cli
+from ansible.compat.six import iteritems
 
 
 class VarsModule(object):
@@ -28,15 +29,38 @@ class VarsModule(object):
                         hostvars['vault_wordpress_sites'][name]['env'][key] = ''.join(['{% raw %}', value, '{% endraw %}'])
             host.vars['vault_wordpress_sites'] = hostvars['vault_wordpress_sites']
 
-    def cli_args_vault(self):
-        if self._options.ask_vault_pass:
-            return '--ask-vault-pass'
-        elif self._options.vault_password_file:
-            return '--vault-password-file {0}'.format(self._options.vault_password_file)
-        else:
-            return ''
+    def cli_options_ping(self):
+        options = []
+
+        remote_user = getattr(self._options, 'remote_user')
+        options.append("--user='{0}'".format(remote_user if remote_user else 'root'))
+
+        strings = {
+            '--connection': 'connection',
+            '--inventory-file': 'inventory',
+            '--private-key': 'private_key_file',
+            '--ssh-common-args': 'ssh_common_args',
+            '--ssh-extra-args': 'ssh_extra_args',
+            '--timeout': 'timeout',
+            '--vault-password-file': 'vault_password_file',
+            }
+
+        for option,value in strings.iteritems():
+            if getattr(self._options, value, False):
+                options.append("{0}='{1}'".format(option, str(getattr(self._options, value))))
+
+        booleans = {
+            '--ask-pass': 'ask_pass',
+            '--ask-vault-pass': 'ask_vault_pass',
+            }
+
+        for option,value in booleans.iteritems():
+            if getattr(self._options, value, False):
+                options.append(option)
+
+        return ' '.join(options)
 
     def get_host_vars(self, host, vault_password=None):
         self.wrap_salts_in_raw(host, host.get_group_vars())
-        host.vars['cli_args_vault'] = self.cli_args_vault()
+        host.vars['cli_options_ping'] = self.cli_options_ping()
         return {}

--- a/roles/remote-user/tasks/main.yml
+++ b/roles/remote-user/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
 - name: Determine whether to connect as root or admin_user
-  local_action: command ansible {{ inventory_hostname }} -m ping{{ (inventory_file == None) | ternary('', ' -i ' + inventory_file | string) }} -u root {{ cli_args_vault | default('') }}
+  local_action: command ansible {{ inventory_hostname }} -m ping {{ cli_options_ping }}
   failed_when: false
   changed_when: false
   register: root_status
 
 - name: Set remote user for each host
   set_fact:
-    ansible_ssh_user: "{{ root_status | success | ternary('root', admin_user) }}"
+    ansible_user: "{{ root_status | success | ternary('root', admin_user) }}"
 
 - name: Announce which user was selected
   debug:
-    msg: "Note: Ansible will attempt connections as user = {{ ansible_ssh_user }}"
+    msg: "Note: Ansible will attempt connections as user = {{ ansible_user }}"


### PR DESCRIPTION
The `remote-user` role's `ping` command tests the connection for the `root` user. Some `ping` history:
- #470 enabled `--inventory` option passed to `ansible-playbook` command to carry over to `ping`.
- #564 enabled vault cli args passed to `ansible-playbook` command to carry over to `ping`.
- #574 raised question of carrying `--ask-pass` over to `ping`, if present.

This PR implements a unified approach to collecting the connection-related cli options passed to the `ansible-playbook` command, carrying the options over to the `ping` command. This includes the options in the bullets above, and a few additional connection-related options (selected from the list displayed if you run `ansible-playbook` with no args or options).