### PR TITLE
Restore Vagrant version to system info fail output

### DIFF
--- a/lib/trellis/plugins/callback/output.py
+++ b/lib/trellis/plugins/callback/output.py
@@ -27,6 +27,7 @@ class CallbackModule(CallbackModule_default):
     def __init__(self):
         super(CallbackModule, self).__init__()
         output.reset_task_info(self)
+        self.vagrant_version = None
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
         self.task_failed = True

--- a/lib/trellis/utils/output.py
+++ b/lib/trellis/utils/output.py
@@ -42,7 +42,6 @@ def reset_task_info(obj, task=None):
     obj.first_host = True
     obj.first_item = True
     obj.task_failed = False
-    obj.vagrant_version = None
 
 # Display dict key only, instead of full json dump
 def replace_item_with_key(obj, result):


### PR DESCRIPTION
#556 tidied up the `output.py` callback plugin but mistakenly moved the initialization/reset of `vagrant_version` from its appropriate place in the [class `__init__()`](https://github.com/roots/trellis/commit/367580db77865c05a1fecc8f2cbe5ff8b10333af#diff-e1e09579f288143dd0aabe0ed4e505feL34) to [`reset_task_info()`](https://github.com/roots/trellis/commit/367580db77865c05a1fecc8f2cbe5ff8b10333af#diff-022e2c64ae2f9c5884afcbae40f94babR44). This latter runs on every task and thus resets `vagrant_version`, preventing it from printing to the fail output. 

This PR reverses the mistake described above, restoring the Vagrant version to the fail output.

Before
```
TASK [common : fail] ***********************************************************
System info:
  Ansible 2.0.2.0; Darwin
  Trellis at "Upgrade Ubuntu from 14.04 Trusty to 16.04 Xenial"
---------------------------------------------------
Fail msg
```

After
```
TASK [common : fail] ***********************************************************
System info:
  Ansible 2.0.2.0; Vagrant 1.8.5; Darwin
  Trellis at "Upgrade Ubuntu from 14.04 Trusty to 16.04 Xenial"
---------------------------------------------------
Fail msg
```