### PR TITLE
Don't run xdebug in the CLI

### DIFF
--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -36,6 +36,12 @@
     dest: /etc/php/7.0/mods-available/xdebug.ini
   when: xdebug_install | default(false)
 
+- name: Disable xdebug CLI
+  file:
+    path: /etc/php/7.0/cli/conf.d/20-xdebug.ini
+    state: absent
+  when: xdebug_install | default(false)
+
 - name: Start php7.0-fpm service
   service:
     name: php7.0-fpm


### PR DESCRIPTION
This is especially important if running Composer via the command line in the vagrant box.

Should speed up anything running via the PHP CLI. 99.9% of the time xdebug does not need to be run with the CLI.