### PR TITLE
WP 4.6 Compat in deploy.yml: set WP_HOME/SITEURL directly

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -19,8 +19,8 @@
       db_user: "{{ site | underscore }}"
       disable_wp_cron: true
       wp_env: "{{ env }}"
-      wp_home: "{{ project.ssl.enabled | default(false) | ternary('https', 'http') }}://${HTTP_HOST}"
-      wp_siteurl: "${WP_HOME}/wp"
+      wp_home: "{{ project.ssl.enabled | default(false) | ternary('https', 'http') }}://{{ project.site_hosts | map(attribute='canonical') | first }}"
+      wp_siteurl: "{{ project.ssl.enabled | default(false) | ternary('https', 'http') }}://{{ project.site_hosts | map(attribute='canonical') | first }}/wp"
     site_env: "{{ wordpress_env_defaults | combine(project.env | default({}), vault_wordpress_sites[site].env) }}"
 
   pre_tasks:


### PR DESCRIPTION
To accompany roots/trellis#647

This can't rely on `site_hosts_canonical` because [`site_hosts_canonical `](https://github.com/roots/trellis/blob/58712e927e4beaf0ff408145da72fd5c1be65b89/group_vars/all/helpers.yml#L11) relies on `item.value.site_hosts` which is not defined in the `deploy.yml` context.

I guess the `map(attribute='canonical'` followed up with `| first` obviates the need for `| list` (cf. [`site_hosts_canonical `](https://github.com/roots/trellis/blob/58712e927e4beaf0ff408145da72fd5c1be65b89/group_vars/all/helpers.yml#L11)). I tested with Ansible 2.0.2.0 and 2.1.1.0 and this version of `deploy.yml` puts the correct values in `/srv/www/example.com/current/.env`.