### PR TITLE
Validate user salts for allowable characters

### DIFF
--- a/group_vars/all/helpers.yml
+++ b/group_vars/all/helpers.yml
@@ -11,3 +11,4 @@ site_env: "{{ wordpress_env_defaults | combine(item.value.env | default({}), vau
 site_hosts_canonical: "{{ item.value.site_hosts | map(attribute='canonical') | list }}"
 site_hosts_redirects: "{{ item.value.site_hosts | selectattr('redirects', 'defined') | sum(attribute='redirects', start=[]) | list }}"
 site_hosts: "{{ site_hosts_canonical | union(site_hosts_redirects) }}"
+users_with_invalid_salts: '{{ vault_users | default([]) | selectattr("salt", "defined") | selectattr("salt", "search", "[^\.\/a-zA-Z0-9]") | list }}'

--- a/group_vars/production/vault.yml
+++ b/group_vars/production/vault.yml
@@ -2,6 +2,7 @@
 vault_mysql_root_password: productionpw
 
 # Documentation: https://roots.io/trellis/docs/security/
+# User salts must be limited to 1-16 characters from the set ./a-zA-Z0-9
 vault_users:
   - name: "{{ admin_user }}"
     password: example_password

--- a/group_vars/staging/vault.yml
+++ b/group_vars/staging/vault.yml
@@ -2,6 +2,7 @@
 vault_mysql_root_password: stagingpw
 
 # Documentation: https://roots.io/trellis/docs/security/
+# User salts must be limited to 1-16 characters from the set ./a-zA-Z0-9
 vault_users:
   - name: "{{ admin_user }}"
     password: example_password

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -34,6 +34,11 @@
   when: ansible_distribution_release == 'trusty'
   run_once: true
 
+- name: Validate user salts
+  fail:
+    msg: "Some users (`{{ users_with_invalid_salts | map(attribute='name') | list | join('`, `') }}`) have disallowed characters in their salts. Please edit `vault_users` in `group_vars/{{ env }}/vault.yml`, limiting user salts to 1-16 characters from the set ./a-zA-Z0-9."
+  when: users_with_invalid_salts | count
+
 - name: Update Apt
   apt:
     update_cache: yes

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -32,7 +32,7 @@
     name: "{{ item.name }}"
     group: "{{ item.groups[0] }}"
     groups: "{{ item.groups | join(',') }}"
-    password: "{% for user in vault_users | default([]) if user.name == item.name and user.password is defined %}{% if loop.first %}{{ user.password | password_hash('sha512', user.salt | default(None)) }}{% endif %}{% else %}{{ None }}{% endfor %}"
+    password: "{% for user in vault_users | default([]) if user.name == item.name and user.password is defined %}{% if loop.first %}{{ user.password | password_hash('sha512', user.salt[:16] | default(None)) }}{% endif %}{% else %}{{ None }}{% endfor %}"
     state: present
     shell: /bin/bash
     update_password: always


### PR DESCRIPTION
#614 introduced ansible's [password_hash filter](http://docs.ansible.com/ansible/playbooks_filters.html#hashing-filters) to Trellis. The [filter uses either](https://github.com/ansible/ansible/blob/v2.0.2.0-1/lib/ansible/plugins/filter/core.py#L238-L241) the Python crypt function ([v2](https://docs.python.org/2/library/crypt.html) or [v3](https://docs.python.org/3/library/crypt.html#module-functions)) or [passlib.hash.sha512_crypt](https://pythonhosted.org/passlib/lib/passlib.hash.sha512_crypt.html#passlib.hash.sha512_crypt), both of which limit salts to 1-16 characters from the regexp range `[./a-zA-Z0-9]`.

Currently, if a salt has a disallowed character, the "Setup users" task fails with 
```
the field 'args' has an invalid value ([u'users']), and could not be
converted to an dict. Error was: invalid characters in sha512_crypt salt
```

Currently, if a salt has more than 16 characters, the task fails with 
```
the field 'args' has an invalid value ([u'users']), and could not be
converted to an dict. Error was: salt too large (sha512_crypt requires <= 16
chars)
```

This PR adds
- a validation step to halt and warn users about salts with disallowed characters
- a comment about character limitations next to the `vault_users` definition
- a slice to use only the first 16 characters of any `salt` (`user.salt[:16]`)