### PR TITLE
Fix #651 - Specify service path for nginx reload

### DIFF
--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -7,7 +7,7 @@
     cron_file: letsencrypt-certificate-renewal
     name: letsencrypt certificate renewal
     user: root
-    job: cd {{ acme_tiny_data_directory }} && ./renew-certs.py && service nginx reload
+    job: cd {{ acme_tiny_data_directory }} && ./renew-certs.py && /usr/sbin/service nginx reload
     day: "{{ letsencrypt_cronjob_daysofmonth }}"
     hour: 4
     minute: 30


### PR DESCRIPTION
Specify service path for nginx reload

See https://github.com/roots/trellis/issues/651