### PR TITLE
Update contributing guidelines link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ A base Ubuntu 14.04 server is required for setting up remote servers.
 
 ## Contributing
 
-Contributions are welcome from everyone. We have [contributing guidelines](CONTRIBUTING.md) to help you get started.
+Contributions are welcome from everyone. We have [contributing guidelines](https://github.com/roots/guidelines/blob/master/CONTRIBUTING.md) to help you get started.
 
 ## Community
 


### PR DESCRIPTION
This link used to point to `./CONTRIBUTING.md` which has now been moved to `.github/CONTRIBUTING.md` and so I've updated it to the one in the roots/guidelines repo, like the Sage readme does.