### PR TITLE
Fix #589 - Support unicode hosts

### DIFF
--- a/lib/trellis/plugins/filter/filters.py
+++ b/lib/trellis/plugins/filter/filters.py
@@ -1,5 +1,5 @@
 # Make coding more python3-ish
-from __future__ import (absolute_import, division, print_function)
+from __future__ import (absolute_import, division, print_function, unicode_literals)
 __metaclass__ = type
 
 import types


### PR DESCRIPTION
Treat all string literals as unicode to support hosts/domain with
unicode characters.