### PR TITLE
Add nginx varible to configure fastcgi_buffer_size

### DIFF
--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -3,6 +3,7 @@ nginx_path: /etc/nginx
 nginx_logs_root: /var/log/nginx
 nginx_user: www-data
 nginx_fastcgi_buffers: 8 8k
+nginx_fastcgi_buffer_size: 8k
 nginx_ssl_path: "{{ nginx_path }}/ssl"
 
 # HSTS defaults

--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -3,7 +3,7 @@ nginx_path: /etc/nginx
 nginx_logs_root: /var/log/nginx
 nginx_user: www-data
 nginx_fastcgi_buffers: 8 8k
-nginx_fastcgi_buffer_size: 8k
+nginx_fastcgi_buffer_size: 4k
 nginx_ssl_path: "{{ nginx_path }}/ssl"
 
 # HSTS defaults

--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -37,6 +37,7 @@ http {
 
   # Setup the fastcgi cache.
   fastcgi_buffers {{ nginx_fastcgi_buffers }};
+  fastcgi_buffer_size {{ nginx_fastcgi_buffer_size }};
   fastcgi_cache_path {{ nginx_cache_path }} levels=1:2 keys_zone=wordpress:{{ nginx_cache_key_storage_size }} max_size={{ nginx_cache_size }} inactive={{ nginx_cache_inactive }};
   fastcgi_cache_use_stale updating error timeout invalid_header http_500;
   fastcgi_cache_lock on;


### PR DESCRIPTION
I needed to increase `fastcgi_buffers` and `fastcgi_buffer_size` on a site I was working on (related to PDF output generation). Since Trellis only has the former value exposed as a variable I've added the later. The default is set to `8k` which matches [nginx's default](http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_buffer_size).