### PR TITLE
Nginx includes: Move templates dir, fix 'No such file' error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Nginx includes: Move templates dir, fix 'No such file' error ([#687](https://github.com/roots/trellis/pull/687))
 * [BREAKING] Move shell scripts to bin/ directory ([#680](https://github.com/roots/trellis/pull/680))
 * Add myhostname to nsswitch.conf to ensure resolvable hostname ([#686](https://github.com/roots/trellis/pull/686))
 * Add `bin/xdebug-tunnel.sh` to manage Xdebug and SSH tunnels on remote hosts ([#678](https://github.com/roots/trellis/pull/678))

--- a/roles/wordpress-setup/defaults/main.yml
+++ b/roles/wordpress-setup/defaults/main.yml
@@ -1,2 +1,3 @@
 site_uses_local_db: "{{ site_env.db_host == 'localhost' }}"
 nginx_includes_templates_path: nginx-includes
+nginx_includes_d_cleanup: true

--- a/roles/wordpress-setup/defaults/main.yml
+++ b/roles/wordpress-setup/defaults/main.yml
@@ -1,1 +1,2 @@
 site_uses_local_db: "{{ site_env.db_host == 'localhost' }}"
+nginx_includes_templates_path: nginx-includes

--- a/roles/wordpress-setup/defaults/main.yml
+++ b/roles/wordpress-setup/defaults/main.yml
@@ -1,3 +1,5 @@
 site_uses_local_db: "{{ site_env.db_host == 'localhost' }}"
 nginx_includes_templates_path: nginx-includes
+nginx_includes_deprecated: roles/wordpress-setup/templates/includes.d
+nginx_includes_pattern: "^({{ nginx_includes_templates_path | regex_escape }}|{{ nginx_includes_deprecated | regex_escape }})/(.*)\\.j2$"
 nginx_includes_d_cleanup: true

--- a/roles/wordpress-setup/tasks/main.yml
+++ b/roles/wordpress-setup/tasks/main.yml
@@ -35,6 +35,9 @@
   when: disable_default_pool | default(true)
   notify: reload php-fpm
 
+- include: nginx-includes.yml
+  tags: [wordpress-setup-nginx-includes, wordpress-setup-nginx]
+
 - include: nginx.yml
   tags: wordpress-setup-nginx
 

--- a/roles/wordpress-setup/tasks/nginx-includes.yml
+++ b/roles/wordpress-setup/tasks/nginx-includes.yml
@@ -24,28 +24,30 @@
                   map('regex_replace', '^(' + nginx_includes_templates_path + '|.*includes\\.d)\\/(.*)$', '\\2') |
                   map('dirname') | unique | select | list | sort
                }}"
-  register: nginx_includes_paths
 
 - name: Template files out to includes.d
   template:
     src: "{{ item }}"
     dest: "{{ nginx_path }}/includes.d/{{ item | regex_replace('^(' + nginx_includes_templates_path + '|.*includes\\.d)\\/(.*)\\.j2$', '\\2') }}"
   with_items: "{{ nginx_includes_templates.files | map(attribute='path') | list | sort(True) }}"
-  register: nginx_includes_managed
   notify: reload nginx
 
 - name: Retrieve list of existing files in includes.d
-  shell: "find {{ nginx_includes_paths.results | map(attribute='path') | join(' ') }} -type f -name \\*.conf 2>/dev/null || :"
+  find:
+    paths: "{{ nginx_path }}/includes.d"
+    pattern: "*.conf"
+    recurse: yes
   register: nginx_includes_existing
-  changed_when: false
+  when: nginx_includes_d_cleanup
 
 - name: Remove unmanaged files from includes.d
   file:
     path: "{{ item }}"
     state: absent
-  with_items: "{{ nginx_includes_existing.stdout_lines |
-                  difference(nginx_includes_managed.results | default([]) | map(attribute='item') |
-                    map('regex_replace', '(.*)\\.j2', '/etc/nginx/includes.d/\\1') | list
-                  )
+  with_items: "{{ nginx_includes_existing.files | default({}) | map(attribute='path') |
+                  difference(nginx_includes_templates.files | map(attribute='path') |
+                    map('regex_replace', '^(' + nginx_includes_templates_path + '|.*includes\\.d)(.*)\\.j2$', nginx_path + '/includes.d\\2') | unique
+                  ) | list
                }}"
+  when: nginx_includes_d_cleanup
   notify: reload nginx

--- a/roles/wordpress-setup/tasks/nginx-includes.yml
+++ b/roles/wordpress-setup/tasks/nginx-includes.yml
@@ -1,17 +1,26 @@
 ---
+- name: Build list of Nginx includes templates
+  find:
+    paths: roles/wordpress-setup/templates/includes.d
+    pattern: "*.conf.j2"
+    recurse: yes
+  become: no
+  connection: local
+  register: nginx_includes_templates
+
 - name: Create includes.d directories
   file:
     path: "{{ nginx_path }}/includes.d/{{ item }}"
     state: directory
     mode: 0755
-  with_items: "{{ wordpress_sites.keys() }}"
+  with_items: "{{ nginx_includes_templates.files | map(attribute='path') | map('relpath', 'roles/wordpress-setup/templates/includes.d') | map('dirname') | unique | select | list | sort }}"
   register: nginx_includes_paths
 
 - name: Template files out to includes.d
   template:
-    src: "includes.d/{{ item }}"
-    dest: "{{ nginx_path }}/includes.d/{{ item[:-3] }}"
-  with_lines: "cd {{ role_path }}/templates/includes.d && find {{ wordpress_sites.keys() | join(' ') }} -type f -name \\*.conf.j2 2>/dev/null || :"
+    src: "{{ item }}"
+    dest: "{{ nginx_path }}/includes.d/{{ item[:-3] | relpath('roles/wordpress-setup/templates/includes.d') }}"
+  with_items: "{{ nginx_includes_templates.files | map(attribute='path') | list }}"
   register: nginx_includes_managed
   notify: reload nginx
 

--- a/roles/wordpress-setup/tasks/nginx-includes.yml
+++ b/roles/wordpress-setup/tasks/nginx-includes.yml
@@ -1,0 +1,32 @@
+---
+- name: Create includes.d directories
+  file:
+    path: "{{ nginx_path }}/includes.d/{{ item }}"
+    state: directory
+    mode: 0755
+  with_items: "{{ wordpress_sites.keys() }}"
+  register: nginx_includes_paths
+
+- name: Template files out to includes.d
+  template:
+    src: "includes.d/{{ item }}"
+    dest: "{{ nginx_path }}/includes.d/{{ item[:-3] }}"
+  with_lines: "cd {{ role_path }}/templates/includes.d && find {{ wordpress_sites.keys() | join(' ') }} -type f -name \\*.conf.j2 2>/dev/null || :"
+  register: nginx_includes_managed
+  notify: reload nginx
+
+- name: Retrieve list of existing files in includes.d
+  shell: "find {{ nginx_includes_paths.results | map(attribute='path') | join(' ') }} -type f -name \\*.conf 2>/dev/null || :"
+  register: nginx_includes_existing
+  changed_when: false
+
+- name: Remove unmanaged files from includes.d
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items: "{{ nginx_includes_existing.stdout_lines |
+                  difference(nginx_includes_managed.results | default([]) | map(attribute='item') |
+                    map('regex_replace', '(.*)\\.j2', '/etc/nginx/includes.d/\\1') | list
+                  )
+               }}"
+  notify: reload nginx

--- a/roles/wordpress-setup/tasks/nginx-includes.yml
+++ b/roles/wordpress-setup/tasks/nginx-includes.yml
@@ -1,26 +1,36 @@
 ---
 - name: Build list of Nginx includes templates
   find:
-    paths: roles/wordpress-setup/templates/includes.d
+    paths:
+      - "{{ nginx_includes_templates_path }}"
+      - roles/wordpress-setup/templates/includes.d
     pattern: "*.conf.j2"
     recurse: yes
   become: no
   connection: local
   register: nginx_includes_templates
 
+- name: Warn about deprecated Nginx includes directory
+  debug:
+    msg: "[DEPRECATION WARNING]: The `roles/wordpress-setup/templates/includes.d` directory for Trellis Nginx includes templates is deprecated and will no longer function beginning with Trellis 1.0. Please move these templates to a directory named `{{ nginx_includes_templates_path }}` in the root of this project. For more information, see https://roots.io/trellis/docs/nginx-includes/"
+  when: True in nginx_includes_templates.files | map(attribute='path') | map('search', 'roles/wordpress-setup/templates/includes.d') | list
+
 - name: Create includes.d directories
   file:
     path: "{{ nginx_path }}/includes.d/{{ item }}"
     state: directory
     mode: 0755
-  with_items: "{{ nginx_includes_templates.files | map(attribute='path') | map('relpath', 'roles/wordpress-setup/templates/includes.d') | map('dirname') | unique | select | list | sort }}"
+  with_items: "{{ nginx_includes_templates.files | map(attribute='path') |
+                  map('regex_replace', '^(' + nginx_includes_templates_path + '|.*includes\\.d)\\/(.*)$', '\\2') |
+                  map('dirname') | unique | select | list | sort
+               }}"
   register: nginx_includes_paths
 
 - name: Template files out to includes.d
   template:
     src: "{{ item }}"
