### PR TITLE
Update apt before python install, avoid redundant cache updates

### DIFF
--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -1,7 +1,7 @@
 composer_keep_updated: true
 composer_global_packages:
  - { name: hirak/prestissimo }
-apt_cache_valid_time: 86400
+apt_cache_valid_time: 3600
 ntp_timezone: Etc/UTC
 ntp_manage_config: true
 www_root: /srv/www

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -44,14 +44,12 @@
   when: env != 'development' and darwin_without_passlib | default(false)
   run_once: true
 
-- name: Update Apt
-  apt:
-    update_cache: yes
-
 - name: Checking essentials
   apt:
     name: "{{ item }}"
     state: present
+    update_cache: true
+    cache_valid_time: "{{ apt_cache_valid_time }}"
   with_items:
   - python-software-properties
   - python-pycurl

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -3,6 +3,8 @@
   apt:
     name: mariadb-client
     state: present
+    update_cache: true
+    cache_valid_time: "{{ apt_cache_valid_time }}"
 
 - block:
   - name: Install MySQL server

--- a/roles/memcached/tasks/main.yml
+++ b/roles/memcached/tasks/main.yml
@@ -4,6 +4,7 @@
     name: "{{ item }}"
     state: present
     update_cache: yes
+    cache_valid_time: "{{ apt_cache_valid_time }}"
   with_items:
   - memcached
   - php-memcached

--- a/roles/ssmtp/tasks/main.yml
+++ b/roles/ssmtp/tasks/main.yml
@@ -3,6 +3,8 @@
   apt:
     name: ssmtp
     state: present
+    update_cache: true
+    cache_valid_time: "{{ apt_cache_valid_time }}"
 
 - name: ssmtp configuration
   template:

--- a/roles/xdebug/tasks/main.yml
+++ b/roles/xdebug/tasks/main.yml
@@ -4,6 +4,8 @@
     apt:
       name: php-xdebug
       state: latest
+      update_cache: true
+      cache_valid_time: "{{ apt_cache_valid_time }}"
 
   - name: Template the Xdebug configuration file
     template:

--- a/server.yml
+++ b/server.yml
@@ -15,7 +15,9 @@
   become: yes
   tasks:
     - name: Install Python 2.x
-      raw: sudo apt-get install -qq -y python-simplejson
+      raw: which python || sudo apt-get update && sudo apt-get install -qq -y python-simplejson
+      register: python_check
+      changed_when: not python_check.stdout | search('/usr/bin/python')
 
 - name: WordPress Server - Install LEMP Stack with PHP 7.0 and MariaDB MySQL
   hosts: web:&{{ env }}


### PR DESCRIPTION
This PR adds an `apt-get update` before the first python install task, fixing the error that occurs with AWS `AMI ID ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20161020 (ami-a9d276c9)`

```
TASK [Install Python 2.x] ******************************************************
Thursday 08 December 2016  19:58:53 -0700 (0:00:00.078)       0:00:18.633 *****
System info:
  Ansible 2.2.0.0; Darwin
  Trellis at "Ansible-Local for Vagrant boxes on Windows"
---------------------------------------------------
Shared connection to 54.187.85.176 closed.
fatal: [54.187.85.176]: FAILED! => {"changed": true, "failed": true, "rc": 100, "stderr": "Shared 
connection to 54.187.85.176 closed.\r\n", "stdout": "\r\nE: Failed to fetch http://us-west-
2.ec2.archive.ubuntu.com/ubuntu/pool/main/p/python2.7/libpython2.7-minimal_2.7.12-
1~16.04_amd64.deb  404  Not Found [IP: 54.71.119.81 80]\r\n\r\nE: Failed to fetch http://us-west-
2.ec2.archive.ubuntu.com/ubuntu/pool/main/p/python2.7/python2.7-minimal_2.7.12-
1~16.04_amd64.deb  404  Not Found [IP: 54.71.119.81 80]\r\n\r\nE: Failed to fetch http://us-west-
2.ec2.archive.ubuntu.com/ubuntu/pool/main/p/python2.7/libpython2.7-stdlib_2.7.12-
1~16.04_amd64.deb  404  Not Found [IP: 54.71.119.81 80]\r\n\r\nE: Failed to fetch http://us-west-
2.ec2.archive.ubuntu.com/ubuntu/pool/main/p/python2.7/python2.7_2.7.12-1~16.04_amd64.deb  404  
Not Found [IP: 54.71.119.81 80]\r\n\r\nE: Unable to fetch some archives, maybe run apt-get update 
or try with --fix-missing?\r\n", "stdout_lines": ["", "E: Failed to fetch http://us-west-
2.ec2.archive.ubuntu.com/ubuntu/pool/main/p/python2.7/libpython2.7-minimal_2.7.12-
1~16.04_amd64.deb  404  Not Found [IP: 54.71.119.81 80]", "", "E: Failed to fetch http://us-west-
2.ec2.archive.ubuntu.com/ubuntu/pool/main/p/python2.7/python2.7-minimal_2.7.12-
1~16.04_amd64.deb  404  Not Found [IP: 54.71.119.81 80]", "", "E: Failed to fetch http://us-west-
2.ec2.archive.ubuntu.com/ubuntu/pool/main/p/python2.7/libpython2.7-stdlib_2.7.12-
1~16.04_amd64.deb  404  Not Found [IP: 54.71.119.81 80]", "", "E: Failed to fetch http://us-west-
2.ec2.archive.ubuntu.com/ubuntu/pool/main/p/python2.7/python2.7_2.7.12-1~16.04_amd64.deb  404  
Not Found [IP: 54.71.119.81 80]", "", "E: Unable to fetch some archives, maybe run apt-get update or 
try with --fix-missing?"]}
	to retry, use: --limit @/Users/philip/projects/roots/example.com/ansible/server.retry
```

This PR makes that first `apt-get update` and python install only run if python is not already installed, and makes the task idempotent.

This PR takes advantage of the existing [`apt_cache_valid_time`](https://github.com/roots/trellis/blob/8453c53213eb722e5293dded8cceff3ebf33a493/group_vars/all/main.yml#L4) variable to prevent redundant cache updates via the [apt module](http://docs.ansible.com/ansible/apt_module.html)'s `cache_valid_time` option.

I shortened the cache expiration from 24 hours to 1 hour. I figure the cache should not repeatedly update within one "session" of provisioning attempts, which might last less than one hour, but should update on the next session, even if it is just later the same day. The 24 hour default may have originally been drawn from [`roles/ferm/README.md`](https://github.com/roots/trellis/blob/8453c53213eb722e5293dded8cceff3ebf33a493/roles/ferm/README.md).

Other notes
- I've used `update_cache: true` as appears elsewhere in Trellis. However, Trellis also has some instances of `update_cache: yes`. I figure I'll let some future PR review all booleans for consistency.
- In `roles/mariadb/tasks/main.yml` I deliberately only set `update_cache` on the first of the two apt tasks. My rationale is that users may run roles separately, so each role should update the cache in its first apt task.