### PR TITLE
Composer install: Use composer module and run as non-root

### DIFF
--- a/roles/deploy/hooks/build-after.yml
+++ b/roles/deploy/hooks/build-after.yml
@@ -10,6 +10,6 @@
   when: not composer_json.stat.exists
 
 - name: Install Composer dependencies
-  command: composer install --no-ansi --no-dev --no-interaction --no-progress --optimize-autoloader --no-scripts
-  args:
-    chdir: "{{ deploy_helper.new_release_path }}"
+  composer:
+    no_scripts: yes
+    working_dir: "{{ deploy_helper.new_release_path }}"

--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -17,12 +17,12 @@
   changed_when: env_file.stdout == "{{ item.key }}.env"
 
 - name: Install Dependencies with Composer
-  command: composer install
-  args:
-    chdir: "{{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/"
-  register: composer_results
+  composer:
+    no_dev: no
+    optimize_autoloader: no
+    working_dir: "{{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/"
+  become: no
   with_dict: "{{ wordpress_sites }}"
-  changed_when: "'Nothing to install or update' not in composer_results.stderr"
 
 - name: Install WP
   command: wp core {{ item.value.multisite.enabled | default(false) | ternary('multisite-install', 'install') }}


### PR DESCRIPTION
Prevents the cause of the `Do not run Composer as root/super user!` message when provisioning the Vagrant VM (example [thread](https://discourse.roots.io/t/ssh-fowarding-fails-during-provisioning-works-on-vagrant-ssh/7938)).