### PR TITLE
Update galaxy roles for Ansible 2.2 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Update galaxy roles for Ansible 2.2 compatibility ([#681](https://github.com/roots/trellis/pull/681))
 * Update to WP-CLI 0.25.0 for WP 4.7 compat ([#673](https://github.com/roots/trellis/pull/673))
 * Enable per-site setup for permalink structure ([#661](https://github.com/roots/trellis/pull/661))
 * WP 4.6 Compat: set WP_HOME/SITEURL directly ([#647](https://github.com/roots/trellis/pull/647))

--- a/dev.yml
+++ b/dev.yml
@@ -11,7 +11,6 @@
     - { role: ntp }
     - { role: sshd, tags: [sshd] }
     - { role: mariadb, tags: [mariadb] }
-    - { role: ssmtp, tags: [ssmtp, mail] }
     - { role: mailhog, tags: [mailhog, mail] }
     - { role: php, tags: [php] }
     - { role: memcached, tags: [memcached] }

--- a/dev.yml
+++ b/dev.yml
@@ -8,7 +8,7 @@
     - { role: common, tags: [common] }
     - { role: fail2ban, tags: [fail2ban] }
     - { role: ferm, tags: [ferm] }
-    - { role: ntp }
+    - { role: ntp, tags: [ntp] }
     - { role: sshd, tags: [sshd] }
     - { role: mariadb, tags: [mariadb] }
     - { role: mailhog, tags: [mailhog, mail] }

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -2,7 +2,8 @@ composer_keep_updated: true
 composer_global_packages:
  - { name: hirak/prestissimo }
 apt_cache_valid_time: 86400
-default_timezone: Etc/UTC
+ntp_timezone: Etc/UTC
+ntp_manage_config: true
 www_root: /srv/www
 ip_whitelist:
   - "{{ lookup('pipe', 'curl -4 -s https://api.ipify.org') }}"

--- a/group_vars/development/mail.yml
+++ b/group_vars/development/mail.yml
@@ -1,8 +1,2 @@
 # Documentation: https://roots.io/trellis/docs/mail/
-mailhog_install_ssmtp: no
-mail_admin: admin@example.dev
-mail_hostname: example.dev
-mail_smtp_server: localhost:1025
-ssmtp_auth_method: ""
-ssmtp_start_tls: 'no'
-ssmtp_tls: 'no'
+php_sendmail_path: "{{ mailhog_install_dir }}/mhsendmail"

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,8 +3,8 @@
   version: 1.5.0
 
 - name: ntp
-  src: resmo.ntp
-  version: 0.3.0
+  src: geerlingguy.ntp
+  version: 1.3.0
 
 - name: logrotate
   src: nickhammond.logrotate

--- a/requirements.yml
+++ b/requirements.yml
@@ -19,4 +19,4 @@
 
 - name: mailhog
   src: geerlingguy.mailhog
-  version: 1.1.0
+  version: 2.1.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,6 @@
 - name: composer
   src: geerlingguy.composer
-  version: 1.2.7
+  version: 1.5.0
 
 - name: ntp
   src: resmo.ntp
@@ -8,14 +8,14 @@
 
 - name: logrotate
   src: nickhammond.logrotate
-  version: fc3ea4
+  version: e7a498d
 
 - name: swapfile
   src: kamaln7.swapfile
   version: 0.4
 
 - src: geerlingguy.daemonize
-  version: 1.1.0
+  version: 1.1.1
 
 - name: mailhog
   src: geerlingguy.mailhog

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -4,4 +4,4 @@ ansible_requirements:
   - version: 2.1.0.0
     operator: '!='
 
-default_timezone: Etc/UTC
+ntp_timezone: Etc/UTC

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -63,20 +63,11 @@
 
 - name: Validate timezone variable
   stat:
-    path: /usr/share/zoneinfo/{{ default_timezone }}
+    path: /usr/share/zoneinfo/{{ ntp_timezone }}
   register: timezone_path
   changed_when: false
 
 - name: Explain timezone error
   fail:
-    msg: "{{ default_timezone }} is not a valid timezone. For a list of valid timezones, check https://php.net/manual/en/timezones.php"
+    msg: "{{ ntp_timezone }} is not a valid timezone. For a list of valid timezones, check https://php.net/manual/en/timezones.php"
   when: not timezone_path.stat.exists
-
-- name: Get current timezone
-  command: cat /etc/timezone
-  register: current_timezone
-  changed_when: false
-
-- name: Set timezone
-  command: timedatectl set-timezone {{ default_timezone }}
-  when: current_timezone.stdout != default_timezone

--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -14,7 +14,7 @@ php_sendmail_path: /usr/sbin/ssmtp -t
 php_session_save_path: /tmp
 php_upload_max_filesize: 25M
 php_track_errors: 'Off'
-php_default_timezone: '{{ default_timezone }}'
+php_timezone: '{{ ntp_timezone }}'
 
 php_opcache_enable: 1
 php_opcache_enable_cli: 1

--- a/roles/php/templates/php.ini.j2
+++ b/roles/php/templates/php.ini.j2
@@ -14,7 +14,7 @@ session.save_path = {{ php_session_save_path }}
 track_errors = {{ php_track_errors }}
 upload_max_filesize = {{ php_upload_max_filesize }}
 expose_php = Off
-date.timezone = {{ php_default_timezone }}
+date.timezone = {{ php_timezone }}
 
 [mysqlnd]
 mysqlnd.collect_memory_statistics = {{ php_mysqlnd_collect_memory_statistics }}


### PR DESCRIPTION
**MailHog.** This PR fixes #679, a conflict between an out-of-date MailHog galaxy role and Ansible 2.2 (also noted at [discourse](https://discourse.roots.io/t/could-not-find-the-requested-service-mailhog/8034/)). Note that the latest MailHog role switches to using mhsendmail, "a sendmail replacement for MailHog," so `dev.yml` no longer needs the `ssmtp` role and `group_vars/development/mail.yml` no longer needs the ssmtp variables. We could potentially move the one remaining variable to `group_vars/development/main.yml` and remove the `mail.yml` file.

**Logrotate.** This PR also fixes a conflict between the logrotate galaxy role and Ansible 2.2. The out-of-date logrotate role included a "bare" variable which now fails in Ansible 2.2. This PR updates to latest logrotate role version that has this update:
```diff
- with_items: logrotate_scripts
+ with_items: "{{ logrotate_scripts }}"
```

**NTP.** This PR replaces the [resmo.ntp](https://github.com/resmo/ansible-role-ntp) galaxy role with the [geerlingguy.ntp](https://github.com/geerlingguy/ansible-role-ntp) role, which may have a little more activity. In this latter, the task "[Set the correct timezone](https://github.com/geerlingguy/ansible-role-ntp/blob/1.3.0/tasks/main.yml#L5-L10)" replaces our `common` role's [`timedatectl set-timezone`](https://github.com/roots/trellis/blob/1040828ba54d37b9a4095867067cefe4b5507c6c/roles/common/tasks/main.yml#L81) command. The two tasks do the same thing. The [timedatectl manpage](http://manpages.ubuntu.com/manpages/wily/man1/timedatectl.1.html) says the `set-timezone` command "will alter the /etc/localtime symlink," which is what the geerlingguy role does manually.  Note: geerlingguy's role uses the variable `ntp_timezone` so I renamed the Trellis [`default_timezone`](https://github.com/roots/trellis/blob/1040828ba54d37b9a4095867067cefe4b5507c6c/group_vars/all/main.yml#L5) variable to `ntp_timezone`.

**Other roles.** The PR also updates the  geerlingguy.composer and geerlingguy.daemonize roles. These changes appear minor, not requiring discussion.

Tested on Ansible versions 2.0.2.0, 2.1.1.0, and 2.2.0.0