### PR TITLE
Transform vault_user salts into allowable chars

### DIFF
--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -32,7 +32,7 @@
     name: "{{ item.name }}"
     group: "{{ item.groups[0] }}"
     groups: "{{ item.groups | join(',') }}"
-    password: "{% for user in vault_users | default([]) if user.name == item.name and user.password is defined %}{% if loop.first %}{{ user.password | password_hash('sha512', user.salt | default(None)) }}{% endif %}{% else %}{{ None }}{% endfor %}"
+    password: '{% for user in vault_users | default([]) if user.name == item.name and user.password is defined %}{% if loop.first %}{{ user.password | password_hash("sha512", user.salt[:16] | default(None) | regex_replace("[^\.\/a-zA-Z0-9]", "x")) }}{% endif %}{% else %}{{ None }}{% endfor %}'
     state: present
     shell: /bin/bash
     update_password: always


### PR DESCRIPTION
Explanation in #628

Opting for this simpler solution suggested by @swalkinshaw which makes for a superior user experience. In this current implementation, the user doesn't have to do a thing.

This PR limits the salt length to the 16 character max and replaces disallowed characters with an allowable character.

This slightly limits the entropy in the password hashing, but the salts were already limited (char length and char set). The tradeoff seems worth it for the sake of not bothering the user with a failed playbook and requirement to manually edit salts down to allowable characters. 