### PR TITLE
Enable Let's Encrypt to detect updated site_hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Enable Let's Encrypt to detect updated `site_hosts` ([#630](https://github.com/roots/trellis/pull/630))
 * Add `SKIP_GALAXY` env var to skip galaxy install in Vagrant ([#734](https://github.com/roots/trellis/pull/734))
 * Avoid `loop.first` variable in conditional jinja loops ([#729](https://github.com/roots/trellis/pull/729))
 * Use dynamic `local_path` to accommodate Ansible running on VM ([#725](https://github.com/roots/trellis/pull/725))

--- a/roles/letsencrypt/defaults/main.yml
+++ b/roles/letsencrypt/defaults/main.yml
@@ -1,7 +1,7 @@
 sites_using_letsencrypt: "[{% for name, site in wordpress_sites.iteritems() if site.ssl.enabled and site.ssl.provider | default('manual') == 'letsencrypt' %}'{{ name }}',{% endfor %}]"
-letsencrypt_enabled: "{{ sites_using_letsencrypt | count > 0 }}"
+letsencrypt_enabled: "{{ sites_using_letsencrypt | count }}"
 site_uses_letsencrypt: "{{ ssl_enabled and item.value.ssl.provider | default('manual') == 'letsencrypt' }}"
-sites_need_confs: "False in [{% for item in nginx_confs.results if 'stat' in item %}{{ item.stat.exists }},{% endfor %}]"
+missing_hosts: "{{ site_uses_letsencrypt | ternary(site_hosts, []) | difference((current_hosts.results | selectattr('item.key', 'equalto', item.key) | selectattr('stdout_lines', 'defined') | sum(attribute='stdout_lines', start=[]) | map('trim') | list | join(' ')).split(' ')) }}"
 
 acme_tiny_repo: 'https://github.com/diafygi/acme-tiny.git'
 acme_tiny_commit: '5a7b4e79bc9bd5b51739c0d8aaf644f62cc440e6'

--- a/roles/letsencrypt/defaults/main.yml
+++ b/roles/letsencrypt/defaults/main.yml
@@ -2,6 +2,7 @@ sites_using_letsencrypt: "[{% for name, site in wordpress_sites.iteritems() if s
 letsencrypt_enabled: "{{ sites_using_letsencrypt | count }}"
 site_uses_letsencrypt: "{{ ssl_enabled and item.value.ssl.provider | default('manual') == 'letsencrypt' }}"
 missing_hosts: "{{ site_uses_letsencrypt | ternary(site_hosts, []) | difference((current_hosts.results | selectattr('item.key', 'equalto', item.key) | selectattr('stdout_lines', 'defined') | sum(attribute='stdout_lines', start=[]) | map('trim') | list | join(' ')).split(' ')) }}"
+letsencrypt_cert_ids: "{ {% for item in generate_cert_ids.results if not item | skipped %}'{{ item.item.key }}':'{{ item.stdout }}', {% endfor %} }"
 
 acme_tiny_repo: 'https://github.com/diafygi/acme-tiny.git'
 acme_tiny_commit: '5a7b4e79bc9bd5b51739c0d8aaf644f62cc440e6'

--- a/roles/letsencrypt/tasks/certificates.yml
+++ b/roles/letsencrypt/tasks/certificates.yml
@@ -5,7 +5,6 @@
     creates: "{{ letsencrypt_keys_dir }}/{{ item.key }}.key"
   when: site_uses_letsencrypt
   with_dict: "{{ wordpress_sites }}"
-  tags: [letsencrypt_keys]
 
 - name: Ensure correct permissions on private keys
   file:
@@ -13,21 +12,36 @@
     mode: 0600
   when: site_uses_letsencrypt
   with_dict: "{{ wordpress_sites }}"
-  tags: [letsencrypt_keys]
 
-- name: Generate CSRs
-  shell: "openssl req -new -sha256 -key '{{ letsencrypt_keys_dir }}/{{ item.key }}.key' -subj '/' -reqexts SAN -config <(cat /etc/ssl/openssl.cnf <(printf '[SAN]\nsubjectAltName=DNS:{{ site_hosts | join(',DNS:') }}')) > {{ acme_tiny_data_directory }}/csrs/{{ item.key }}.csr"
-  args:
-    executable: /bin/bash
-    creates: "{{ acme_tiny_data_directory }}/csrs/{{ item.key }}.csr"
+- name: Generate Lets Encrypt certificate IDs
+  shell: |
+    echo "{{ [site_hosts | join(' '), letsencrypt_ca, acme_tiny_commit, letsencrypt_intermediate_cert_sha256sum] | join('\n') }}" |
+    cat {{ letsencrypt_account_key }} {{ letsencrypt_keys_dir }}/{{ item.key }}.key - |
+    md5sum | cut -c -7
+  register: generate_cert_ids
+  changed_when: false
   when: site_uses_letsencrypt
   with_dict: "{{ wordpress_sites }}"
-  tags: [letsencrypt_keys]
+  tags: [wordpress, wordpress-setup]
 
-- name: Generate the initial certificate
+- name: Generate CSRs
+  shell: "openssl req -new -sha256 -key '{{ letsencrypt_keys_dir }}/{{ item.key }}.key' -subj '/' -reqexts SAN -config <(cat /etc/ssl/openssl.cnf <(printf '[SAN]\nsubjectAltName=DNS:{{ site_hosts | join(',DNS:') }}')) > {{ acme_tiny_data_directory }}/csrs/{{ item.key }}-{{ letsencrypt_cert_ids[item.key] }}.csr"
+  args:
+    executable: /bin/bash
+    creates: "{{ acme_tiny_data_directory }}/csrs/{{ item.key }}-{{ letsencrypt_cert_ids[item.key] }}.csr"
+  when: site_uses_letsencrypt
+  with_dict: "{{ wordpress_sites }}"
+
+- name: Generate certificate renewal script
+  template:
+    src: renew-certs.py
+    dest: "{{ acme_tiny_data_directory }}/renew-certs.py"
+    mode: 0700
+
+- name: Generate the certificates
   command: ./renew-certs.py
   args:
     chdir: "{{ acme_tiny_data_directory }}"
-  register: generate_initial_cert
-  changed_when: generate_initial_cert.stdout is defined and 'Created' in generate_initial_cert.stdout
+  register: generate_certs
+  changed_when: generate_certs.stdout is defined and 'Created' in generate_certs.stdout
   notify: reload nginx

--- a/roles/letsencrypt/tasks/nginx.yml
+++ b/roles/letsencrypt/tasks/nginx.yml
@@ -1,35 +1,38 @@
 ---
-- name: Check for existing Nginx conf per site
-  stat:
-    path: "{{ nginx_path }}/sites-enabled/{{ item.key }}.conf"
-  register: nginx_confs
-  when: site_uses_letsencrypt
-  with_dict: "{{ wordpress_sites }}"
-
 - name: Create Nginx conf for challenges location
   template:
     src: acme-challenge-location.conf.j2
     dest: "{{ nginx_path }}/acme-challenge-location.conf"
-  when: sites_need_confs
+
+- name: Get list of hosts in current Nginx conf
+  shell: |
+    [ ! -f {{ nginx_path }}/sites-enabled/{{ item.key }}.conf ] ||
+    sed -n -e "/listen 80/,/server_name/{s/server_name \(.*\);/\1/p}" {{ nginx_path }}/sites-enabled/{{ item.key }}.conf
+  register: current_hosts
+  changed_when: false
+  when: site_uses_letsencrypt
+  with_dict: "{{ wordpress_sites }}"
 
 - name: Create needed Nginx confs for challenges
   template:
     src: nginx-challenge-site.conf.j2
-    dest: "{{ nginx_path }}/sites-available/letsencrypt-{{ item.item.key }}.conf"
-  when: not item | skipped and not item.stat.exists
-  with_items: "{{ nginx_confs.results }}"
+    dest: "{{ nginx_path }}/sites-available/letsencrypt-{{ item.key }}.conf"
+  register: challenge_site_confs
+  when: missing_hosts | count
+  with_dict: "{{ wordpress_sites }}"
 
 - name: Enable Nginx sites
   file:
-    src: "{{ nginx_path }}/sites-available/letsencrypt-{{ item.item.key }}.conf"
-    dest: "{{ nginx_path }}/sites-enabled/letsencrypt-{{ item.item.key }}.conf"
+    src: "{{ nginx_path }}/sites-available/letsencrypt-{{ item.key }}.conf"
+    dest: "{{ nginx_path }}/sites-enabled/letsencrypt-{{ item.key }}.conf"
     state: link
-  when: not item | skipped and not item.stat.exists
-  with_items: "{{ nginx_confs.results }}"
+  register: challenge_sites_enabled
+  when: missing_hosts | count
+  with_dict: "{{ wordpress_sites }}"
   notify: disable temporary challenge sites
 
 - include: "{{ playbook_dir }}/roles/common/tasks/reload_nginx.yml"
-  when: sites_need_confs
+  when: challenge_site_confs | changed or challenge_sites_enabled | changed
 
 - name: Create test Acme Challenge file
   shell: touch {{ acme_tiny_challenges_directory }}/ping.txt

--- a/roles/letsencrypt/tasks/setup.yml
+++ b/roles/letsencrypt/tasks/setup.yml
@@ -39,12 +39,6 @@
   register: generate_account_key
   when: letsencrypt_account_key_source_content is not defined and letsencrypt_account_key_source_file is not defined
 
-- name: Generate certificate renewal script
-  template:
-    src: renew-certs.py
-    dest: "{{ acme_tiny_data_directory }}/renew-certs.py"
-    mode: 0700
-
 - name: Download intermediate certificate
   get_url:
     url: "{{ letsencrypt_intermediate_cert_url }}"

--- a/roles/letsencrypt/templates/nginx-challenge-site.conf.j2
+++ b/roles/letsencrypt/templates/nginx-challenge-site.conf.j2
@@ -1,5 +1,5 @@
 server {
   listen 80;
-  server_name{% for item in item.item.value.site_hosts %} {{ item.canonical }}{% for redirect in item.redirects | default([]) %} {{ redirect }}{% endfor %}{% endfor %};
+  server_name {{ missing_hosts | join(' ') }};
   include acme-challenge-location.conf;
 }

--- a/roles/wordpress-setup/templates/https.conf.j2
+++ b/roles/wordpress-setup/templates/https.conf.j2
@@ -13,7 +13,7 @@ add_header Strict-Transport-Security "max-age={{ [hsts_max_age, hsts_include_sub
   ssl_certificate         {{ nginx_path }}/ssl/{{ item.value.ssl.cert | basename }};
   ssl_certificate_key     {{ nginx_path }}/ssl/{{ item.value.ssl.key | basename }};
 {%- elif item.value.ssl.provider | default('manual') == 'letsencrypt' -%}
-  ssl_certificate         {{ nginx_path }}/ssl/letsencrypt/{{ item.key }}-bundled.cert;
+  ssl_certificate         {{ nginx_path }}/ssl/letsencrypt/{{ item.key }}-{{ letsencrypt_cert_ids[item.key] }}-bundled.cert;
   ssl_certificate_key     {{ nginx_path }}/ssl/letsencrypt/{{ item.key }}.key;
 {%- elif item.value.ssl.provider | default('manual') == 'self-signed' -%}
   ssl_certificate         {{ nginx_path }}/ssl/{{ item.key }}.cert;

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -76,15 +76,11 @@ server {
 
   server_name {{ site_hosts | join(' ') }}{% if item.value.multisite.subdomains | default(false) %} *.{{ site_hosts_canonical | join(' *.') }}{% endif %};
 
-  {% if item.value.ssl.provider | default('manual') == 'letsencrypt' -%}
   include acme-challenge-location.conf;
 
   location / {
     return 301 https://$host$request_uri;
   }
-  {% else %}
-  return 301 https://$host$request_uri;
-  {% endif -%}
 }
 {% endif %}
 


### PR DESCRIPTION
### Update CSRs and certs

The primary problem to solve: If a user has already created Let's Encrypt CSRs and certs then modifies `site_hosts`, the LE role will fail to update the CSRs/certs.

If an LE cert exists, it will not update [if not older than 60 days](https://github.com/roots/trellis/blob/6ad6fcbb6e0c0cfdaaf7ecb734c2e867ff0437a7/roles/letsencrypt/templates/renew-certs.py#L22). If a CSR exists, it [will not be recreated](https://github.com/roots/trellis/blob/6ad6fcbb6e0c0cfdaaf7ecb734c2e867ff0437a7/roles/letsencrypt/tasks/certificates.yml#L21) because the [`creates` parameter](http://docs.ansible.com/ansible/shell_module.html) specifies the CSR file, and "when it already exists, this step will not be run." 

This PR updates the LE role to detect changes to `site_hosts` and update the CSR. The PR also updates the `renew-certs.py` to detect changes to the CSR and update the cert, even if younger than 60 days.

~~The CSR updates become idempotent via a new rsync like Trellis already uses for [the .env file](https://github.com/roots/trellis/blob/6ad6fcbb6e0c0cfdaaf7ecb734c2e867ff0437a7/roles/wordpress-install/tasks/main.yml#L5-L17) (details on rationale of using [rsync for idempotence](https://github.com/roots/trellis/pull/268#issuecomment-119903331)).~~

### Add acme challenge location to conf

**Edit: The remainder of this comment is now obsolete after internal discussion and a decision to avoid the `replace` module.**

If a user has just updated to a version of Trellis that includes the LE role, the LE role's [Test Acme Challenges](https://github.com/roots/trellis/blob/6ad6fcbb6e0c0cfdaaf7ecb734c2e867ff0437a7/roles/letsencrypt/tasks/nginx.yml#L38) would fail because the `wordpress-setup` role hasn't yet had a chance to insert `include acme-challenge-location.conf;` into the conf. This challenge location could also be missing for users with current Trellis with ssl [enabled with a non-LE provider](https://github.com/roots/trellis/blob/6ad6fcbb6e0c0cfdaaf7ecb734c2e867ff0437a7/roles/wordpress-setup/templates/wordpress-site.conf.j2#L86). This missing challenge location has required users to run the `wordpress` role first to update their conf before running the `letsencrypt` role, an unexpected hassle.

This PR updates the LE role to detect the missing challenge location and inserts it into the conf so that users no longer must run the `wordpress` role first. This feature is convenient but relies on the [replace module](http://docs.ansible.com/ansible/replace_module.html), which introduces some risk. There are some reassurances, however.
- The `replace` task will not even run if the challenge location is already in the conf.
- If an unforeseen regex failure messes up the conf, the user can fix it by running the `wordpress` tag, which they would have had to do anyway without this attempted `replace`. Then the challenge location will be in the conf and the `replace` won't ever run again for that user/project.
- The `replace` regex is designed to remove nothing. It should return everything matched, just adding the challenge location conf.

Explaining some regex (suggestions welcome)
example: `(listen 80;(?:[^\{]*\n)*)(.*return 301 \$scheme:\/\/.*\$request_uri;)`
- `(listen 80;(?:[^\{]*\n)*)` -- backref 1
  - `listen 80;` -- this portion of the match must begin with `listen 80;`
  - `(?:[^\{]*\n)*`
    - The `?:` prevents the creation of a separate backref for this `(?:pattern)`.
    - The `[^\{]*\n` will match any character(s) -- _except_ `{` -- followed by a newline. Excluding the `{` prevents matching across server/location blocks. For example, we wouldn't want a match to start at the `listen 80;` from the "ssl redirect server block" and finish on the `return 301` in the following "general redirects server block."
    - The final `*` lets there be multiple instances of `[^\{]*\n`
- `(.*return 301 \$scheme:\/\/.*\$request_uri;)` -- backref 2

The match patterns appear applicable to the conf for the past year (back to [ff0fbff](https://github.com/roots/trellis/blob/ff0fbff1f0ef863ae936cf357972815d0ea4ded2/roles/wordpress-setup/templates/wordpress-site.conf.j2), June 30, 2015).
### Handlers

**Edit:** The handler adjustment separated out to #722.