### PR TITLE
backup feature

### DIFF
--- a/group_vars/production/vault.yml
+++ b/group_vars/production/vault.yml
@@ -22,3 +22,6 @@ vault_wordpress_sites:
       secure_auth_salt: "generateme"
       logged_in_salt: "generateme"
       nonce_salt: "generateme"
+      # Uncomment if you use backups
+      # backup_target_user: example_user
+      # backup_target_pass: example_backup_password

--- a/group_vars/production/wordpress_sites.yml
+++ b/group_vars/production/wordpress_sites.yml
@@ -19,3 +19,9 @@ wordpress_sites:
       provider: letsencrypt
     cache:
       enabled: false
+    backup:
+      enabled: false # switch to true to enable backup
+      auto: true
+      target: scp://user@example.com/example.com_backups # any location supported by duplicity
+      schedule: '0 4 * * *' # change this value
+      purge: false # switch to true to enable automatic purging of old backups

--- a/group_vars/staging/vault.yml
+++ b/group_vars/staging/vault.yml
@@ -22,3 +22,6 @@ vault_wordpress_sites:
       secure_auth_salt: "generateme"
       logged_in_salt: "generateme"
       nonce_salt: "generateme"
+      # Uncomment if you use backups
+      # backup_target_user: example_user
+      # backup_target_pass: example_backup_password

--- a/group_vars/staging/wordpress_sites.yml
+++ b/group_vars/staging/wordpress_sites.yml
@@ -19,3 +19,12 @@ wordpress_sites:
       provider: letsencrypt
     cache:
       enabled: false
+    backup:
+      enabled: false
+      auto: false
+      target: scp://user@example.com/example.com_backups # any location supported by duplicity
+      schedule: '0 4 * * *' # change this value
+      purge: false # switch to true to enable automatic purging of old backups
+      # let "enabled: true" and "auto: false" to install backup profiles but not
+      # actually making backups, for example to restore your production database
+      # on staging

--- a/requirements.yml
+++ b/requirements.yml
@@ -20,3 +20,7 @@
 - name: mailhog
   src: geerlingguy.mailhog
   version: 2.1.0
+
+- name: Stouts.backup
+  src: Stouts.backup
+  version: 3.4.5

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -1,0 +1,3 @@
+site_uses_backup: "{{ item.value.backup is defined and item.value.backup.enabled | default(false) }}"
+site_purge_backup: "{{ item.value.backup is defined and item.value.backup.purge | default(false) }}"
+site_purge_backup: "{{ item.value.backup is defined and item.value.backup.enabled and item.value.backup.auto and item.value.backup.purge | default(false) }}"

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -1,0 +1,48 @@
+---
+- name: Ensure python pip and paramiko dependencies are installed
+  apt:
+    name:
+      - python-pip
+      - python-dev
+      - libffi-dev
+    state: present
+
+- name: Ensure paramiko is installed
+  pip:
+    name: paramiko
+    state: present
+
+- name: List backup jobs
+  set_fact:
+    backup_user: "{{ admin_user }}"
+    backup_group: sudo
+
+    backup_mysql_user: "{{ mysql_root_user }}"
+    backup_mysql_pass: "{{ mysql_root_password }}"
+
+    # Define the backup jobs
+    backup_profiles:
+    # Backup uploads
+      - name: "{{ item.key }}_uploads"
+        schedule: "{{ item.value.backup.schedule | default(omit) }}"
+        source: "{{ www_root }}/{{ item.key }}/shared/uploads"
+        target: "{{ item.value.backup.target }}/uploads"
+        target_user: "{{ site_env.backup_target_user }}"
+        target_pass: "{{ site_env.backup_target_pass }}"
+        action: "{{ site_purge_backup | ternary('purge_backup --force', 'backup') }}"
+
+    # Backup database
+      - name: "{{ item.key }}_database"
+        schedule: "{{ item.value.backup.schedule | default(omit) }}"
+        source: "mysql://{{ item.key | underscore }}_{{ env }}"          # Backup prefixes: postgresql://, maysql://, mongo://
+        target: "{{ item.value.backup.target }}/database"
+        target_user: "{{ site_env.backup_target_user }}"
+        target_pass: "{{ site_env.backup_target_pass }}"
+        action: "{{ site_purge_backup | ternary('purge_backup --force', 'backup') }}"
+
+  when: site_uses_backup
+  with_dict: "{{ wordpress_sites }}"
+  register: backup_jobs
+
+- name: Configure backup jobs
+  set_fact: backup_profiles="{{ backup_jobs.results | selectattr('ansible_facts', 'defined') | map(attribute='ansible_facts.backup_profiles.0') | list }} + {{ backup_jobs.results | selectattr('ansible_facts', 'defined') | map(attribute='ansible_facts.backup_profiles.1') | list }}"

--- a/server.yml
+++ b/server.yml
@@ -40,3 +40,5 @@
     - { role: wp-cli, tags: [wp-cli] }
     - { role: letsencrypt, tags: [letsencrypt], when: sites_using_letsencrypt | count }
     - { role: wordpress-setup, tags: [wordpress, wordpress-setup, letsencrypt] }
+    - { role: backup, tags: [backup] }
+    - { role: Stouts.backup, tags: [backup] }


### PR DESCRIPTION
This is a proposition for a backup feature inspired by @MWDelaney work. 

The role uses [Souts.backup](https://github.com/Stouts/Stouts.backup) to create two duply backup profiles for each `wordpress_sites` which has `backup: {enabled: true}`.

The configuration for each `wordpress_sites` is the following : 

``` yaml
backup:
    enabled: true # creates a backup profile if true (default: false)
    auto: true # set up a cron job for backup each night if true (default: false)
    target: scp://user@example.com/website_name # any valid duplicity location
```

The parameter `auto` allows to create backup profile without installing the cron job. This is usefull if you want to use the backup profile only to restore backups made from another server, by running `sudo duply website_name_database restore` and `sudo duply website_name_uploads restore` . This can be an interesting solution to synchronize database and uploads between production and staging for example.
