### PR TITLE
Make raw_vars compatible with play vars and Ansible 2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Make `raw_vars` compatible with play vars and Ansible 2.1 ([#684](https://github.com/roots/trellis/pull/684))
 * Ensure there is always at least one PHP-FPM pool defined ([#682](https://github.com/roots/trellis/pull/682))
 * Update galaxy roles for Ansible 2.2 compatibility ([#681](https://github.com/roots/trellis/pull/681))
 * Update to WP-CLI 0.25.0 for WP 4.7 compat ([#673](https://github.com/roots/trellis/pull/673))

--- a/lib/trellis/plugins/callback/output.py
+++ b/lib/trellis/plugins/callback/output.py
@@ -5,7 +5,12 @@ __metaclass__ = type
 import os.path
 import sys
 
-from ansible.parsing.dataloader import DataLoader
+from ansible import __version__
+from ansible.errors import AnsibleError
+
+if __version__.startswith('1'):
+    raise AnsibleError('Trellis no longer supports Ansible 1.x. Please upgrade to Ansible 2.x.')
+
 from ansible.plugins.callback.default import CallbackModule as CallbackModule_default
 
 try:
@@ -59,10 +64,9 @@ class CallbackModule(CallbackModule_default):
         super(CallbackModule, self).v2_playbook_on_play_start(play)
 
         # Check for relevant settings or overrides passed via cli --extra-vars
-        loader = DataLoader()
-        play_vars = play.get_variable_manager().get_vars(loader=loader, play=play)
-        if 'vagrant_version' in play_vars:
-            self.vagrant_version = play_vars['vagrant_version']
+        extra_vars = play.get_variable_manager().extra_vars
+        if 'vagrant_version' in extra_vars:
+            self.vagrant_version = extra_vars['vagrant_version']
 
     def v2_runner_item_on_ok(self, result):
         output.display_item(self, result)


### PR DESCRIPTION
[discourse.roots.io/t/7861/3](https://discourse.roots.io/t/server-yml-failing-at-wordpress-setup-create-database-of-sites-after-upgrade-to-0-9-8/7861/3) revealed that [`raw_vars`](https://github.com/roots/trellis/blob/e6bf2ef5bfa9e0ea45cfe48bf3cb108944ba01d0/group_vars/all/main.yml#L15-L20) auto-escaping stopped working as of Ansible 2.1. Ansible made an internal API change removing the possibility for vars plugins to access and modify vars for `Host` objects. The fate of Ansible vars plugins appears uncertain, given that Ansible...
>was planning on killing vars_plugins in their current form  --[_ref_](https://github.com/ansible/ansible/pull/17067#issuecomment-252038254)

This PR moves `plugins/vars/vars.py` to `plugins/callback/vars.py`. In the new callback context, the plugin can still access and modify `Host` vars, restoring the `raw_vars` auto-escaping functionality.

Given that this new callback context also grants access to play vars, the `raw_vars` can now escape play vars (i.e., vars defined in playbooks) in addition to group vars. Play vars take [precedence](https://github.com/ansible/ansible/blob/v2.2.0.0-1/lib/ansible/vars/__init__.py#L199-L210).

I moved the Ansible 1.x warning to the callback plugin `output.py`. As the designated stdout callback plugin, `output.py` is processed first, before `vars.py`.