### PR TITLE
Use to_text to prevent to_unicode deprecation warning

### DIFF
--- a/lib/trellis/utils/output.py
+++ b/lib/trellis/utils/output.py
@@ -8,7 +8,12 @@ import re
 import textwrap
 
 from ansible import __version__
-from ansible.utils.unicode import to_unicode
+
+# to_unicode will no longer be needed once Trellis requires Ansible >= 2.2
+try:
+    from ansible.module_utils._text import to_text
+except ImportError:
+    from ansible.utils.unicode import to_unicode as to_text
 
 def system(vagrant_version=None):
     # Get most recent Trellis CHANGELOG entry
@@ -69,7 +74,7 @@ def display(obj, result):
 
     # Display additional info when failed
     if failed:
-        items = (item for item in ['reason', 'module_stderr', 'module_stdout', 'stderr'] if item in result and to_unicode(result[item]) != '')
+        items = (item for item in ['reason', 'module_stderr', 'module_stdout', 'stderr'] if item in result and to_text(result[item]) != '')
         for item in items:
             msg = result[item] if msg == '' else '\n'.join([msg, result.pop(item, '')])
 
@@ -78,9 +83,9 @@ def display(obj, result):
 
     # Must pass unicode strings to Display.display() to prevent UnicodeError tracebacks
     if isinstance(msg, list):
-        msg = '\n'.join([to_unicode(x) for x in msg])
+        msg = '\n'.join([to_text(x) for x in msg])
     elif not isinstance(msg, unicode):
-        msg = to_unicode(msg)
+        msg = to_text(msg)
 
     # Wrap text
     msg = '\n'.join([textwrap.fill(line, wrap_width, replace_whitespace=False)


### PR DESCRIPTION
Ansible 2.2+ prints this warning:
```
[DEPRECATION WARNING]: ansible.utils.unicode.to_unicode is deprecated. 
Use ansible.module_utils._text.to_text instead.
This feature will be removed in version 2.4.
```

This PR prevents the deprecation warning by importing and using [`to_text`](https://github.com/ansible/ansible/blob/v2.2.0.0-1/lib/ansible/module_utils/_text.py#L135) when available (Ansible 2.2+) and otherwise falling back to [`to_unicode`](https://github.com/ansible/ansible/blob/v2.1.1.0-1/lib/ansible/utils/unicode.py#L43). The fallback will no longer be needed once Trellis requires Ansible >= 2.2.