### PR TITLE
Adjust ansible_user and reload_nginx handler for Ansible 2.1

### DIFF
--- a/roles/common/tasks/reload_nginx.yml
+++ b/roles/common/tasks/reload_nginx.yml
@@ -1,12 +1,10 @@
 ---
-- name: test nginx conf
+- name: reload nginx
   command: nginx -t
   register: nginx_test
-  changed_when: false
+  notify: "{{ (ansible_version.full | version_compare('2.1.1.0', '>=') and role_path | basename == 'common') | ternary('perform nginx reload', omit) }}"
 
-- name: reload nginx
+- name: perform nginx reload
   service:
     name: nginx
     state: reloaded
-  when: nginx_test | success
-  changed_when: false

--- a/roles/remote-user/tasks/main.yml
+++ b/roles/remote-user/tasks/main.yml
@@ -1,23 +1,21 @@
 ---
-- block:
-  - name: Require manual definition of remote-user
-    fail:
-      msg: |
-        When using `--ask-pass` option, use `-u` option to define remote-user:
-        ansible-playbook server.yml -e env={{ env }} -u root --ask-pass
-    when: cli_ask_pass | default(false)
+- name: Require manual definition of remote-user
+  fail:
+    msg: |
+      When using `--ask-pass` option, use `-u` option to define remote-user:
+      ansible-playbook server.yml -e env={{ env }} -u root --ask-pass
+  when: ansible_user is not defined and cli_ask_pass | default(false)
 
-  - name: Check whether Ansible can connect as root
-    local_action: command ansible {{ inventory_hostname }} -m raw -a whoami -u root {{ cli_options | default('') }}
-    failed_when: false
-    changed_when: false
-    register: root_status
-    tags: [connection-tests]
+- name: Check whether Ansible can connect as root
+  local_action: command ansible {{ inventory_hostname }} -m raw -a whoami -u root {{ cli_options | default('') }}
+  failed_when: false
+  changed_when: false
+  register: root_status
+  tags: [connection-tests]
 
-  - name: Set remote user for each host
-    set_fact:
-      ansible_user: "{{ ('root' in root_status.stdout_lines) | ternary('root', admin_user) }}"
-
+- name: Set remote user for each host
+  set_fact:
+    ansible_user: "{{ ('root' in root_status.stdout_lines) | ternary('root', admin_user) }}"
   when: ansible_user is not defined
 
 - name: Announce which user was selected


### PR DESCRIPTION
This PR updates Trellis to accommodate two changes in Ansible 2.1.1.0 

### Handlers
The Trellis [`reload nginx` handler](https://github.com/roots/trellis/blob/6ad6fcbb6e0c0cfdaaf7ecb734c2e867ff0437a7/roles/common/handlers/main.yml#L12-L13) is an include file with two tasks. A [discourse thread](https://discourse.roots.io/t/7145/8) revealed that Ansible 2.1.1.0 was only running the second of these two tasks. The second task fails without the var that should have been registered in the first task.

As far as I can tell, Ansible 2.0.2.0 treated the `include` task as a single handler task, but 2.1.1.0 reads into the include file, seeing two potential handler tasks. In this latter case, only the second task uses the notified handler name (`reload nginx`) so only this second task runs.

This change in 2.1.1.0  jeopardizes the strategy of using an `include` to run multiple tasks via a single handler name. Once Trellis requires Ansible >= 2.2, these two tasks in question can be run under a single name via the coming [`listen` parameter](http://docs.ansible.com/ansible/playbooks_intro.html#handlers-running-operations-on-change).

In the meantime, this PR gives the first task the handler name that will be notified (`reload nginx`) and lets that first task notify the second task as another handler.

The challenge is that when the first task in `reload_nginx.yml` is used as an included task (vs. as a handler) -- always the case in 2.0.2.0 and [once in 2.1.1.0](https://github.com/roots/trellis/blob/6ad6fcbb6e0c0cfdaaf7ecb734c2e867ff0437a7/roles/letsencrypt/tasks/nginx.yml#L29) -- it results in the second task being run twice. The second task runs  once in its role as a task in the `include`, then again in its role as a notified handler. This isn't a huge problem but it is unnecessary repetition. The PR avoids the unnecessary repetition by making the first task's `notify` parameter conditional on when the task is running as a handler (vs. included task). 

### ansible_user
Previously the `ansible_user` variable defaulted to `undefined`, even on `local_action` tasks. In Ansible 2.1.1.0 (or in some version since 2.0.2.0), `ansible_user` for `local_action` tasks defaults to the username active on the control machine.

This causes a problem to the `remote-user` role's `block` conditional [`when: ansible_user is not defined`](https://github.com/roots/trellis/blob/6ad6fcbb6e0c0cfdaaf7ecb734c2e867ff0437a7/roles/remote-user/tasks/main.yml#L21). When Ansible interprets the "[Check whether Ansible can connect as root](https://github.com/roots/trellis/blob/6ad6fcbb6e0c0cfdaaf7ecb734c2e867ff0437a7/roles/remote-user/tasks/main.yml#L10-L11)" task, `ansible_user` is in fact now defined because the task uses a `local_action`. Thus the task doesn't run and doesn't register the variable needed in the following task, so the playbook fails.

This PR distributes the `block`'s conditional `when` to the separate tasks. The "Check whether Ansible can connect as root" task is no longer conditional on `ansible_user is undefined` because then it would never run. There is no problem to have this task always run because of its `failed_when: false` and `changed_when: false`.
