### PR TITLE
Add list of raw_vars whose values are auto-escaped

### DIFF
--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -17,3 +17,12 @@ wordpress_env_defaults:
   wp_siteurl: "${WP_HOME}/wp"
 
 site_env: "{{ wordpress_env_defaults | combine(item.value.env | default({}), vault_wordpress_sites[item.key].env) }}"
+
+# Values of raw_vars will be wrapped in `{% raw %}` to avoid templating problems if values include `{%` and `{{`.
+# Will recurse dicts/lists. `*` is wildcard for one or more dict keys, list indices, or strings. Example:
+#   - vault_wordpress_sites.*.*_salt    -- matches vault_wordpress_sites.example.com.env.secure_auth_salt etc.
+# Will not function for var names or topmost dict keys that contain a period ('.').
+raw_vars:
+  - vault_mail_password
+  - vault_mysql_root_password
+  - vault_wordpress_sites

--- a/lib/trellis/plugins/vars/vars.py
+++ b/lib/trellis/plugins/vars/vars.py
@@ -41,6 +41,9 @@ class VarsModule(object):
         if 'raw_vars' not in hostvars:
             return
 
+        if not isinstance(hostvars['raw_vars'], AnsibleSequence):
+            raise AnsibleError('The `raw_vars` variable must be defined as a list.')
+
         patterns = [re.sub(r'\*', '(.)*', re.sub(r'\.', '\.', var)) for var in hostvars['raw_vars'] if var.split('.')[0] in hostvars]
         keys = set(pattern.split('\.')[0] for pattern in patterns)
         for key in keys:


### PR DESCRIPTION
#548 wrapped WP salts/keys in `{% raw %}` to avoid templating failures due to values containing opening jinja delimiters `{{` and `{%`. This was not user-configurable (no easy way to opt-out of the magic) and it didn't wrap other variables likely to have randomly generated values, leaving the potential for problematic jinja delimiters.

This PR replaces the #548 method with a new list of `raw_vars` as a user-configurable method to wrap chosen variable values in `{% raw %}`.

This doesn't seem to be a very risky use of the potentially evolving Ansible plugin API. The only new API material introduced is the checking of Ansible-specific classes `AnsibleMapping`, `AnsibleSequence`, and `AnsibleUnicode` in the `raw_triage` method. These classes have [been around](https://github.com/ansible/ansible/blob/v2.0.0.0-1/lib/ansible/parsing/yaml/objects.py) all of Ansible 2.0.

-----
To see it work, pull this branch then add the vars below to the end of `group_vars/all/main.yml`:
```
simple_var: no {{ fail

complex_var:
  - name: "{{ admin_user }}"
    password: random_with_{{_jinja_delimiter
    salt: ran{%dom
    some_list:
      - no {{ fail
      - templated -> {{ admin_user }}
  - name: "{{ web_user }}"
    some_dict:
      key_1: no {% fail
      key_2: no {{ fail
      other_key: templated -> {{ web_user }}

raw_vars:
  - simple_var
  - complex_var.*.password
  - complex_var.*.salt
  - complex_var.*.some_list.0
  - complex_var.*.some_dict.key_*
```

Now add this task to the end of the `Determine Remote User` play in `server.yml`:
```
  tasks:
    - debug:
        msg: |
          {{ simple_var | to_nice_yaml }}
          {{ complex_var | to_nice_yaml }}
      tags: remote-user
```

Now run `server.yml` to print the vars, seeing that the stray jinja delimiters don't cause failures:
```
ansible-playbook server.yml -e env=production --tags remote-user
```

