### PR TITLE
Create /home/vagrant/trellis bindfs mount with proper permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### HEAD
+* Create `/home/vagrant/trellis` bindfs mount with proper permissions ([#705](https://github.com/roots/trellis/pull/705))
+
 ### 0.9.9: December 14th, 2016
 * Create `project_shared_children` files if they do not exist ([#706](https://github.com/roots/trellis/pull/706))
 * Diffie-Hellman params now conditional on SSL status ([#709](https://github.com/roots/trellis/pull/709))

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -160,7 +160,7 @@ def post_up_message
   msg << "\n* Composer and WP-CLI commands need to be run on the virtual machine."
   msg << "\n* You can SSH into the machine with `vagrant ssh`."
   msg << "\n* Then navigate to your WordPress sites at `/srv/www`"
-  msg << "\n  or to your Trellis files at `/home/vagrant/trellis`."
+  msg << "\n  or to your Trellis files at `#{ANSIBLE_PATH_ON_VM}`."
 
   msg
 end

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -10,3 +10,4 @@ roles_path = vendor/roles
 
 [ssh_connection]
 ssh_args = -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s
+pipelining = True


### PR DESCRIPTION
Fixes an [issue](https://github.com/roots/trellis/issues/697#issuecomment-264594492) where Ansible, running in a VM on a Windows host, throws an error while interpreting a `.vault_pass` file as executable.

```
ERROR! Problem running vault password script / v a g r a n t / . v a u l t _ p a s s ([Errno 8]
Exec format error). If this is not a script, remove the executable bit from the file.
```

This PR implements a variation of [`@aoe`'s approach](https://discourse.roots.io/t/shared-trellis-folder-permissions-vault-problem/6640/7), using vagrant-bindfs to mount the `/vagrant` share with non-executable permissions. This PR makes a separate bindfs mount for `/vagrant/bin` executable, the only items that need to be executable, as far as I know.

Punishing details below.

### NFS performance
I could have wrapped the new vagrant-bindfs mounts (lines 85-87) in a conditional for Windows only, but it seems simpler without. I compared [times](http://stackoverflow.com/a/29132716/6847025) from 20 trials of a test playbook that runs various Ansible `local_action` tasks on the VM from a regular VirtualBox share (current Trellis) and from an NFS share (result of this PR). The NFS mean time of 23.245 seconds (_SD_ = 2.018) was slightly faster than the VB share mean of 23.603 seconds (_SD_ = 2.401), but the difference was not statistically significant, _p_ = 0.613. This suggests that changing to NFS doesn't incur any performance hit.

### Pipelining
Performance tests while preparing this PR also examined setting [`pipelining = True`](http://docs.ansible.com/ansible/intro_configuration.html#pipelining) in `ansible.cfg`.
>By default, this option is disabled to preserve compatibility with sudoers configurations that have requiretty (the default on many distros), but is highly recommended if you can enable it.

The Trellis Ubuntu Xenial distro does not have `requiretty` in `/etc/sudoers`, so :+1: pipelining. 

Repeating the performance tests mentioned above, but with pipelining enabled, the NFS mean time of 18.238 seconds (_SD_ = 0.323) was again slightly faster than the VB share mean of 18.618 seconds (_SD_ = 0.188), and the difference statistically significant, _p_ < 0.001 (very small difference nonetheless). This again suggests that changing to NFS doesn't incur any performance hit.

### Mount options
I tested various combinations of [`mount_options`](http://manpages.ubuntu.com/manpages/xenial/en/man5/nfs.5.html)`: ['rw', 'vers=3', 'tcp', fsc', 'actimeo=1']` that appear in various internet reports of how to speed up NFS performance on Vagrant. According to `nfsstat -m` (command run on the VM) our nfs shares automatically apply the `rw` and `vers=3`. The other options occasionally achieved tiny improvements that were statistically significant, but their effect size was so small they seemed negligible and not worth including.

The `fsc` would require installing and enabling `cachefilesd` on the VM, then remounting the NFS shares, which would complicate the `vagrant up` process, unless we start using a vagrant box with `cachefilesd` already installed/enabled. 

The `tcp` option is said to be slower, but helpful if NFS is used over "lossy networks." This didn't feel applicable, and testing results didn't show a clear benefit.

The `actimeo` option to set file attribute cache times would perhaps improve `gulp watch` response times if `gulp` were being run on the VM ([example](https://www.inovex.de/blog/doh-my-vagrant-nfs-is-slow/)), but the Roots recommendation is to run `gulp` on the host machine.

I also tested these mount options on the NFS share with the `site` files. The 20 iterations of `touch site/web/app/themes/sage/assets` then measuring the `gulp watch` build times and Browsersync page load times with a VM running roots/sage 8.5.0 again occasionally showed statistically significant differences, but again they had negligibly small effect sizes, so I omitted all mount options for `site`. Perhaps someone will want to revisit these mount options with Sage 9 when it's released.

### Permissions on .vault_pass
A nice thing about [`@aoe`'s approach](https://discourse.roots.io/t/shared-trellis-folder-permissions-vault-problem/6640/7) of `.vault_pass` into a new `vault/` dir is the `p: '0000,u=rD'` so `g` and `o` have no permissions for `.vault_pass`. However, for Trellis to sync a `vault/` directory by default, the directory would have to always be present, whether added to Trellis core, or created by every user, which seems impractical. Users who want tighter permissions on just `.vault_pass` can create their own directory and sync it as `@aoe` suggested. Even then, `.vault_pass` would still be readable by `vagrant` user, the user that I imagine will be used by all accessing the VM.