### PR TITLE
Update WP Multisite Home URL after instllation

### DIFF
--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -62,3 +62,10 @@
   with_dict: "{{ wordpress_sites }}"
   when: item.value.site_install | default(true) and item.value.multisite.enabled | default(false)
   changed_when: "'The network already exists.' not in wp_install_results.stdout"
+
+- name: Update WP Multisite Home URL
+  command: wp option update home {{ site_env.wp_home }} --allow-root
+  args:
+    chdir: "{{ www_root }}/{{ item.key }}/current/"
+  with_dict: "{{ wordpress_sites }}"
+  when: item.value.site_install | default(true) and item.value.multisite.enabled | default(false)


### PR DESCRIPTION
Fixes the issue described here: https://discourse.roots.io/t/wp-multisite-primary-site-accessible-using-wp/5312

Even on a freshly provisioned box a manual multisite installation via wp-cli results in the `home` option matching `siteurl`/`wp_siteurl`.