-    dest: "{{ nginx_path }}/includes.d/{{ item[:-3] | relpath('roles/wordpress-setup/templates/includes.d') }}"
-  with_items: "{{ nginx_includes_templates.files | map(attribute='path') | list }}"
+    dest: "{{ nginx_path }}/includes.d/{{ item | regex_replace('^(' + nginx_includes_templates_path + '|.*includes\\.d)\\/(.*)\\.j2$', '\\2') }}"
+  with_items: "{{ nginx_includes_templates.files | map(attribute='path') | list | sort(True) }}"
   register: nginx_includes_managed
   notify: reload nginx
 

--- a/roles/wordpress-setup/tasks/nginx-includes.yml
+++ b/roles/wordpress-setup/tasks/nginx-includes.yml
@@ -3,7 +3,7 @@
   find:
     paths:
       - "{{ nginx_includes_templates_path }}"
-      - roles/wordpress-setup/templates/includes.d
+      - "{{ nginx_includes_deprecated }}"
     pattern: "*.conf.j2"
     recurse: yes
   become: no
@@ -12,8 +12,8 @@
 
 - name: Warn about deprecated Nginx includes directory
   debug:
-    msg: "[DEPRECATION WARNING]: The `roles/wordpress-setup/templates/includes.d` directory for Trellis Nginx includes templates is deprecated and will no longer function beginning with Trellis 1.0. Please move these templates to a directory named `{{ nginx_includes_templates_path }}` in the root of this project. For more information, see https://roots.io/trellis/docs/nginx-includes/"
-  when: True in nginx_includes_templates.files | map(attribute='path') | map('search', 'roles/wordpress-setup/templates/includes.d') | list
+    msg: "[DEPRECATION WARNING]: The `{{ nginx_includes_deprecated }}` directory for Trellis Nginx includes templates is deprecated and will no longer function beginning with Trellis 1.0. Please move these templates to a directory named `{{ nginx_includes_templates_path }}` in the root of this project. For more information, see https://roots.io/trellis/docs/nginx-includes/"
+  when: True in nginx_includes_templates.files | map(attribute='path') | map('search', nginx_includes_deprecated | regex_escape) | list
 
 - name: Create includes.d directories
   file:
