### PR TITLE
Update WP's timezone_string

### DIFF
--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -63,6 +63,15 @@
   with_dict: "{{ wordpress_sites }}"
   when: wp_install_results | changed or wp_multisite_install_results | changed
 
+- name: Setup WP Timezone
+  command: wp option update timezone_string {{ default_timezone }} --allow-root
+  args:
+    chdir: "{{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/"
+  register: wp_timezone_update_results
+  with_dict: "{{ wordpress_sites }}"
+  changed_when: "'Success: Updated' in wp_timezone_update_results.stdout"
+  when: wp_install_results | changed
+
 - name: Update WP Multisite Home URL
   command: wp option update home {{ site_env.wp_home }} --allow-root
   args:


### PR DESCRIPTION
Update WP's `timezone_string` with the value from the `default_timezone` configuration.

Note:
I can't for the sake of me figure out how to escape single quotes inside the `changed_when` so I simplified it. Ideally, it would be: `changed_when: "'Success: Updated ''timezone_string'' option.' in wp_timezone_update_results.stdout"`

I can change the PR when I get feedback on the above note.