### PR TITLE
Update acme-tiny for new Let's Encrypt agreement URL

### DIFF
--- a/roles/letsencrypt/defaults/main.yml
+++ b/roles/letsencrypt/defaults/main.yml
@@ -4,7 +4,7 @@ site_uses_letsencrypt: "{{ item.value.ssl is defined and item.value.ssl.enabled 
 sites_need_confs: "False in [{% for item in nginx_confs.results if 'stat' in item %}{{ item.stat.exists }},{% endfor %}]"
 
 acme_tiny_repo: 'https://github.com/diafygi/acme-tiny.git'
-acme_tiny_commit: '69a457269a6392ac31b629b4e103e8ea7dd282c9'
+acme_tiny_commit: '5a7b4e79bc9bd5b51739c0d8aaf644f62cc440e6'
 
 acme_tiny_software_directory: /usr/local/letsencrypt
 acme_tiny_data_directory: /var/lib/letsencrypt


### PR DESCRIPTION
Let's Encrypt appears to be rejecting old agreement URLs (diafygi/acme-tiny@ecd26b1). 

Example failure at task [`Generate the initial certificate`](https://github.com/roots/trellis/blob/aa7c0645f4e88cf0bb2717aa2d1251e463c89c3e/roles/letsencrypt/tasks/certificates.yml#L26):
`Provided agreement URL [https://letsencrypt.org/documents/LE-SA-v1.0.1-July-27-2015.pdf] does not match current agreement URL [https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf]`

This PR updates Trellis to use the latest version of `acme-tiny` with the updated agreement URL. 