@@ -21,14 +21,14 @@
     state: directory
     mode: 0755
   with_items: "{{ nginx_includes_templates.files | map(attribute='path') |
-                  map('regex_replace', '^(' + nginx_includes_templates_path + '|.*includes\\.d)\\/(.*)$', '\\2') |
+                  map('regex_replace', nginx_includes_pattern, '\\2') |
                   map('dirname') | unique | select | list | sort
                }}"
 
 - name: Template files out to includes.d
   template:
     src: "{{ item }}"
-    dest: "{{ nginx_path }}/includes.d/{{ item | regex_replace('^(' + nginx_includes_templates_path + '|.*includes\\.d)\\/(.*)\\.j2$', '\\2') }}"
+    dest: "{{ nginx_path }}/includes.d/{{ item | regex_replace(nginx_includes_pattern, '\\2') }}"
   with_items: "{{ nginx_includes_templates.files | map(attribute='path') | list | sort(True) }}"
   notify: reload nginx
 
@@ -46,7 +46,7 @@
     state: absent
   with_items: "{{ nginx_includes_existing.files | default({}) | map(attribute='path') |
                   difference(nginx_includes_templates.files | map(attribute='path') |
-                    map('regex_replace', '^(' + nginx_includes_templates_path + '|.*includes\\.d)(.*)\\.j2$', nginx_path + '/includes.d\\2') | unique
+                    map('regex_replace', nginx_includes_pattern, nginx_path + '/includes.d/\\2') | unique
                   ) | list
                }}"
   when: nginx_includes_d_cleanup

