### PR TITLE
Fix #581 - Use WP-CLI to run WP cron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Fix #581 - Use WP-CLI to run WP cron ([#583](https://github.com/roots/trellis/pull/583))
 * Require explicit redirects and drop www_redirect ([#622](https://github.com/roots/trellis/pull/622))
 * Fix #612 - Bump nginx_fastcgi_buffer_size to `8k` ([#620](https://github.com/roots/trellis/pull/620))
 * Setup permalink structure for multisite installs too ([#617](https://github.com/roots/trellis/pull/617))

--- a/roles/wordpress-setup/tasks/main.yml
+++ b/roles/wordpress-setup/tasks/main.yml
@@ -30,7 +30,7 @@
     name: "{{ item.key }} WordPress cron"
     minute: "*/15"
     user: "{{ web_user }}"
-    job: "curl -k -s {{ site_env.wp_siteurl }}/wp-cron.php > /dev/null 2>&1"
+    job: "cd {{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }} && wp cron event run --due-now"
     cron_file: "wordpress-{{ item.key | replace('.', '_') }}"
   with_dict: "{{ wordpress_sites }}"
   when: site_env.disable_wp_cron and not item.value.multisite.enabled | default(false)

--- a/roles/wp-cli/defaults/main.yml
+++ b/roles/wp-cli/defaults/main.yml
@@ -1,4 +1,4 @@
-wp_cli_version: 0.23.1
+wp_cli_version: 0.24.0
 wp_cli_bin_path: /usr/bin/wp
 wp_cli_phar_url: "https://github.com/wp-cli/wp-cli/releases/download/v{{ wp_cli_version }}/wp-cli-{{ wp_cli_version }}.phar"
 wp_cli_completion_url: "https://raw.githubusercontent.com/wp-cli/wp-cli/v{{ wp_cli_version }}/utils/wp-completion.bash"

--- a/roles/wp-cli/tasks/main.yml
+++ b/roles/wp-cli/tasks/main.yml
@@ -3,6 +3,7 @@
   get_url:
     url: "{{ wp_cli_phar_url }}"
     dest: "{{ wp_cli_bin_path }}"
+    force: true
     mode: 0755
 
 - name: Retrieve WP-CLI tab completions


### PR DESCRIPTION
https://github.com/roots/trellis/pull/533 caused a regression in the cron job which runs `wp-cron.php`. Since `wp_home` and `wp_siteurl` were changed to use bash and PHP variables, the cron command wouldn't work.

The solution is to avoid this and use WP-CLI's `cron` command for running due cron events.

Note: this can't be merged yet because the `--due-now` feature is not in the last WP-CLI release so we're waiting on the next one. 