### PR TITLE
Add wildcard subdomain to https redirect block

### DIFF
--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -81,7 +81,7 @@ server {
 server {
   listen 80;
 
-  server_name {{ item.value.site_hosts | reverse_www(enabled=item.value.www_redirect | default(true)) | join(' ') }};
+  server_name {{ item.value.site_hosts | reverse_www(enabled=item.value.www_redirect | default(true)) | join(' ') }}  {% if item.value.multisite.subdomains | default(false) %} *.{{ item.value.site_hosts | join(' *.') }} {% endif %};
 
   {% if item.value.ssl.provider | default('manual') == 'letsencrypt' -%}
   include acme-challenge-location.conf;


### PR DESCRIPTION
This adds a wildcard subdomain entry for each `site_hosts` to the `server_name` https redirect block when multisite subdomains are enabled. Previously subdomains were not being automatically redirected to https.