### PR TITLE
Fix tags in the dev.yml.

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -11,8 +11,8 @@
     - { role: ntp }
     - { role: sshd, tags: [sshd] }
     - { role: mariadb, tags: [mariadb] }
-    - { role: ssmtp, tags: [ssmtp mail] }
-    - { role: mailhog, tags: [mailhog mail] }
+    - { role: ssmtp, tags: [ssmtp, mail] }
+    - { role: mailhog, tags: [mailhog, mail] }
     - { role: php, tags: [php] }
     - { role: memcached, tags: [memcached] }
     - { role: nginx, tags: [nginx] }


### PR DESCRIPTION
Tags for mail, mailhog and ssmtp where not delimited with a comma in
dev.yml, requiring to use something like `--tags 'mailhog mail'` in CLI.

Fixed the same way as the tags in server.yml.