### PR TITLE
Fix #468 - Use curl to install wp-cli tab completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Fix #468 - Use curl to install wp-cli tab completions ([#593](https://github.com/roots/trellis/pull/593))
 * Require Ansible 2.0.2 and remove deploy_helper ([#579](https://github.com/roots/trellis/pull/579))
 * Add connection-related cli options to ping command ([#578](https://github.com/roots/trellis/pull/578))
 * Wrap my.cnf password in quotes ([#577](https://github.com/roots/trellis/pull/577))

--- a/roles/wp-cli/defaults/main.yml
+++ b/roles/wp-cli/defaults/main.yml
@@ -1,4 +1,5 @@
+wp_cli_version: 0.23.1
 wp_cli_bin_path: /usr/bin/wp
-wp_cli_phar_url: "https://github.com/wp-cli/wp-cli/releases/download/v0.23.1/wp-cli-0.23.1.phar"
-wp_cli_completion_url: "https://raw.githubusercontent.com/wp-cli/wp-cli/master/utils/wp-completion.bash"
-wp_cli_completion_path: /etc/bash_completion.d
+wp_cli_phar_url: "https://github.com/wp-cli/wp-cli/releases/download/v{{ wp_cli_version }}/wp-cli-{{ wp_cli_version }}.phar"
+wp_cli_completion_url: "https://raw.githubusercontent.com/wp-cli/wp-cli/v{{ wp_cli_version }}/utils/wp-completion.bash"
+wp_cli_completion_path: /etc/bash_completion.d/wp-completion.bash

--- a/roles/wp-cli/tasks/main.yml
+++ b/roles/wp-cli/tasks/main.yml
@@ -5,8 +5,15 @@
     dest: "{{ wp_cli_bin_path }}"
     mode: 0755
 
+- name: Retrieve WP-CLI tab completions
+  command: curl -4Ls {{ wp_cli_completion_url }} -o /tmp/wp-completion-{{ wp_cli_version }}.bash
+  args:
+    creates: /tmp/wp-completion-{{ wp_cli_version }}.bash
+    warn: false
+
 - name: Install WP-CLI tab completions
-  get_url:
-    url: "{{ wp_cli_completion_url }}"
-    dest: "{{ wp_cli_completion_path }}"
-    mode: 0644
+  command: rsync -c --chmod=0644 --info=name /tmp/wp-completion-{{ wp_cli_version }}.bash {{ wp_cli_completion_path }}
+  args:
+    warn: false
+  register: wp_cli_completion
+  changed_when: wp_cli_completion.stdout == "wp-completion-{{ wp_cli_version }}.bash"


### PR DESCRIPTION
### Background

As reported in #468, `get_url` occasionally fails to connect to the `raw.githubusercontent.com` domain to download the wp-cli tab completions (from the Vagrant VM only, in my experience). When the connection fails under certain [conditions](https://github.com/ansible/ansible/blob/5a3493be5f1f9e6652464b927bbccd01ce98a53a/lib/ansible/module_utils/urls.py#L517), Ansible's fail output mentions the possibility that if the _managed_ machine is running python < 2.7.9, its `urllib` may be failing to apply [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication) to the cert request and validation. Although that is a good lead to eliminate, because the current default Ubuntu/Trusty64 box for Vagrant and DigitalOcean uses python 2.7.6, SNI appears unnecessary and irrelevant in the current case.

In contrast to the [`downloads.jetbrains.com` example](https://github.com/ansible/ansible/issues/11579#issuecomment-121775819), the GitHub servers appear to not need clients to apply SNI to connection requests to `raw.githubusercontent.com`. The servers return the same appropriate cert whether or not a client's request indicates `servername` to apply SNI:

```bash
# with SNI via `servername`
$ openssl s_client -connect raw.githubusercontent.com:443 -servername raw.githubusercontent.com | openssl x509 -noout -text

Certificate:
        Serial Number:
            07:7a:5d:c3:36:23:01:f9:89:fe:54:f7:f8:6f:3e:64
        Subject: C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=www.github.com
            X509v3 Subject Alternative Name:
                DNS:www.github.com ... DNS:*.githubusercontent.com ...


# without SNI (omitting `servername`)
$ openssl s_client -connect raw.githubusercontent.com:443 | openssl x509 -noout -text

Certificate:
        Serial Number:
            07:7a:5d:c3:36:23:01:f9:89:fe:54:f7:f8:6f:3e:64
        Subject: C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=www.github.com
            X509v3 Subject Alternative Name:
                DNS:www.github.com ... DNS:*.githubusercontent.com ...
```

I believe there is simply an intermittent connectivity problem with GitHub, perhaps due to some kind of rate limiting. For example, the `openssl s_client -connect` request above will be rejected after a few quick repetitions. Similarly, multiple `curl` requests occasionally produce the `curl: (35) Server aborted the SSL handshake` we saw with `curl` in #434.

### This PR

This PR switches the connection to `command: curl` because I found it to be more reliable than `get_url`. It also caches a versioned file to use on future provisions in order to avoid failure-prone connection attempts to GitHub.

### Implementation details

By pulling the file from the cache using `rsync` rather than `command: cp ...`, the task is idempotent, only updating the file if ever it changes. Trellis uses this technique already in [`Copy .env file into web root`](https://github.com/roots/trellis/blob/2e36598dc2c0723f1105b3a0ca9620b412236d59/roles/wordpress-install/tasks/main.yml#L14-L17) (discussed in [#268](https://github.com/roots/trellis/pull/268#issuecomment-119903331)).

In contrast, `command: cp ... creates=wp-completion.bash` would skip if ever the file already exists, failing to update to new future versions. This may be an argument for updating Trellis instances of `command: cp ...` to `rsync`. For example, the nginx confs ([one](https://github.com/roots/trellis/blob/2e36598dc2c0723f1105b3a0ca9620b412236d59/roles/nginx/tasks/main.yml#L35) and [two](https://github.com/roots/trellis/blob/2e36598dc2c0723f1105b3a0ca9620b412236d59/roles/nginx/tasks/main.yml#L52)) will not be updated when the [version](https://github.com/roots/trellis/blob/2e36598dc2c0723f1105b3a0ca9620b412236d59/roles/nginx/tasks/main.yml#L31) changes.

Another difference with those nginx config tasks is that this uses `curl` to retrieve a single file, whereas the nginx tasks use the `git` module and all the [stuff it does](https://github.com/ansible/ansible-modules-core/blob/devel/source_control/git.py) that seems unnecessary for our purposes here.

The `curl` seemed to have fewer connection problems when I added [`-4`](http://manpages.ubuntu.com/manpages/trusty/en/man1/curl.1.html) to tell `curl` to resolve names to IPv4 addresses ([corroboration](http://blogs.agilefaqs.com/2013/11/25/curl-35-unknown-ssl-protocol-error-in-connection/)).

### Other notes

Note that although it would be natural to think that the `get_url` in the preceding [`Install WP-CLI` task](https://github.com/roots/trellis/blob/2e36598dc2c0723f1105b3a0ca9620b412236d59/roles/wp-cli/tasks/main.yml#L2-L6) would also have the same problem connecting to `https://github.com/wp-cli/wp-cli/releases`, this path actually forwards over to `https://github-cloud.s3.amazonaws.com/releases/` as thus doesn't appear to have the same connectivity problems.

When the `curl` runs, we'll get `[WARNING]: Consider using get_url module rather than running curl` but we considered it, tried it even, and had to abandon it because it was failing us.

The `command: rsync` will yield `[WARNING]: Consider using synchronize module rather than running rsync` but we considered it and Ansible's synchronize module only syncs files from control machine to managed machine, and we a file synced entirely within the managed machine.