### PR TITLE
Add bin/xdebug-tunnel.sh script to manage ssh tunnels

### DIFF
--- a/bin/xdebug-tunnel.sh
+++ b/bin/xdebug-tunnel.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Usage:
+#   To open a tunnel: bin/xdebug-tunnel.sh example_com_prod
+#   To close a tunnel: bin/xdebug-tunnel.sh example_com_prod close
+
+SSH_HOST="-e xdebug_tunnel_inventory_host=${1}"
+MAYBE_CLOSE="${2}"
+CLOSE_CONNECTION=
+DEBUG="${DEBUG:-}"
+VERBOSITY="${VERBOSITY:--vvvv}"
+EXTRA_PARAMs="${EXTRA_PARAMS:-}"
+
+if [[ "${MAYBE_CLOSE}" == 'close' ]]; then
+  CLOSE_CONNECTION="-e xdebug_tunnel_close=true"
+fi
+
+if [[ -n "${DEBUG}" ]]; then
+  EXTRA_PARAMS="${EXTRA_PARAMS} ${VERBOSITY}"
+fi
+
+ansible-playbook xdebug-tunnel.yml ${SSH_HOST} ${CLOSE_CONNECTION} ${EXTRA_PARAMS}

--- a/bin/xdebug-tunnel.sh
+++ b/bin/xdebug-tunnel.sh
@@ -13,7 +13,7 @@ PARAMs="${PARAMS:-}"
 if [[ "${MAYBE_CLOSE}" == 'close' ]]; then
   PARAMS="${PARAMS} -e xdebug_tunnel_close=true -e xdebug_install=false"
 else
-  PARAMS="${PARAMS} -e xdebug_install=true"
+  PARAMS="${PARAMS} -e xdebug_install=true -e xdebug_remote_enable=1"
 fi
 
 if [[ -n "${DEBUG}" ]]; then

--- a/bin/xdebug-tunnel.sh
+++ b/bin/xdebug-tunnel.sh
@@ -8,14 +8,17 @@ MAYBE_CLOSE="${2}"
 CLOSE_CONNECTION=
 DEBUG="${DEBUG:-}"
 VERBOSITY="${VERBOSITY:--vvvv}"
-EXTRA_PARAMs="${EXTRA_PARAMS:-}"
+PARAMs="${PARAMS:-}"
 
 if [[ "${MAYBE_CLOSE}" == 'close' ]]; then
-  CLOSE_CONNECTION="-e xdebug_tunnel_close=true"
+  PARAMS="${PARAMS} -e xdebug_tunnel_close=true -e xdebug_install=false"
+else
+  PARAMS="${PARAMS} -e xdebug_install=true"
 fi
 
 if [[ -n "${DEBUG}" ]]; then
-  EXTRA_PARAMS="${EXTRA_PARAMS} ${VERBOSITY}"
+  PARAMS="${PARAMS} ${VERBOSITY}"
 fi
 
-ansible-playbook xdebug-tunnel.yml ${SSH_HOST} ${CLOSE_CONNECTION} ${EXTRA_PARAMS}
+PARAMS="${SSH_HOST} ${CLOSE_CONNECTION} ${PARAMS}"
+ansible-playbook xdebug-tunnel.yml ${PARAMS}

--- a/roles/xdebug-tunnel/defaults/main.yml
+++ b/roles/xdebug-tunnel/defaults/main.yml
@@ -1,0 +1,11 @@
+xdebug_tunnel_close: false
+xdebug_tunnel_remote_port: 9000
+xdebug_tunnel_host: localhost
+xdebug_tunnel_local_port: 9000
+xdebug_tunnel_control_socket: "/tmp/trellis-xdebug-{{ xdebug_tunnel_inventory_host }}"
+xdebug_tunnel_control_identity: "{{ ansible_user_id }}"
+
+xdebug_tunnel_port_mapping: "{{ xdebug_tunnel_remote_port }}:{{ xdebug_tunnel_host }}:{{ xdebug_tunnel_local_port }}"
+xdebug_tunnel_ssh_user: "{{ hostvars[xdebug_tunnel_inventory_host]['ansible_user'] | default(admin_user) }}"
+xdebug_tunnel_ssh_host: "{{ hostvars[xdebug_tunnel_inventory_host]['ansible_host'] | default(xdebug_tunnel_inventory_host) }}"
+xdebug_tunnel_user_at_host: "{{ xdebug_tunnel_ssh_user }}@{{ xdebug_tunnel_ssh_host }}"

