### PR TITLE
Update per-item callback names for Ansible 2.0.2.0

### DIFF
--- a/lib/trellis/plugins/callback/output.py
+++ b/lib/trellis/plugins/callback/output.py
@@ -63,18 +63,18 @@ class CallbackModule(CallbackModule_default):
         if 'vagrant_version' in play_vars:
             self.vagrant_version = play_vars['vagrant_version']
 
-    def v2_playbook_item_on_ok(self, result):
+    def v2_runner_item_on_ok(self, result):
         output.display_item(self, result)
         output.replace_item_with_key(self, result)
-        super(CallbackModule, self).v2_playbook_item_on_ok(result)
+        super(CallbackModule, self).v2_runner_item_on_ok(result)
 
-    def v2_playbook_item_on_failed(self, result):
+    def v2_runner_item_on_failed(self, result):
         self.task_failed = True
         output.display_item(self, result)
         output.replace_item_with_key(self, result)
-        super(CallbackModule, self).v2_playbook_item_on_failed(result)
+        super(CallbackModule, self).v2_runner_item_on_failed(result)
 
-    def v2_playbook_item_on_skipped(self, result):
+    def v2_runner_item_on_skipped(self, result):
         output.display_item(self, result)
         output.replace_item_with_key(self, result)
-        super(CallbackModule, self).v2_playbook_item_on_skipped(result)
+        super(CallbackModule, self).v2_runner_item_on_skipped(result)


### PR DESCRIPTION
This PR updates the Trellis output plugin to use the [callback names modified in Ansible 2.0.2.0](https://github.com/ansible/ansible/commit/9d46a16f3f38819d3c567cea119dc85d0da7618e#diff-ab09fa2a9291a017c38c5db420d7ee0fL323).

Otherwise textwrap will not be applied to the `msg` in tasks that use `with_items`.