### PR TITLE
Fix #666 - Solution for Vagrant Box Versioning issue

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,6 +38,7 @@ Vagrant.require_version '>= 1.8.5'
 
 Vagrant.configure('2') do |config|
   config.vm.box = 'bento/ubuntu-16.04'
+  config.vm.box_version = '2.2.9'
   config.ssh.forward_agent = true
 
   config.vm.post_up_message = post_up_message


### PR DESCRIPTION
The latest release of the `bento/ubuntu16.04` box `2.3.0` is causing trellis to hang on `vagrant up`.

My solution is to lock the VM to the previous version `2.2.9` where the issue is not occurring.

We should look into testing against these vagrant boxes before pushing them to master.