### PR TITLE
Pass cli options to user role's admin_user ping test

### DIFF
--- a/lib/trellis/plugins/vars/vars.py
+++ b/lib/trellis/plugins/vars/vars.py
@@ -32,9 +32,6 @@ class VarsModule(object):
     def cli_options_ping(self):
         options = []
 
-        remote_user = getattr(self._options, 'remote_user')
-        options.append("--user='{0}'".format(remote_user if remote_user else 'root'))
-
         strings = {
             '--connection': 'connection',
             '--inventory-file': 'inventory',

--- a/roles/remote-user/tasks/main.yml
+++ b/roles/remote-user/tasks/main.yml
@@ -1,13 +1,13 @@
 ---
 - name: Determine whether to connect as root or admin_user
-  local_action: command ansible {{ inventory_hostname }} -m ping {{ cli_options_ping }}
+  local_action: command ansible {{ inventory_hostname }} -m ping -u {{ ansible_user | default('root') }} {{ cli_options_ping | default('') }}
   failed_when: false
   changed_when: false
   register: root_status
 
 - name: Set remote user for each host
   set_fact:
-    ansible_user: "{{ root_status | success | ternary('root', admin_user) }}"
+    ansible_user: "{{ root_status | success | ternary(ansible_user | default('root'), admin_user) }}"
 
 - name: Announce which user was selected
   debug:

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -51,7 +51,7 @@
     - keys
 
 - name: Check whether Ansible can connect as admin_user
-  local_action: command ansible {{ inventory_hostname }} -m ping{{ (inventory_file == None) | ternary('', ' -i ' + inventory_file | string) }} -u {{ admin_user }}
+  local_action: command ansible {{ inventory_hostname }} -m ping -u {{ admin_user }} {{ cli_options_ping | default('') }}
   failed_when: false
   changed_when: false
   become: no


### PR DESCRIPTION
When #578 added connection-related CLI options to the `remote-user` role's `ping` command, it probably should have also updated the `users` role's `ping` command (introduced in #345). Here is a [discourse thread](https://discourse.roots.io/t/disabling-root-login-while-using-ask-vault-pass-error-decryption-failed/6655) demonstrating the need for this fix.

This PR:
- applies #578's `cli_options_ping` to the `users` role
- removes `--user` from `cli_options_ping`, adjusting each task to specify user explicitly, given that the two different ping tests rely on different users
- adds a default for the `cli_options_ping` variable as a safety in case [`vars_plugins`](https://github.com/roots/trellis/blob/472ce5c91c0ee5da3d295b1d830281500b7be590/ansible.cfg#L11) ever happened to be disabled, in which case the var would be undefined