### PR TITLE
Fix subdomain detection in reverse_www

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Fix subdomain detection in `reverse_www` filter ([#619](https://github.com/roots/trellis/pull/619))
 * Setup permalink structure for multisite installs too ([#617](https://github.com/roots/trellis/pull/617))
 * Fix `wp_home` option in Multisite after install in development ([#616](https://github.com/roots/trellis/pull/616))
 * Add `current_path` var and default to enable custom current release path ([#607](https://github.com/roots/trellis/pull/607))

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -95,7 +95,7 @@ server {
 }
 {% endif %}
 
-{% for host in item.value.site_hosts if item.value.www_redirect | default(true) %}
+{% for host in item.value.site_hosts if item.value.www_redirect | default(true) and host != host | reverse_www %}
 server {
   {% if item.value.ssl is defined and item.value.ssl.enabled | default(false) -%}
     listen 443 ssl http2;


### PR DESCRIPTION
Replaces our naive detection with querying the tldextract service.

This isn't 100% ideal since it relies on an external request which might fail. But for now it's better than trying to bundle tldextract itself in Trellis and have to maintain the TLD data list.