### PR TITLE
Add vault_users patterns to raw_vars

### DIFF
--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -14,4 +14,6 @@ ip_whitelist:
 raw_vars:
   - vault_mail_password
   - vault_mysql_root_password
+  - vault_users.*.password
+  - vault_users.*.salt
   - vault_wordpress_sites


### PR DESCRIPTION
When the `raw_vars` (#615) PR was merged, I should have rebased the `vault_users` PR (#614) and added these `vault_users` patterns to the new `raw_vars`.

Sorry I didn't remember to do it before `vault_users` was merged. Adding the patterns here now.