### PR TITLE
Fix #612 - Bump nginx_fastcgi_buffer_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Fix #612 - Bump nginx_fastcgi_buffer_size to `8k` ([#620](https://github.com/roots/trellis/pull/620))
 * Setup permalink structure for multisite installs too ([#617](https://github.com/roots/trellis/pull/617))
 * Fix `wp_home` option in Multisite after install in development ([#616](https://github.com/roots/trellis/pull/616))
 * Add `current_path` var and default to enable custom current release path ([#607](https://github.com/roots/trellis/pull/607))

--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -3,7 +3,7 @@ nginx_path: /etc/nginx
 nginx_logs_root: /var/log/nginx
 nginx_user: www-data
 nginx_fastcgi_buffers: 8 8k
-nginx_fastcgi_buffer_size: 4k
+nginx_fastcgi_buffer_size: 8k
 nginx_ssl_path: "{{ nginx_path }}/ssl"
 
 # HSTS defaults


### PR DESCRIPTION
`admin-ajax.php` apparently causes huge headers causing Nginx errors:

> upstream sent too big header while reading response header from upstream

Bumping this default value to `8k` fixes the issues.