### PR TITLE
Update MariaDB repo and key for Xenial

### DIFF
--- a/roles/mariadb/defaults/main.yml
+++ b/roles/mariadb/defaults/main.yml
@@ -1,8 +1,7 @@
 mariadb_binary_logging_disabled: true
-mariadb_keyserver_fingerprint: "0xcbcb082a1bb943db"
+mariadb_keyserver_fingerprint: "0xF1656F24C74CD1D8" # https://downloads.mariadb.org/mariadb/repositories/
 mariadb_mirror: nyc2.mirrors.digitalocean.com
 mariadb_version: "10.0"
-mariadb_dist: trusty
 mysql_root_user: root
 
 sites_using_remote_db: "[{% for name, site in wordpress_sites.iteritems() if site.env is defined and site.env.db_host | default('localhost') != 'localhost' %}'{{ name }}',{% endfor %}]"

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -1,8 +1,25 @@
 ---
 - name: Add MariaDB MySQL apt-key
   apt_key:
+    url: "http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0xcbcb082a1bb943db"
+    state: present
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'trusty'
+
+- name: Add MariaDB MySQL apt-key
+  apt_key:
     url: "http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search={{ mariadb_keyserver_fingerprint }}"
     state: present
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'xenial'
+
+- name: Remove mismatched releases in MariaDB MySQL repo
+  apt_repository:
+    repo: "{{ item }}"
+    state: absent
+  with_items:
+    - "deb http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu trusty main"
+    - "deb-src http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu trusty main"
+  register: mariadbrepomismatched
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'xenial'
 
 - name: Add MariaDB MySQL deb and deb-src
   apt_repository:
@@ -11,6 +28,20 @@
   with_items:
     - "deb http://{{ mariadb_mirror }}/mariadb/repo/{{ mariadb_version }}/ubuntu {{ mariadb_dist | default(ansible_distribution_release) }} main"
     - "deb-src http://{{ mariadb_mirror }}/mariadb/repo/{{ mariadb_version }}/ubuntu {{ mariadb_dist | default(ansible_distribution_release) }} main"
+
+- name: Update MariaDB MySQL client when releases are mismatched
+  apt:
+    name: mariadb-client
+    state: latest
+    update_cache: yes
+  when: mariadbrepomismatched.changed
+
+- name: Update MariaDB MySQL server when releases are mismatched
+  apt:
+    name: mariadb-server
+    state: latest
+    update_cache: yes
+  when: mariadbrepomismatched.changed and not sites_using_remote_db
 
 - name: Install MySQL client
   apt:


### PR DESCRIPTION
MariaDB was still using the repo and signing keys for Trusty which was also using weak digest algorithm (SHA 1) you can see this when you run `apt-get update` currently.

This change should cover all the bases and be non-breaking on existing installs as well as work as it currently does in relation to remote database setups.
- Conditionally check if you have the old Trusty repository currently configured. If so it will remove those lines and add the updated repo.
- If it detects the removal of the Trusty lines then it moves to update your MariaDB packages but only on that run so it won't be updating packages on every run once the initial change is made.
- If you are running a setup with only remote databases it will only update `mariadb-client` but if you have local databases then it will update `mariadb-server` as well.

You can easily test this by spinning up a VM as the role stands currently. Then switch to this new branch and re-provision and you will see it gracefully updates everything. Then run it again and you will see that it doesn't try updating MariaDB packages again.
