### PR TITLE
Install ansible 2.0.2 in windows via pip

### DIFF
--- a/windows.sh
+++ b/windows.sh
@@ -31,12 +31,11 @@ fi
 
 # Install Ansible and its dependencies if not installed.
 if [ ! -f /usr/bin/ansible ]; then
-  echo "Adding Ansible repository..."
-  sudo apt-add-repository -y ppa:ansible/ansible
-  echo "Updating system..."
-  sudo apt-get -y update
-  echo "Installing Ansible..."
-  sudo apt-get -y install ansible
+  echo "Installing pip..."
+  sudo sudo apt-get -y install python-pip
+  echo "Installing Ansible with pip..."
+  sudo pip install ansible=='2.0.2.0'
+  sudo pip install markupsafe
 fi
 
 if [ ! -d ${ANSIBLE_PATH}/vendor ]; then

--- a/windows.sh
+++ b/windows.sh
@@ -32,7 +32,7 @@ fi
 # Install Ansible and its dependencies if not installed.
 if [ ! -f /usr/bin/ansible ]; then
   echo "Installing pip..."
-  sudo sudo apt-get -y install python-pip
+  sudo apt-get -y install python-pip
   echo "Installing Ansible with pip..."
   sudo pip install ansible=='2.0.2.0'
   sudo pip install markupsafe


### PR DESCRIPTION
Ansible 2.1.0 has a bug, and apt cannot install 2.0.2 version that is not afected.

See: https://github.com/ansible/ansible/issues/15915
See: https://discourse.roots.io/t/taskinclude-object-has-no-attribute-has-triggered/6834/5