### PR TITLE
Modularize Nginx wordpress-site.conf.j2 and add Nginx conf hooks

### DIFF
--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -19,3 +19,6 @@ nginx_cache_size: 250m
 nginx_cache_inactive: 1h
 nginx_skip_cache_uri: /wp-admin/|/xmlrpc.php|wp-.*.php|/feed/|index.php|sitemap(_index)?.xml
 nginx_skip_cache_cookie: comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in
+
+# Nginx hooks
+nginx_http: ''

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -54,13 +54,3 @@
   args:
     creates: "{{ nginx_path }}/sites-enabled/no-default.conf"
   notify: reload nginx
-
-- name: Create base WordPress config
-  template:
-    src: wordpress.conf.j2
-    dest: "{{ nginx_path }}/wordpress.conf"
-
-- name: Create base WordPress subdirectory Multisite config
-  template:
-    src: wordpress_multisite_subdirectories.conf.j2
-    dest: "{{ nginx_path }}/wordpress_multisite_subdirectories.conf"

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -42,6 +42,7 @@
     src: nginx.conf.j2
     dest: "{{ nginx_path }}/nginx.conf"
   notify: reload nginx
+  tags: nginx-includes
 
 - name: Disable default server
   file:

--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -32,6 +32,8 @@ error_log  {{ nginx_logs_root }}/error.log warn;
 pid        /run/nginx.pid;
 
 http {
+  {{ nginx_http | indent(2) }}
+
   # Hide nginx version information.
   server_tokens off;
 

--- a/roles/nginx/templates/wordpress_multisite_subdirectories.conf.j2
+++ b/roles/nginx/templates/wordpress_multisite_subdirectories.conf.j2
@@ -1,7 +1,0 @@
-# {{ ansible_managed }}
-
-if (!-e $request_filename) {
-  rewrite /wp-admin$ $scheme://$host$uri/ permanent;
-  rewrite ^(/[^/]+)?(/wp-.*) /wp$2 last;
-  rewrite ^(/[^/]+)?(/.*\.php) /wp$2 last;
-}

--- a/roles/wordpress-setup/defaults/main.yml
+++ b/roles/wordpress-setup/defaults/main.yml
@@ -3,3 +3,7 @@ nginx_includes_templates_path: nginx-includes
 nginx_includes_deprecated: roles/wordpress-setup/templates/includes.d
 nginx_includes_pattern: "^({{ nginx_includes_templates_path | regex_escape }}|{{ nginx_includes_deprecated | regex_escape }})/(.*)\\.j2$"
 nginx_includes_d_cleanup: true
+nginx_server_before: ''
+nginx_location_before: include includes.d/{{ item.key }}/*.conf;
+nginx_location: ''
+nginx_location_php: ''

--- a/roles/wordpress-setup/tasks/main.yml
+++ b/roles/wordpress-setup/tasks/main.yml
@@ -36,7 +36,7 @@
   notify: reload php-fpm
 
 - include: nginx-includes.yml
-  tags: [wordpress-setup-nginx-includes, wordpress-setup-nginx]
+  tags: [nginx-includes, wordpress-setup-nginx]
 
 - include: nginx.yml
   tags: wordpress-setup-nginx

--- a/roles/wordpress-setup/tasks/nginx.yml
+++ b/roles/wordpress-setup/tasks/nginx.yml
@@ -27,6 +27,7 @@
     dest: "{{ nginx_path }}/sites-available/{{ item.key }}.conf"
   with_dict: "{{ wordpress_sites }}"
   notify: reload nginx
+  tags: nginx-includes
 
 - name: Enable WordPress site
   file:

--- a/roles/wordpress-setup/templates/https-redirect.conf.j2
+++ b/roles/wordpress-setup/templates/https-redirect.conf.j2
@@ -1,0 +1,17 @@
+{% if ssl_enabled %}
+server {
+  listen 80;
+
+  server_name {{ site_hosts | join(' ') }}{% if item.value.multisite.subdomains | default(false) %} *.{{ site_hosts_canonical | join(' *.') }}{% endif %};
+
+  {% if item.value.ssl.provider | default('manual') == 'letsencrypt' -%}
+  include acme-challenge-location.conf;
+
+  location / {
+    return 301 https://$host$request_uri;
+  }
+  {% else %}
+  return 301 https://$host$request_uri;
+  {% endif -%}
+}
+{% endif %}

--- a/roles/wordpress-setup/templates/multisite-rewrites.conf.j2
+++ b/roles/wordpress-setup/templates/multisite-rewrites.conf.j2
@@ -1,0 +1,12 @@
+{% if item.value.multisite.enabled | default(false) -%}
+  {% if item.value.multisite.subdomains | default(false) -%}
+    rewrite ^/(wp-.*.php)$ /wp/$1 last;
+    rewrite ^/(wp-(content|admin|includes).*) /wp/$1 last;
+  {%- else -%}
+    if (!-e $request_filename) {
+      rewrite /wp-admin$ $scheme://$host$uri/ permanent;
+      rewrite ^(/[^/]+)?(/wp-.*) /wp$2 last;
+      rewrite ^(/[^/]+)?(/.*\.php) /wp$2 last;
+    }
+  {%- endif %}
+{%- endif %}

--- a/roles/wordpress-setup/templates/redirects.conf.j2
+++ b/roles/wordpress-setup/templates/redirects.conf.j2
@@ -1,0 +1,23 @@
+{% for host in item.value.site_hosts if host.redirects | default([]) %}
+server {
+  {% if ssl_enabled -%}
+    listen 443 ssl http2;
+
+    {{ lookup('template', 'https.conf.j2') | indent(4) }}
+  {% else -%}
+    listen 80;
+  {% endif -%}
+
+  server_name {{ host.redirects | join(' ') }};
+
+  {% if not ssl_enabled -%}
+    include acme-challenge-location.conf;
+
+    location / {
+      return 301 $scheme://{{ host.canonical }}$request_uri;
+    }
+  {% else %}
+    return 301 $scheme://{{ host.canonical }}$request_uri;
+  {% endif %}
+}
+{% endfor %}

--- a/roles/wordpress-setup/templates/wordpress-base.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-base.conf.j2
@@ -4,6 +4,7 @@ location ~* /app/uploads/.*\.php$ {
 }
 
 location / {
+  {{ item.value.nginx_location | default(nginx_location) | indent(2) }}
   try_files $uri $uri/ /index.php?$args;
 }
 

--- a/roles/wordpress-setup/templates/wordpress-base.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-base.conf.j2
@@ -1,5 +1,3 @@
-# {{ ansible_managed }}
-
 # Prevent PHP scripts from being executed inside the uploads folder.
 location ~* /app/uploads/.*\.php$ {
   deny all;

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -11,21 +11,11 @@ server {
   index index.php index.htm index.html;
 
   charset utf-8;
-
   {% if env == 'development' -%}
   # See Virtualbox section at http://wiki.nginx.org/Pitfalls
   sendfile off;
   {%- endif %}
-
-  {% if item.value.multisite.enabled | default(false) -%}
-    {% if item.value.multisite.subdomains | default(false) -%}
-      rewrite ^/(wp-.*.php)$ /wp/$1 last;
-      rewrite ^/(wp-(content|admin|includes).*) /wp/$1 last;
-    {%- else -%}
-      include wordpress_multisite_subdirectories.conf;
-    {%- endif %}
-  {%- endif %}
-
+  {{ lookup('template', 'multisite-rewrites.conf.j2') | indent(2) }}
   add_header Fastcgi-Cache $upstream_cache_status;
 
   {% if ssl_enabled %}{{ lookup('template', 'https.conf.j2') }}{% endif %}
@@ -51,7 +41,8 @@ server {
   {% endif -%}
 
   include includes.d/{{ item.key }}/*.conf;
-  include wordpress.conf;
+
+  {{ lookup('template', 'wordpress-base.conf.j2') | indent(2) }}
 
   location ~ \.php$ {
     try_files $uri /index.php;
@@ -69,41 +60,5 @@ server {
     fastcgi_pass unix:/var/run/php-fpm-wordpress.sock;
   }
 }
-
-{% if ssl_enabled %}
-server {
-  listen 80;
-
-  server_name {{ site_hosts | join(' ') }}{% if item.value.multisite.subdomains | default(false) %} *.{{ site_hosts_canonical | join(' *.') }}{% endif %};
-
-  {% if item.value.ssl.provider | default('manual') == 'letsencrypt' -%}
-  include acme-challenge-location.conf;
-
-  location / {
-    return 301 https://$host$request_uri;
-  }
-  {% else %}
-  return 301 https://$host$request_uri;
-  {% endif -%}
-}
-{% endif %}
-
-{% for host in item.value.site_hosts if host.redirects | default([]) %}
-server {
-  listen {{ ssl_enabled | ternary('443 ssl http2', '80') }};
-
-  {% if ssl_enabled %}{{ lookup('template', 'https.conf.j2') }}{% endif %}
-
-  server_name {{ host.redirects | join(' ') }};
-
-  {% if not ssl_enabled -%}
-    include acme-challenge-location.conf;
-
-    location / {
-      return 301 $scheme://{{ host.canonical }}$request_uri;
-    }
-  {% else %}
-    return 301 $scheme://{{ host.canonical }}$request_uri;
-  {% endif %}
-}
-{% endfor %}
+{{ lookup('template', 'https-redirect.conf.j2') }}
+{{ lookup('template', 'redirects.conf.j2') }}

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -1,4 +1,5 @@
 # {{ ansible_managed }}
+{{ item.value.nginx_server_before | default(nginx_server_before) }}
 
 server {
   listen {{ ssl_enabled | ternary('443 ssl http2', '80') }};
@@ -40,11 +41,12 @@ server {
     }
   {% endif -%}
 
-  include includes.d/{{ item.key }}/*.conf;
+  {{ item.value.nginx_location_before | default(nginx_location_before) | indent(2) }}
 
   {{ lookup('template', 'wordpress-base.conf.j2') | indent(2) }}
 
   location ~ \.php$ {
+    {{ item.value.nginx_location_php | default(nginx_location_php) | indent(4) }}
     try_files $uri /index.php;
 
     {% if item.value.cache is defined and item.value.cache.enabled | default(false) -%}


### PR DESCRIPTION
Trellis Nginx includes have been limited to one location, inside the primary `server` block. This PR adds hooks to enable users to include files or inject snippets in other locations (e.g., outside `server` block). Here is [an example](https://discourse.roots.io/t/nginx-error-server-name-hash-bucket-size-exceeded/7905/3) of needing to inject a directive in the `http` context.

The docs in [roots/docs#57](https://github.com/roots/docs/pull/57) will be most helpful for understanding the intent of this PR. Builds on [#687](https://github.com/roots/trellis/pull/687)

This PR is simpler than it looks. The first commit accounts for most all the PR's additions/deletions, and doesn't change code. It just breaks the WordPress site conf out into separate modules/files. The second commit (Nginx hooks) adds only 13 lines.

The modularization of the Nginx confs is for convenience, to make the sections clear amongst all the jinja templating complexity. This is the approach already in use for `roles/wordpress-setup/templates/https.conf.j2`.

The one change made in the modularization is that this PR moves the base WordPress conf out of the `nginx` role into the `wordpress-setup` role. This changes this base WP conf from an `include` whose content is general to all sites, to content injected into each site's conf such that it can be customized per site, via the `nginx_location` hook.
