### PR TITLE
Proper capitalization of includeSubDomains token

### DIFF
--- a/roles/wordpress-setup/templates/https.conf.j2
+++ b/roles/wordpress-setup/templates/https.conf.j2
@@ -5,7 +5,7 @@ ssl_dhparam /etc/nginx/ssl/dhparams.pem;
 ssl_buffer_size 1400; # 1400 bytes to fit in one MTU
 
 {% set hsts_max_age = item.value.ssl.hsts_max_age | default(nginx_hsts_max_age) %}
-{% set hsts_include_subdomains = item.value.ssl.hsts_include_subdomains | default(nginx_hsts_include_subdomains) | ternary('includeSubdomains', None) %}
+{% set hsts_include_subdomains = item.value.ssl.hsts_include_subdomains | default(nginx_hsts_include_subdomains) | ternary('includeSubDomains', None) %}
 {% set hsts_preload = item.value.ssl.hsts_preload | default(nginx_hsts_preload) | ternary('preload', None) %}
 add_header Strict-Transport-Security "max-age={{ [hsts_max_age, hsts_include_subdomains, hsts_preload] | reject('none') | join('; ') }}";
 


### PR DESCRIPTION
Upon submitting my domain for preload, I received this warning:

**Warning: Non-standard capitalization of includeSubDomains**
Header contains the token `includeSubdomains`. The recommended capitalization is `includeSubDomains`.

Just a quick fix to meet the recommended capitalization.