--- a/roles/xdebug-tunnel/tasks/close.yml
+++ b/roles/xdebug-tunnel/tasks/close.yml
@@ -1,0 +1,10 @@
+---
+- name: Close XDebug SSH Tunnel
+  command: "ssh -S '{{ xdebug_tunnel_control_socket }}' -O exit '{{ xdebug_tunnel_control_identity }}'"
+  when: xdebug_tunnel_close
+  register: xdebug_tunnel_closing
+  ignore_errors: true
+
+- name: Fail the play if tunnel was already closed
+  fail: msg="SSH tunnel already closed!"
+  when: "'No such file or directory' in xdebug_tunnel_closing.stderr | default('')"

--- a/roles/xdebug-tunnel/tasks/main.yml
+++ b/roles/xdebug-tunnel/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- include: open.yml
+  when: xdebug_tunnel_close == false
+
+- include: close.yml
+  when: xdebug_tunnel_close
+
+- name: Announce tunnel was created
+  debug:
+    msg: "SSH Tunnel {{ xdebug_tunnel_creation.failed | default(false) | ternary('was not', 'was') }} created!"
+  when: xdebug_tunnel_creation is defined and xdebug_tunnel_creation.changed
+
+- name: Announce tunnel was closed
+  debug:
+    msg: "SSH Tunnel {{ xdebug_tunnel_closing.failed | default(false) | ternary('was not', 'was') }} closed!"
+  when: xdebug_tunnel_closing is defined and xdebug_tunnel_closing.changed

--- a/roles/xdebug-tunnel/tasks/open.yml
+++ b/roles/xdebug-tunnel/tasks/open.yml
@@ -1,0 +1,12 @@
+---
+- debug: var=xdebug_tunnel_inventory_host
+- debug: var=hostvars[xdebug_tunnel_inventory_host]
+- name: Create XDebug SSH Tunnel
+  command: "ssh -M -S '{{ xdebug_tunnel_control_socket }}' -fnNT -L {{ xdebug_tunnel_port_mapping }} {{ xdebug_tunnel_user_at_host}} '{{ xdebug_tunnel_control_identity }}'"
+  when: xdebug_tunnel_close == false
+  register: xdebug_tunnel_creation
+  ignore_errors: true
+
+- name: Fail the play if tunnel already exists
+  fail: msg="SSH tunnel already exists! Refer to TODO for help. Error:\n{{ xdebug_tunnel_creation.stderr | default('') }}"
+  when: "'bind: Address already in use' in xdebug_tunnel_creation.stderr | default('')"

--- a/roles/xdebug-tunnel/tasks/open.yml
+++ b/roles/xdebug-tunnel/tasks/open.yml
@@ -1,8 +1,6 @@
 ---
-- debug: var=xdebug_tunnel_inventory_host
-- debug: var=hostvars[xdebug_tunnel_inventory_host]
 - name: Create XDebug SSH Tunnel
-  command: "ssh -M -S '{{ xdebug_tunnel_control_socket }}' -fnNT -L {{ xdebug_tunnel_port_mapping }} {{ xdebug_tunnel_user_at_host}} '{{ xdebug_tunnel_control_identity }}'"
+  command: "ssh -M -S '{{ xdebug_tunnel_control_socket }}' -fnNT -R {{ xdebug_tunnel_port_mapping }} {{ xdebug_tunnel_user_at_host}} '{{ xdebug_tunnel_control_identity }}'"
   when: xdebug_tunnel_close == false
   register: xdebug_tunnel_creation
   ignore_errors: true

--- a/roles/xdebug/defaults/main.yml
+++ b/roles/xdebug/defaults/main.yml
@@ -1,3 +1,5 @@
+xdebug_install: false
+
 # XDebug Remote Debugging
 xdebug_remote_enable: 0
 xdebug_remote_connect_back: 0

--- a/roles/xdebug/tasks/disable.yml
+++ b/roles/xdebug/tasks/disable.yml
@@ -1,0 +1,7 @@
+---
+- name: Disable xdebug fpm when xdebug_install is false
+  file:
+    path: /etc/php/7.0/fpm/conf.d/20-xdebug.ini
+    state: absent
+  when: not xdebug_install
+  notify: reload php-fpm

--- a/roles/xdebug/tasks/enable.yml
+++ b/roles/xdebug/tasks/enable.yml
@@ -1,0 +1,18 @@
+---
+- name: Install Xdebug
+  apt:
+    name: php-xdebug
+    state: latest
+
+- name: xdebug configuration file
+  template:
+    src: xdebug.ini.j2
+    dest: /etc/php/7.0/mods-available/xdebug.ini
+  notify: reload php-fpm
+
+- name: Ensure 20-xdebug.ini present
+  file:
+    src: /etc/php/7.0/mods-available/xdebug.ini
+    dest: /etc/php/7.0/fpm/conf.d/20-xdebug.ini
+    state: link
+  notify: reload php-fpm

