### PR TITLE
Fix 404s by moving skip_cache conditions to server block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Fix 404s by moving skip_cache conditions to server block ([#692](https://github.com/roots/trellis/pull/692))
 * Nginx includes: Move templates dir, fix 'No such file' error ([#687](https://github.com/roots/trellis/pull/687))
 * [BREAKING] Move shell scripts to bin/ directory ([#680](https://github.com/roots/trellis/pull/680))
 * Add myhostname to nsswitch.conf to ensure resolvable hostname ([#686](https://github.com/roots/trellis/pull/686))

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -40,30 +40,31 @@ server {
     include acme-challenge-location.conf;
   {% endif %}
 
+  {% if item.value.cache is defined and item.value.cache.enabled | default(false) -%}
+    set $skip_cache 0;
+
+    if ($query_string != "") {
+      set $skip_cache 1;
+    }
+
+    # Don't cache uris containing the following segments
+    if ($request_uri ~* "{{ item.value.cache.skip_cache_uri | default(nginx_skip_cache_uri) }}") {
+      set $skip_cache 1;
+    }
+
+    # Don't use the cache if cookies includes the following
+    if ($http_cookie ~* "{{ item.value.cache.skip_cache_cookie | default(nginx_skip_cache_cookie) }}") {
+      set $skip_cache 1;
+    }
+  {% endif -%}
+
   include includes.d/{{ item.key }}/*.conf;
   include wordpress.conf;
 
   location ~ \.php$ {
-    try_files $uri =404;
-    error_page 404 /index.php;
+    try_files $uri /index.php;
 
     {% if item.value.cache is defined and item.value.cache.enabled | default(false) -%}
-      set $skip_cache 0;
-
-      if ($query_string != "") {
-        set $skip_cache 1;
-      }
-
-      # Don't cache uris containing the following segments
-      if ($request_uri ~* "{{ item.value.cache.skip_cache_uri | default(nginx_skip_cache_uri) }}") {
-        set $skip_cache 1;
-      }
-
-      # Don't use the cache if cookies includes the following
-      if ($http_cookie ~* "{{ item.value.cache.skip_cache_cookie | default(nginx_skip_cache_cookie) }}") {
-        set $skip_cache 1;
-      }
-
       fastcgi_cache wordpress;
       fastcgi_cache_valid {{ item.value.cache.duration | default(nginx_cache_duration) }};
       fastcgi_cache_bypass $skip_cache;


### PR DESCRIPTION
**Problem**
Fixes a version of #436 where a system default 404 page is returned instead of the WordPress 404 (via index.html) . To reproduce, provision with cache [`enabled: true`](https://github.com/roots/trellis/blob/78400a99e953c6db3c628adde8b866e4fe13ece4/group_vars/production/wordpress_sites.yml#L21) and do any of the following:

- visit `example.com/missing.php?p=1` (triggers the `$query_string` condition in code block below)
- visit `example.com/xmlrpc.php` (triggers [`nginx_skip_cache_uri`](https://github.com/roots/trellis/blob/78400a99e953c6db3c628adde8b866e4fe13ece4/roles/nginx/defaults/main.yml#L20) condition in code block below)
- log in to `wp-admin` and then visit `example.com/missing.php` (triggers [`nginx_skip_cache_cookie`](https://github.com/roots/trellis/blob/78400a99e953c6db3c628adde8b866e4fe13ece4/roles/nginx/defaults/main.yml#L21) in code block below)

**Solution**
The PR diff display overcomplicates the changes. This PR simply moves the following portion of the caching section up out of the location block context and into the server block context.
```
set $skip_cache 0;

if ($query_string != "") {
  set $skip_cache 1;
}

# Don't cache uris containing the following segments
if ($request_uri ~* "{{ item.value.cache.skip_cache_uri | default(nginx_skip_cache_uri) }}") {
  set $skip_cache 1;
}

# Don't use the cache if cookies includes the following
if ($http_cookie ~* "{{ item.value.cache.skip_cache_cookie | default(nginx_skip_cache_cookie) }}") {
  set $skip_cache 1;
}
```

**Explanation**
Why does it fix the problem to move these `if` conditions out of the `location ~ \.php$` block? Because [If Is Evil](https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/), particularly when inside a location block. Here is a summary of the affected Trellis location block:

```
location ~ \.php$ {
  try_files $uri =404;
  error_page 404 /index.php;

  ... if conditions in code block above ...
}
```

The excerpt above appears to exhibit the problem demonstrated in the [example](https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/#examples) titled `# try_files wont work due to if`. If one of the `if` conditions is met, the `try_files` directive won't even be run. In our case, this means the WP `index.php` does not load and the system 404 is used instead. I am guessing this is related to the various descriptions [here](http://agentzh.blogspot.com/2011/03/how-nginx-location-if-works.html) about how 'Nginx traps into the "if" inner block because its condition ... was met.'

**Justification**
Here are two examples recommending placing the `if` condition cache exceptions in the server block instead of the location block: [easyengine.io](https://easyengine.io/wordpress-nginx/tutorials/single-site/fastcgi-cache-with-purging/) and [digitalocean.com](https://www.digitalocean.com/community/tutorials/how-to-setup-fastcgi-caching-with-nginx-on-your-vps), the latter even suggesting that these exceptions "must be used in the **server{ }** context."