### PR TITLE
Fix ANSIBLE_PATH in windows.sh

### DIFF
--- a/bin/windows.sh
+++ b/bin/windows.sh
@@ -5,7 +5,7 @@
 # @author Andrea Brandi
 # @version 1.0
 
-ANSIBLE_PATH="$(find /vagrant -name 'bin/windows.sh' -printf '%h' -quit)"
+ANSIBLE_PATH="$(find /vagrant -name 'dev.yml' -printf '%h' -quit)"
 export PYTHONUNBUFFERED=1
 
 # Create an ssh key if not already created.


### PR DESCRIPTION
Thanks @christopher-stook for mentioning:

>I noticed the ANSIBLE_PATH becomes /vagrant/bin instead of /vagrant in the windows.sh script which means it will not find the playbooks in the vagrant root.   _[--ref](https://github.com/roots/trellis/commit/0aebdd69feb19c94416429bb44ee54974a56194f#commitcomment-20028782)_

