### PR TITLE
PHP 7.1 update

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,5 +1,5 @@
 ---
-- name: "WordPress Server: Install LEMP Stack with PHP 7.0 and MariaDB MySQL"
+- name: "WordPress Server: Install LEMP Stack with PHP 7.1 and MariaDB MySQL"
   hosts: web:&development
   become: yes
   remote_user: vagrant

--- a/group_vars/all/users.yml
+++ b/group_vars/all/users.yml
@@ -19,4 +19,4 @@ users:
 web_user: web
 web_group: www-data
 web_sudoers:
-  - "/usr/sbin/service php7.0-fpm *"
+  - "/usr/sbin/service php7.1-fpm *"

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -6,7 +6,7 @@
 
 - name: reload php-fpm
   service:
-    name: php7.0-fpm
+    name: php7.1-fpm
     state: reloaded
 
 - name: reload nginx

--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -31,7 +31,7 @@
   when: wp_installed | success and project.multisite.enabled | default(false)
 
 - name: Reload php-fpm
-  shell: sudo service php7.0-fpm reload
+  shell: sudo service php7.1-fpm reload
   args:
     chdir: "{{ deploy_helper.new_release_path }}"
     warn: false

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -1,42 +1,42 @@
 ---
-- name: Add PHP 7.0 PPA
+- name: Add PHP 7.1 PPA
   apt_repository:
     repo: "ppa:ondrej/php"
     update_cache: yes
 
-- name: Install PHP 7.0
+- name: Install PHP 7.1
   apt:
     name: "{{ item }}"
     state: present
     force: yes
   with_items:
-  - php7.0-cli
-  - php7.0-common
-  - php7.0-curl
-  - php7.0-dev
-  - php7.0-fpm
-  - php7.0-gd
-  - php7.0-mbstring
-  - php7.0-mcrypt
-  - php7.0-mysql
-  - php7.0-opcache
-  - php7.0-xml
-  - php7.0-xmlrpc
-  - php7.0-zip
+  - php7.1-cli
+  - php7.1-common
+  - php7.1-curl
+  - php7.1-dev
+  - php7.1-fpm
+  - php7.1-gd
+  - php7.1-mbstring
+  - php7.1-mcrypt
+  - php7.1-mysql
+  - php7.1-opcache
+  - php7.1-xml
+  - php7.1-xmlrpc
+  - php7.1-zip
 
-- name: Start php7.0-fpm service
+- name: Start php7.1-fpm service
   service:
-    name: php7.0-fpm
+    name: php7.1-fpm
     state: started
     enabled: true
 
 - name: Create socket directory
   file:
-    path: /var/run/php7.0-fpm/
+    path: /var/run/php7.1-fpm/
     state: directory
 
 - name: PHP configuration file
   template:
     src: php.ini.j2
-    dest: /etc/php/7.0/fpm/php.ini
+    dest: /etc/php/7.1/fpm/php.ini
   notify: reload php-fpm

--- a/roles/wordpress-setup/tasks/main.yml
+++ b/roles/wordpress-setup/tasks/main.yml
@@ -25,13 +25,13 @@
 - name: Create WordPress php-fpm configuration file
   template:
     src: php-fpm.conf.j2
-    dest: /etc/php/7.0/fpm/pool.d/wordpress.conf
+    dest: /etc/php/7.1/fpm/pool.d/wordpress.conf
   notify: reload php-fpm
 
 - name: Disable default PHP-FPM pool
-  command: mv /etc/php/7.0/fpm/pool.d/www.conf /etc/php/7.0/fpm/pool.d/www.disabled
+  command: mv /etc/php/7.1/fpm/pool.d/www.conf /etc/php/7.1/fpm/pool.d/www.disabled
   args:
-    creates: /etc/php/7.0/fpm/pool.d/www.disabled
+    creates: /etc/php/7.1/fpm/pool.d/www.disabled
   when: disable_default_pool | default(true)
   notify: reload php-fpm
 

--- a/roles/xdebug/tasks/main.yml
+++ b/roles/xdebug/tasks/main.yml
@@ -8,13 +8,13 @@
   - name: Template the Xdebug configuration file
     template:
       src: xdebug.ini.j2
-      dest: /etc/php/7.0/mods-available/xdebug.ini
+      dest: /etc/php/7.1/mods-available/xdebug.ini
     notify: reload php-fpm
 
   - name: Ensure 20-xdebug.ini is present
     file:
-      src: /etc/php/7.0/mods-available/xdebug.ini
-      dest: /etc/php/7.0/fpm/conf.d/20-xdebug.ini
+      src: /etc/php/7.1/mods-available/xdebug.ini
+      dest: /etc/php/7.1/fpm/conf.d/20-xdebug.ini
       state: link
     notify: reload php-fpm
 
@@ -22,12 +22,12 @@
 
 - name: Disable Xdebug
   file:
-    path: /etc/php/7.0/fpm/conf.d/20-xdebug.ini
+    path: /etc/php/7.1/fpm/conf.d/20-xdebug.ini
     state: absent
   when: not xdebug_remote_enable | bool
   notify: reload php-fpm
 
 - name: Disable Xdebug CLI
   file:
-    path: /etc/php/7.0/cli/conf.d/20-xdebug.ini
+    path: /etc/php/7.1/cli/conf.d/20-xdebug.ini
     state: absent

--- a/server.yml
+++ b/server.yml
@@ -17,7 +17,7 @@
     - name: Install Python 2.x
       raw: sudo apt-get install -qq -y python-simplejson
 
-- name: WordPress Server - Install LEMP Stack with PHP 7.0 and MariaDB MySQL
+- name: WordPress Server - Install LEMP Stack with PHP 7.1 and MariaDB MySQL
   hosts: web:&{{ env }}
   become: yes
   roles:

--- a/xdebug-tunnel.yml
+++ b/xdebug-tunnel.yml
@@ -13,5 +13,5 @@
   handlers:
     - name: reload php-fpm
       service:
-        name: php7.0-fpm
+        name: php7.1-fpm
         state: reloaded


### PR DESCRIPTION
Tested on fresh `vagrant up` as well as provisioning from master then 7.1 on top for some backwards compatibility testing.

Provisioning over top of a PHP 7.0 box appears to run fine, but the `php7.0-fpm` continues to run, and the 7.1 service cannot start until the 7.0 is stopped. I'm not sure why Ansible did not throw an error.

This is also probably on hold until WP 4.7, as there is a big ugly warning thrown on first provision with the 2015 theme: https://core.trac.wordpress.org/ticket/37772