### PR TITLE
add $http_origin to fastcgi_cache_key

### DIFF
--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -41,7 +41,7 @@ http {
   fastcgi_cache_path {{ nginx_cache_path }} levels=1:2 keys_zone=wordpress:{{ nginx_cache_key_storage_size }} max_size={{ nginx_cache_size }} inactive={{ nginx_cache_inactive }};
   fastcgi_cache_use_stale updating error timeout invalid_header http_500;
   fastcgi_cache_lock on;
-  fastcgi_cache_key $realpath_root$scheme$host$request_uri$request_method;
+  fastcgi_cache_key $realpath_root$scheme$host$request_uri$request_method$http_origin;
   fastcgi_ignore_headers Cache-Control Expires Set-Cookie;
   fastcgi_pass_header Set-Cookie;
   fastcgi_pass_header Cookie;


### PR DESCRIPTION
Wordpress API adds the origin to CORS headers, if requesting from two different origins while the cache is hot headers will be incorrect unless http_origin is added to the cache key.

Had to add this to a server where I have more than one possible origin pulling content from the wordpress api, causing CORS errors. I think it makes sense having this as the default behaviour.