### PR TITLE
Use admin_email as default admin_user instead of "admin"

### DIFF
--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -29,7 +29,7 @@
            --allow-root
            --url="{{ site_env.wp_home }}"
            --title="{{ item.value.site_title | default(item.key) }}"
-           --admin_user="{{ item.value.admin_user | default('admin') }}"
+           --admin_user="{{ item.value.admin_user | default(item.value.admin_email) }}"
            --admin_password="{{ vault_wordpress_sites[item.key].admin_password }}"
            --admin_email="{{ item.value.admin_email }}"
   args:
@@ -53,7 +53,7 @@
            --base="{{ item.value.multisite.base_path | default('/') }}"
            --subdomains="{{ item.value.multisite.subdomains | default('false') }}"
            --title="{{ item.value.site_title | default(item.key) }}"
-           --admin_user="{{ item.value.admin_user | default('admin') }}"
+           --admin_user="{{ item.value.admin_user | default(item.value.admin_email) }}"
            --admin_password="{{ vault_wordpress_sites[item.key].admin_password }}"
            --admin_email="{{ item.value.admin_email }}"
   args:


### PR DESCRIPTION
Use `admin_email` as default `admin_user` instead of "admin"