--- a/roles/wordpress-setup/tasks/nginx.yml
+++ b/roles/wordpress-setup/tasks/nginx.yml
@@ -15,38 +15,6 @@
   with_dict: "{{ wordpress_sites }}"
   when: item.value.ssl.enabled and item.value.ssl.key is defined
 
-- name: Create includes.d directories
-  file:
-    path: "{{ nginx_path }}/includes.d/{{ item }}"
-    state: directory
-    mode: 0755
-  with_items: "{{ wordpress_sites.keys() }}"
-  register: nginx_includes_paths
-
-- name: Template files out to includes.d
-  template:
-    src: "includes.d/{{ item }}"
-    dest: "{{ nginx_path }}/includes.d/{{ item[:-3] }}"
-  with_lines: "cd {{ role_path }}/templates/includes.d && find {{ wordpress_sites.keys() | join(' ') }} -type f -name \\*.conf.j2 2>/dev/null || :"
-  register: nginx_includes_managed
-  notify: reload nginx
-
-- name: Retrieve list of existing files in includes.d
-  shell: "find {{ nginx_includes_paths.results | map(attribute='path') | join(' ') }} -type f -name \\*.conf 2>/dev/null || :"
-  register: nginx_includes_existing
-  changed_when: false
-
-- name: Remove unmanaged files from includes.d
-  file:
-    path: "{{ item }}"
-    state: absent
-  with_items: "{{ nginx_includes_existing.stdout_lines |
-                  difference(nginx_includes_managed.results | default([]) | map(attribute='item') |
-                    map('regex_replace', '(.*)\\.j2', '/etc/nginx/includes.d/\\1') | list
-                  )
-               }}"
-  notify: reload nginx
-
 - name: Create Nginx conf for challenges location
   template:
     src: "{{ playbook_dir }}/roles/letsencrypt/templates/acme-challenge-location.conf.j2"


### PR DESCRIPTION
This PR fixes #517, preventing the message that occurs if users have no Nginx includes templates: `roles/wordpress-setup/templates/includes.d: No such file or directory`.
Docs in [roots/docs#57](https://github.com/roots/docs/pull/57)

What changes for users?
- Users will no longer see 'No such file' error.
- Everything continues to function as is, but users will see a deprecation warning until they move templates to `nginx-includes` (directory name configurable via `nginx_includes_templates_path`).
- Users now have option to set `nginx_includes_d_cleanup: false` to prevent Trellis from removing unmanaged confs from remote.

More possibilities and options will come in the Nginx hooks PR #688. For example, the current Nginx includes are limited in that files can only be included in one spot within the conf, within the site's primary `server` block. [#688](https://github.com/roots/trellis/pull/688) will make it possible add lines or includes elsewhere (outside `server` block, etc.).