### PR TITLE
WP 4.6 Compat: set WP_HOME/SITEURL directly

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -100,6 +100,10 @@ Vagrant.configure('2') do |config|
         'development' => ['default']
       }
 
+      if tags = ENV['ANSIBLE_TAGS']
+        ansible.tags = tags
+      end
+
       ansible.extra_vars = {'vagrant_version' => Vagrant::VERSION}
       if vars = ENV['ANSIBLE_VARS']
         extra_vars = Hash[vars.split(',').map { |pair| pair.split('=') }]

--- a/group_vars/all/helpers.yml
+++ b/group_vars/all/helpers.yml
@@ -4,8 +4,8 @@ wordpress_env_defaults:
   db_user: "{{ item.key | underscore }}"
   disable_wp_cron: true
   wp_env: "{{ env }}"
-  wp_home: "{{ item.value.ssl.enabled | default(false) | ternary('https', 'http') }}://${HTTP_HOST}"
-  wp_siteurl: "${WP_HOME}/wp"
+  wp_home: "{{ item.value.ssl.enabled | default(false) | ternary('https', 'http') }}://{{ site_hosts_canonical | first }}"
+  wp_siteurl: "{{ item.value.ssl.enabled | default(false) | ternary('https', 'http') }}://{{ site_hosts_canonical | first }}/wp"
 
 site_env: "{{ wordpress_env_defaults | combine(item.value.env | default({}), vault_wordpress_sites[item.key].env) }}"
 site_hosts_canonical: "{{ item.value.site_hosts | map(attribute='canonical') | list }}"


### PR DESCRIPTION
https://github.com/WordPress/WordPress/commit/905f4ec0f835dc9eb0a34f37c297bd6a02d519ba
changed email address handling with PHPMailer. It's not validating email
addresses. This was failing since Trellis was using string interpolation
with the `HTTP_HOST` constant. It wasn't being evaluated in that
context.

The solution is to set these values directly with the first canonical
site host eliminating the need for the magic constant and string
interpolation.