### PR TITLE
Switch to ondrej/nginx PPA for ALPN support

### DIFF
--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -1,12 +1,18 @@
 ---
 - name: Add Nginx PPA
   apt_repository:
-    repo: "ppa:nginx/development"
+    repo: "ppa:ondrej/nginx"
     update_cache: yes
 
 - name: Install Nginx
   apt:
     name: nginx
+    state: present
+    force: yes
+
+- name: Install Open SSL
+  apt:
+    name: openssl=1.0.2h-1+deb.sury.org~trusty+1
     state: present
     force: yes
 


### PR DESCRIPTION
Chrome 51 and newer only support ALPN. This is a negotiation protocol
that HTTP/2 uses. To support ALPN, you need OpenSSL 1.0.2+.

Ubuntu 14.04 unfortunately stops at OpenSSL 1.0.1 so we need to use a
custom PPA in order to support this.