### PR TITLE
Add `main` format to wordpress-sites access_log

### DIFF
--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -8,7 +8,7 @@ server {
   {% endif %}
 
   server_name  {% for host in site_hosts_canonical %}{{ host }} {% if item.value.multisite.subdomains | default(false) %}*.{{ host }} {% endif %}{% endfor %};
-  access_log   {{ www_root }}/{{ item.key }}/logs/access.log;
+  access_log   {{ www_root }}/{{ item.key }}/logs/access.log main;
   error_log    {{ www_root }}/{{ item.key }}/logs/error.log;
 
   root  {{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/web;


### PR DESCRIPTION
Seems this is an error. Just took me half an hour to figure out why the `log_format` in the main nginx.conf file was not actually being used.

Thanks for all you do!