### PR TITLE
Vagrant post up message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Add Vagrant post up message ([#602](https://github.com/roots/trellis/pull/602))
 * Fix #468 - Use curl to install wp-cli tab completions ([#593](https://github.com/roots/trellis/pull/593))
 * Require Ansible 2.0.2 and remove deploy_helper ([#579](https://github.com/roots/trellis/pull/579))
 * Add connection-related cli options to ping command ([#578](https://github.com/roots/trellis/pull/578))

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -40,6 +40,8 @@ Vagrant.configure('2') do |config|
   config.vm.box = 'ubuntu/trusty64'
   config.ssh.forward_agent = true
 
+  config.vm.post_up_message = post_up_message
+
   # Fix for: "stdin: is not a tty"
   # https://github.com/mitchellh/vagrant/issues/1673#issuecomment-28288042
   config.ssh.shell = %{bash -c 'BASH_ENV=/etc/profile exec bash'}
@@ -134,6 +136,15 @@ end
 
 def nfs_path(site_name)
   "/vagrant-nfs-#{site_name}"
+end
+
+def post_up_message
+  msg = 'Your Trellis Vagrant box is ready to use!'
+  msg << "\n* Composer and WP-CLI commands need to be run on the virtual machine."
+  msg << "\n* You can SSH into the machine with `vagrant ssh`."
+  msg << "\n* Then navigate to your WordPress sites at `/srv/www`."
+
+  msg
 end
 
 def remote_site_path(site_name)


### PR DESCRIPTION
https://github.com/roots/trellis/pull/584 had issues because we can't reliably know the state of WP sites on the VM. So this is a simplified post up message.