### PR TITLE
Support SSH password authentication

### DIFF
--- a/lib/trellis/plugins/vars/vars.py
+++ b/lib/trellis/plugins/vars/vars.py
@@ -29,7 +29,7 @@ class VarsModule(object):
                         hostvars['vault_wordpress_sites'][name]['env'][key] = ''.join(['{% raw %}', value, '{% endraw %}'])
             host.vars['vault_wordpress_sites'] = hostvars['vault_wordpress_sites']
 
-    def cli_options_ping(self):
+    def cli_options(self):
         options = []
 
         strings = {
@@ -59,5 +59,5 @@ class VarsModule(object):
 
     def get_host_vars(self, host, vault_password=None):
         self.wrap_salts_in_raw(host, host.get_group_vars())
-        host.vars['cli_options_ping'] = self.cli_options_ping()
+        host.vars['cli_options'] = self.cli_options()
         return {}

--- a/lib/trellis/plugins/vars/vars.py
+++ b/lib/trellis/plugins/vars/vars.py
@@ -46,18 +46,13 @@ class VarsModule(object):
             if getattr(self._options, value, False):
                 options.append("{0}='{1}'".format(option, str(getattr(self._options, value))))
 
-        booleans = {
-            '--ask-pass': 'ask_pass',
-            '--ask-vault-pass': 'ask_vault_pass',
-            }
-
-        for option,value in booleans.iteritems():
-            if getattr(self._options, value, False):
-                options.append(option)
+        if getattr(self._options, 'ask_vault_pass', False):
+            options.append('--ask-vault-pass')
 
         return ' '.join(options)
 
     def get_host_vars(self, host, vault_password=None):
         self.wrap_salts_in_raw(host, host.get_group_vars())
         host.vars['cli_options'] = self.cli_options()
+        host.vars['cli_ask_pass'] = getattr(self._options, 'ask_pass', False)
         return {}

--- a/roles/remote-user/tasks/main.yml
+++ b/roles/remote-user/tasks/main.yml
@@ -1,13 +1,23 @@
 ---
-- name: Determine whether to connect as root or admin_user
-  local_action: command ansible {{ inventory_hostname }} -m ping -u {{ ansible_user | default('root') }} {{ cli_options | default('') }}
-  failed_when: false
-  changed_when: false
-  register: root_status
+- block:
+  - name: Require manual definition of remote-user
+    fail:
+      msg: |
+        When using `--ask-pass` option, use `-u` option to define remote-user:
+        ansible-playbook server.yml -e env={{ env }} -u root --ask-pass
+    when: cli_ask_pass | default(false)
 
-- name: Set remote user for each host
-  set_fact:
-    ansible_user: "{{ root_status | success | ternary(ansible_user | default('root'), admin_user) }}"
+  - name: Check whether Ansible can connect as root
+    local_action: command ansible {{ inventory_hostname }} -m ping -u root {{ cli_options | default('') }}
+    failed_when: false
+    changed_when: false
+    register: root_status
+
+  - name: Set remote user for each host
+    set_fact:
+      ansible_user: "{{ root_status | success | ternary('root', admin_user) }}"
+
+  when: ansible_user is not defined
 
 - name: Announce which user was selected
   debug:

--- a/roles/remote-user/tasks/main.yml
+++ b/roles/remote-user/tasks/main.yml
@@ -12,10 +12,11 @@
     failed_when: false
     changed_when: false
     register: root_status
+    tags: [connection-tests]
 
   - name: Set remote user for each host
     set_fact:
-      ansible_user: "{{ root_status | success | ternary('root', admin_user) }}"
+      ansible_user: "{{ root_status | default({'failed':false}) | success | ternary('root', admin_user) }}"
 
   when: ansible_user is not defined
 

--- a/roles/remote-user/tasks/main.yml
+++ b/roles/remote-user/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Determine whether to connect as root or admin_user
-  local_action: command ansible {{ inventory_hostname }} -m ping -u {{ ansible_user | default('root') }} {{ cli_options_ping | default('') }}
+  local_action: command ansible {{ inventory_hostname }} -m ping -u {{ ansible_user | default('root') }} {{ cli_options | default('') }}
   failed_when: false
   changed_when: false
   register: root_status

--- a/roles/users/tasks/connection-warnings.yml
+++ b/roles/users/tasks/connection-warnings.yml
@@ -1,0 +1,40 @@
+---
+- name: Fail if root login will be disabled but admin_user cannot connect
+  fail:
+    msg: 'The admin_user `{{ admin_user }}` is unable to connect to the server. To prevent you from losing access to your server, the playbook has halted before disabling root login (`sshd_permit_root_login: false`). Ensure that the admin_user appears in your `users` hash with a valid entry for `keys`.'
+  when: not cli_ask_pass | default(false) and ansible_user == 'root'
+
+- block:
+  - name: Confirm that a non-root user can connect
+    pause:
+      prompt: |
+
+        The play will disable SSH login for `root` (because `sshd_permit_root_login: false`)
+        but the admin_user named `{{ admin_user }}` appears unable to connect via SSH key.
+
+        Be careful to avoid losing SSH access to your server.
+        Continue only if `{{ admin_user }}` will be able to connect via password or if
+        a different user will be able to connect and invoke sudo.
+
+        (press RETURN to continue or CTRL+C to abort)
+    when: not sshd_permit_root_login and ansible_user == 'root'
+
+  - name: Confirm disabling of SSH password authentication
+    pause:
+      prompt: |
+
+        The play will disable password login (because `sshd_password_authentication: false`)
+        but the admin_user named `{{ admin_user }}` appears unable to connect via SSH key.
+
+        Be careful to avoid losing SSH access to your server.
+        Continue only if you are certain you will have another means of connecting,
+        such as via SSH keys.
+
+        If you prefer to continue to allow SSH password authentication (less secure),
+        abort now and make the following edit in `group_vars/all/security.yml`:
+        `sshd_password_authentication: true`
+
+        (press RETURN to continue or CTRL+C to abort)
+    when: not sshd_password_authentication
+
+  when: cli_ask_pass | default(false)

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -56,9 +56,7 @@
   changed_when: false
   become: no
   register: admin_user_status
-  when: not sshd_permit_root_login
+  when: (ansible_user != admin_user and not sshd_permit_root_login) or (cli_ask_pass and not sshd_password_authentication)
 
-- name: Fail if root login will be disabled but admin_user cannot connect
-  fail:
-    msg: 'The admin_user is unable to connect to the server. To prevent you from losing access to your server, the playbook has halted before disabling root login (`sshd_permit_root_login: false`). Ensure that the admin_user appears in your `users` hash with a valid entry for `keys`.'
-  when: not sshd_permit_root_login and admin_user_status | failed
+- include: connection-warnings.yml
+  when: admin_user_status | failed

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -20,6 +20,7 @@
       - "{{ admin_user in sudoer_passwords.keys() }}"
     msg: "When `sshd_permit_root_login: false`, you must add `sudo` to the `groups` for admin_user (in `users` hash), and set a password for admin_user in `sudoer_passwords`. Otherwise Ansible could lose the ability to run the necessary sudo commands."
   when: not sshd_permit_root_login
+  tags: sshd
 
 - name: Setup users
   user:
@@ -57,6 +58,8 @@
   become: no
   register: admin_user_status
   when: (ansible_user != admin_user and not sshd_permit_root_login) or (cli_ask_pass and not sshd_password_authentication)
+  tags: [connection-tests, sshd]
 
 - include: connection-warnings.yml
   when: admin_user_status | failed
+  tags: [connection-tests, sshd]

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -51,7 +51,7 @@
     - keys
 
 - name: Check whether Ansible can connect as admin_user
-  local_action: command ansible {{ inventory_hostname }} -m ping -u {{ admin_user }} {{ cli_options_ping | default('') }}
+  local_action: command ansible {{ inventory_hostname }} -m ping -u {{ admin_user }} {{ cli_options | default('') }}
   failed_when: false
   changed_when: false
   become: no


### PR DESCRIPTION
This PR adds support for SSH password authentication via the `--ask-pass` option.
Each commit message provides relevant details.

Props to @ptibbetts for discovering in #604 that the `--ask-pass` option does not function properly in [cli_options_ping](https://github.com/roots/trellis/blob/f36bcb5f04d453421fe1b73190bd8df8092e7da8/roles/remote-user/tasks/main.yml#L3). Adjusting the `ansible.cfg` section `[ssh_connection]` to include `pipelining = False` did not resolve the error `(25, 'Inappropriate ioctl for device')` as it may have for others, nor did adjusting the `local_action` to use the `shell` or `raw` module (instead of the `command` module).