### PR TITLE
Switch to distro packages for MariaDB

### DIFF
--- a/roles/mariadb/defaults/main.yml
+++ b/roles/mariadb/defaults/main.yml
@@ -1,8 +1,4 @@
 mariadb_binary_logging_disabled: true
-mariadb_keyserver_fingerprint: "0xcbcb082a1bb943db"
-mariadb_mirror: nyc2.mirrors.digitalocean.com
-mariadb_version: "10.0"
-mariadb_dist: trusty
 mysql_root_user: root
 
 sites_using_remote_db: "[{% for name, site in wordpress_sites.iteritems() if site.env is defined and site.env.db_host | default('localhost') != 'localhost' %}'{{ name }}',{% endfor %}]"

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -1,17 +1,4 @@
 ---
-- name: Add MariaDB MySQL apt-key
-  apt_key:
-    url: "http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search={{ mariadb_keyserver_fingerprint }}"
-    state: present
-
-- name: Add MariaDB MySQL deb and deb-src
-  apt_repository:
-    repo: "{{ item }}"
-    state: present
-  with_items:
-    - "deb http://{{ mariadb_mirror }}/mariadb/repo/{{ mariadb_version }}/ubuntu {{ mariadb_dist | default(ansible_distribution_release) }} main"
-    - "deb-src http://{{ mariadb_mirror }}/mariadb/repo/{{ mariadb_version }}/ubuntu {{ mariadb_dist | default(ansible_distribution_release) }} main"
-
 - name: Install MySQL client
   apt:
     name: mariadb-client


### PR DESCRIPTION
Use official Ubuntu managed packages for simplicity and less dependencies to deal with.

#659