### PR TITLE
Support complex Ansible version comparisons

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,2 +1,7 @@
-minimum_ansible_version: 2.0.2.0
+ansible_requirements:
+  - version: 2.0.2.0
+    operator: '>='
+  - version: 2.1.0.0
+    operator: '!='
+
 default_timezone: Etc/UTC

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,10 +1,13 @@
 ---
 - name: Validate Ansible version
-  assert:
-    that:
-     - "{{ ansible_version is defined }}"
-     - "{{ ansible_version.full | version_compare(minimum_ansible_version, '>=') }}"
-    msg: "Your Ansible version is too old. Trellis requires at least {{ minimum_ansible_version }}. Your version is {{ ansible_version.full | default('< 1.6') }}"
+  fail:
+    msg: |
+      Your Ansible version is {{ ansible_version.full | default('unknown') }}.
+      Please install a version of Ansible that meets these requirements:
+      {% for item in ansible_requirements %}
+        {{ item.operator }} {{ item.version }}
+      {% endfor %}
+  when: ansible_version is not defined or false in [{% for item in ansible_requirements %}{{ ansible_version.full | version_compare(item.version, item.operator) }},{% endfor %}]
   run_once: true
 
 - name: Update Apt


### PR DESCRIPTION
Example output:
```
TASK [common : Validate Ansible version] ***************************************
System info:
  Ansible 2.1.0.0; Darwin
  Trellis at "Add Vagrant post up message"
---------------------------------------------------
Your Ansible version is 2.1.0.0.
Please install a version of Ansible that meets these requirements:
  >= 2.0.2.0
  != 2.1.0.0

fatal: [xxx.xxx.xxx.xxx]: FAILED! => {"changed": false, "failed": true}
```

edit: ref for [version comparison filters](http://docs.ansible.com/ansible/playbooks_filters.html#version-comparison-filters)