--- a/roles/xdebug/tasks/main.yml
+++ b/roles/xdebug/tasks/main.yml
@@ -1,16 +1,9 @@
 ---
-- name: Install Xdebug
-  apt:
-    name: php-xdebug
-    state: latest
-  when: xdebug_install | default(false)
+- include: enable.yml
+  when: xdebug_install
 
-- name: xdebug configuration file
-  template:
-    src: xdebug.ini.j2
-    dest: /etc/php/7.0/mods-available/xdebug.ini
-  when: xdebug_install | default(false)
-  notify: reload php-fpm
+- include: disable.yml
+  when: not xdebug_install
 
 - name: Disable xdebug CLI
   file:

--- a/xdebug-tunnel.yml
+++ b/xdebug-tunnel.yml
@@ -4,12 +4,15 @@
   gather_facts: false
   roles:
     - { role: remote-user, tags: [remote-user, always] }
-  post_tasks:
-    - name: Gather Facts
-      setup:
+
+- name: Enable/Disable Xdebug
+  hosts: "{{ xdebug_tunnel_inventory_host }}"
+  roles:
+    - { role: xdebug, tags: [xdebug] }
+  handlers:
+    - include: roles/common/handlers/main.yml
 
 - name: Manage XDebug SSH Tunnel
   hosts: localhost
   roles:
-    - { role: xdebug, tags: [xdebug] }
     - { role: xdebug-tunnel, tags: [xdebug-tunnel] }

--- a/xdebug-tunnel.yml
+++ b/xdebug-tunnel.yml
@@ -1,0 +1,14 @@
+---
+- name: Determine Remote User
+  hosts: "{{ xdebug_tunnel_inventory_host }}"
+  gather_facts: false
+  roles:
+    - { role: remote-user, tags: [remote-user, always] }
+  post_tasks:
+    - name: Gather Facts
+      setup:
+
+- name: Manage XDebug SSH Tunnel
+  hosts: localhost
+  roles:
+    - { role: xdebug-tunnel, tags: [xdebug-tunnel] }

--- a/xdebug-tunnel.yml
+++ b/xdebug-tunnel.yml
@@ -11,4 +11,5 @@
 - name: Manage XDebug SSH Tunnel
   hosts: localhost
   roles:
+    - { role: xdebug, tags: [xdebug] }
     - { role: xdebug-tunnel, tags: [xdebug-tunnel] }


### PR DESCRIPTION
This adds the ability for Trellis to manage creating SSH tunnels for use with Xdebug. While it's not recommended to use in production, it can be useful in production-like environments. For example, if there's an issue in production that you can't duplicate locally in development, or also exists in staging, you can create an SSH Tunnel to bridge the production-like environment to your local machine, allowing communication between Xdebug and whatever local debugger you're using (PHPStorm, Vim, Sublime Text, etc).

Another use case is cloning your production server and working on that instead of production itself so as to not ruin things more 😐 

Usage:

Provided this hosts file:
```
# let's pretend hosts/prodlike

some_inventory_hostname ansible_ssh_host=12.34.56.78

[prodlike]
some_inventory_hostname

[web]
some_inventory_hostname
```

```
bin/xdebug-tunnel.sh some_inventory_hostname
```

This script runs the `xdebug-tunnel.yml` playbook with the necessary variables to install Xdebug on the environment as well as establish the tunnel. 

To close the tunnel, as well as disable Xdebug, run:

```
bin/xdebug-tunnel.sh some_inventory_hostname close
```

This will remove the `/etc/php/7.0/fpm/conf.d/20-xdebug.ini` symlink, effectively disabling it for that environment while leaving xdebug installed. It also closes the SSH connection.

If you don't use inventory aliases in your host files, you can also use an ip address directly instead of the alias. For example, if your host file looks like this:

```
[prodlike]
12.34.56.78

[web]
12.34.56.78
```

You can do this:

```
bin/xdebug-tunnel.sh 12.34.56.78
```

You do have to be consistent though. If you open it using an alias and close it using an ip address, it'll yell at you because the tunnel socket is created using that passed parameter. It creates files matching the following pattern:

```
/tmp/trellis-xdebug-{{ provided host }}
```

**Note: This PR depends on https://github.com/roots/trellis/pull/676. Once that's merged, I'll change the base branch to `master`.**