### PR TITLE
Update README requirements re: Ansible and passlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Trellis will configure a server with the following and more:
 
 Make sure all dependencies have been installed before moving on:
 
-* [Ansible](http://docs.ansible.com/ansible/intro_installation.html#latest-releases-via-pip) 2.0.2
+* [Ansible](http://docs.ansible.com/ansible/intro_installation.html#latest-releases-via-pip) >= 2.0.2 (except 2.1.0)
 * [Virtualbox](https://www.virtualbox.org/wiki/Downloads) >= 4.3.10
 * [Vagrant](https://www.vagrantup.com/downloads.html) >= 1.8.5
 * [vagrant-bindfs](https://github.com/gael-ian/vagrant-bindfs#installation) >= 0.3.1 (Windows users may skip this)
@@ -72,7 +72,7 @@ Trellis documentation is available at [https://roots.io/trellis/docs/](https://r
 
 ## Remote server setup (staging/production)
 
-A base Ubuntu 16.04 server is required for setting up remote servers.
+A base Ubuntu 16.04 server is required for setting up remote servers. OS X users must have [passlib](http://pythonhosted.org/passlib/install.html#installation-instructions) installed.
 
 1. Configure your WordPress sites in `group_vars/<environment>/wordpress_sites.yml` and in `group_vars/<environment>/vault.yml` (see the [Vault docs](https://roots.io/trellis/docs/vault/) for how to encrypt files containing passwords)
 2. Add your server IP/hostnames to `hosts/<environment>`

--- a/lib/trellis/plugins/vars/vars.py
+++ b/lib/trellis/plugins/vars/vars.py
@@ -17,12 +17,6 @@ from ansible.parsing.dataloader import DataLoader
 from ansible.parsing.yaml.objects import AnsibleMapping, AnsibleSequence, AnsibleUnicode
 from ansible.template import Templar
 
-try:
-    import passlib.hash
-except:
-    if sys.platform.startswith('darwin'):
-        raise AnsibleError('Ansible on OS X requires the python passlib module to create user password hashes.\nsudo easy_install pip\npip install passlib')
-
 
 class VarsModule(object):
     ''' Creates and modifies host variables '''
@@ -82,9 +76,20 @@ class VarsModule(object):
 
         return ' '.join(options)
 
+    def darwin_without_passlib(self):
+        if not sys.platform.startswith('darwin'):
+            return False
+
+        try:
+            import passlib.hash
+            return False
+        except:
+            return True
+
     def get_host_vars(self, host, vault_password=None):
         self.raw_vars(host, host.get_group_vars())
         host.vars['cli_options'] = self.cli_options()
         host.vars['cli_ask_pass'] = getattr(self._options, 'ask_pass', False)
         host.vars['cli_ask_become_pass'] = getattr(self._options, 'become_ask_pass', False)
+        host.vars['darwin_without_passlib'] = self.darwin_without_passlib()
         return {}

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -34,6 +34,16 @@
   when: ansible_distribution_release == 'trusty'
   run_once: true
 
+- name: Check whether passlib is needed
+  fail:
+    msg: |
+      Ansible on OS X requires python passlib module to create user password hashes
+
+      sudo easy_install pip
+      pip install passlib
+  when: env != 'development' and darwin_without_passlib | default(false)
+  run_once: true
+
 - name: Update Apt
   apt:
     update_cache: yes


### PR DESCRIPTION
- clarifies Ansible version requirement
- makes OS X `passlib` requirement explicit in README (for provisioning remote servers only) 
- omits `passlib` test/msg from dev (dev lacks `users` role; `passlib` not needed to hash password)

Note: `passlib` will most likely already be on OS X machines for users who generated a [crypted password](http://docs.ansible.com/ansible/faq.html#how-do-i-generate-crypted-passwords-for-the-user-module) for the defunct `vault_sudoer_passwords`. #614 removed `vault_sudoer_passwords` but added the requirement for `passlib` for OS X users provisioning remote servers.