### PR TITLE
Ensure there is always at least one PHP-FPM pool defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Ensure there is always at least one PHP-FPM pool defined ([#682](https://github.com/roots/trellis/pull/682))
 * Update galaxy roles for Ansible 2.2 compatibility ([#681](https://github.com/roots/trellis/pull/681))
 * Update to WP-CLI 0.25.0 for WP 4.7 compat ([#673](https://github.com/roots/trellis/pull/673))
 * Enable per-site setup for permalink structure ([#661](https://github.com/roots/trellis/pull/661))

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -53,13 +53,6 @@
     path: /var/run/php7.0-fpm/
     state: directory
 
-- name: Disable default pool
-  command: mv /etc/php/7.0/fpm/pool.d/www.conf /etc/php/7.0/fpm/pool.d/www.disabled
-  args:
-    creates: /etc/php/7.0/fpm/pool.d/www.disabled
-  when: disable_default_pool
-  notify: reload php-fpm
-
 - name: PHP configuration file
   template:
     src: php.ini.j2

--- a/roles/wordpress-setup/tasks/main.yml
+++ b/roles/wordpress-setup/tasks/main.yml
@@ -28,6 +28,13 @@
     dest: /etc/php/7.0/fpm/pool.d/wordpress.conf
   notify: reload php-fpm
 
+- name: Disable default PHP-FPM pool
+  command: mv /etc/php/7.0/fpm/pool.d/www.conf /etc/php/7.0/fpm/pool.d/www.disabled
+  args:
+    creates: /etc/php/7.0/fpm/pool.d/www.disabled
+  when: disable_default_pool | default(true)
+  notify: reload php-fpm
+
 - include: nginx.yml
   tags: wordpress-setup-nginx
 


### PR DESCRIPTION
### History
Occasionally, the [Start php7.0-fpm service](https://github.com/roots/trellis/blob/a2127653cd8d7274b493a5523d0b83d2305774a2/roles/php/tasks/main.yml#L45) task will fail with the error below.
```
Job for php7.0-fpm.service failed because the control process exited with
error code. See "systemctl status php7.0-fpm.service" and "journalctl -xe"
for details.
```
#642 took a first step to prevent this error and the scenario as presented in [discourse.roots.io/t/7444](https://discourse.roots.io/t/failed-starting-php7-0-fpm-service/7444). Some of the reports in [discourse.roots.io/t/7418](https://discourse.roots.io/t/playbook-server-failed-install-php-7-0/7418/8) were probably related.

### News
The error can still occur when the playbook is rerun after previously failing between these two tasks:
- [php : Disable default pool](https://github.com/roots/trellis/blob/a2127653cd8d7274b493a5523d0b83d2305774a2/roles/php/tasks/main.yml#L56)
- [wordpress-setup : Create WordPress php-fpm configuration file](https://github.com/roots/trellis/blob/a2127653cd8d7274b493a5523d0b83d2305774a2/roles/wordpress-setup/tasks/main.yml#L25)

Between these two tasks, no PHP-FPM pool defined. The `systemctl status php7.0-fpm.service` reveals `ERROR: No pool defined. at least one pool section must be specified in config file`.

Unfortunately the playbook occasionally fails between these two tasks, e.g., due to connectivity issues while downloading a dependency.

### Replicate
To replicate the problem, add this task to the end of `roles/php/tasks/main.yml`:
```
- fail:
    msg: provision again and watch the 'Start php7.0-fpm service' task fail
```
Then run the server.yml twice and see the error in question on the second run.

### Resolution
This PR resolves the issue by removing the default pool only after the new WP pool is created.