### PR TITLE
Create project_shared_children files if they do not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Create `project_shared_children` files if they do not exist ([#706](https://github.com/roots/trellis/pull/706))
 * Diffie-Hellman params now conditional on SSL status ([#709](https://github.com/roots/trellis/pull/709))
 * Update PHP to 7.1 ([#695](https://github.com/roots/trellis/pull/695))
 * Update WP-CLI to 1.0.0 ([#708](https://github.com/roots/trellis/pull/708))

--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -44,3 +44,6 @@ project_environment:
 # The project_current_path is the symlink used for the latest or active deployment
 # - default is 'current'
 project_current_path: "{{ project.current_path | default('current') }}"
+
+# Helpers
+project_shared_file: "{{ item.type | default('directory') | lower in ['file', 'touch'] }}"

--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -21,15 +21,15 @@ project_templates:
     src: roles/deploy/templates/env.j2
     dest: .env
 
-# The shared_children is a list of all files/folders in your project that need to be linked to a path in "/shared".
+# The shared_children is a list of all files/folders in your project that need to be linked to a path in `/shared`.
 # For example a sessions directory or an uploads folder. They are created if they don't exist, with the type
-# specified in the `type` key (file or directory).
+# specified in the `type` key (file or directory). Use `type: absent` to remove an item from `/shared`.
 # Example:
 # project_shared_children:
-#   - path: "app/sessions"
-#     src: "sessions"
-#     mode: "0755"
-#     type: "file" / "directory"  // <- optional, defaults to "directory"
+#   - path: app/sessions  // <- required for type `directory` and `file`, optional for type `absent`
+#     src: sessions       // <- required
+#     mode: '0755'        // <- optional, must be quoted, defaults to `'0755'` if `directory` or `'0644'` if `file`
+#     type: directory     // <- optional, defaults to `directory`, options: `directory`, `file`, `absent`
 project_shared_children:
   - path: web/app/uploads
     src: uploads

--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -23,13 +23,13 @@ project_templates:
 
 # The shared_children is a list of all files/folders in your project that need to be linked to a path in `/shared`.
 # For example a sessions directory or an uploads folder. They are created if they don't exist, with the type
-# specified in the `type` key (file or directory). Use `type: absent` to remove an item from `/shared`.
+# specified in the `type` key (file or directory).
 # Example:
 # project_shared_children:
-#   - path: app/sessions  // <- required for type `directory` and `file`, optional for type `absent`
-#     src: sessions       // <- required
+#   - path: app/sessions
+#     src: sessions
 #     mode: '0755'        // <- optional, must be quoted, defaults to `'0755'` if `directory` or `'0644'` if `file`
-#     type: directory     // <- optional, defaults to `directory`, options: `directory`, `file`, `absent`
+#     type: directory     // <- optional, defaults to `directory`, options: `directory` or `file`
 project_shared_children:
   - path: web/app/uploads
     src: uploads
@@ -44,6 +44,3 @@ project_environment:
 # The project_current_path is the symlink used for the latest or active deployment
 # - default is 'current'
 project_current_path: "{{ project.current_path | default('current') }}"
-
-# Helpers
-project_shared_file: "{{ item.type | default('directory') | lower in ['file', 'touch'] }}"

--- a/roles/deploy/tasks/share.yml
+++ b/roles/deploy/tasks/share.yml
@@ -5,7 +5,7 @@
 - name: Ensure shared sources are present -- directories
   file:
     path: "{{ deploy_helper.shared_path }}/{{ project_shared_file | ternary(item.src | dirname, item.src) }}"
-    state: "{{ project_shared_file | ternary('directory', item.type | default('directory')) }}"
+    state: "{{ project_shared_file | ternary('directory', item.type | default('directory')) | lower }}"
     mode: "{{ project_shared_file | ternary('0755', item.mode | default('0755')) }}"
   with_items: "{{ project_shared_children }}"
 
@@ -17,18 +17,26 @@
   with_items: "{{ project_shared_children }}"
   when: project_shared_file
 
+- name: Ensure parent directories for shared paths are present
+  file:
+    path: "{{ deploy_helper.new_release_path }}/{{ item.path | default('') | dirname }}"
+    state: directory
+  with_items: "{{ project_shared_children }}"
+
 - name: Ensure shared paths are absent
   file:
-    path: "{{ deploy_helper.new_release_path }}/{{ item.path }}"
+    path: "{{ deploy_helper.new_release_path }}/{{ item.path  | default('') }}"
     state: absent
   with_items: "{{ project_shared_children }}"
+  when: item.type | default('directory') | lower != 'absent'
 
 - name: Create shared symlinks
   file:
-    path: "{{ deploy_helper.new_release_path }}/{{ item.path }}"
+    path: "{{ deploy_helper.new_release_path }}/{{ item.path | default('') }}"
     src: "{{ deploy_helper.shared_path }}/{{ item.src }}"
     state: link
   with_items: "{{ project_shared_children }}"
+  when: item.type | default('directory') | lower != 'absent'
 
 - include: "{{ deploy_share_after | default('../hooks/example.yml') }}"
   tags: deploy-share-after

--- a/roles/deploy/tasks/share.yml
+++ b/roles/deploy/tasks/share.yml
@@ -2,12 +2,20 @@
 - include: "{{ deploy_share_before | default('../hooks/example.yml') }}"
   tags: deploy-share-before
 
-- name: Ensure shared sources are present
+- name: Ensure shared sources are present -- directories
+  file:
+    path: "{{ deploy_helper.shared_path }}/{{ project_shared_file | ternary(item.src | dirname, item.src) }}"
+    state: "{{ project_shared_file | ternary('directory', item.type | default('directory')) }}"
+    mode: "{{ project_shared_file | ternary('0755', item.mode | default('0755')) }}"
+  with_items: "{{ project_shared_children }}"
+
+- name: Ensure shared sources are present -- files
   file:
     path: "{{ deploy_helper.shared_path }}/{{ item.src }}"
-    state: "{{ item.type | default('directory') }}"
-    mode: "{{ item.mode | default('0755') }}"
+    state: touch
+    mode: "{{ item.mode | default('0644') }}"
   with_items: "{{ project_shared_children }}"
+  when: project_shared_file
 
 - name: Ensure shared paths are absent
   file:

--- a/roles/deploy/tasks/share.yml
+++ b/roles/deploy/tasks/share.yml
@@ -4,10 +4,19 @@
 
 - name: Ensure shared sources are present -- directories
   file:
-    path: "{{ deploy_helper.shared_path }}/{{ project_shared_file | ternary(item.src | dirname, item.src) }}"
-    state: "{{ project_shared_file | ternary('directory', item.type | default('directory')) | lower }}"
-    mode: "{{ project_shared_file | ternary('0755', item.mode | default('0755')) }}"
+    path: "{{ deploy_helper.shared_path }}/{{ item.src }}"
+    state: directory
+    mode: "{{ item.mode | default('0755') }}"
   with_items: "{{ project_shared_children }}"
+  when: item.type | default('directory') | lower == 'directory'
+
+- name: Ensure shared sources are present -- files' parent directories
+  file:
+    path: "{{ deploy_helper.shared_path }}/{{ item.src | dirname }}"
+    state: directory
+    mode: '0755'
+  with_items: "{{ project_shared_children }}"
+  when: item.type | default('directory') | lower == 'file'
 
 - name: Ensure shared sources are present -- files
   file:
@@ -15,28 +24,26 @@
     state: touch
     mode: "{{ item.mode | default('0644') }}"
   with_items: "{{ project_shared_children }}"
-  when: project_shared_file
+  when: item.type | default('directory') | lower == 'file'
 
 - name: Ensure parent directories for shared paths are present
   file:
-    path: "{{ deploy_helper.new_release_path }}/{{ item.path | default('') | dirname }}"
+    path: "{{ deploy_helper.new_release_path }}/{{ item.path | dirname }}"
     state: directory
   with_items: "{{ project_shared_children }}"
 
 - name: Ensure shared paths are absent
   file:
-    path: "{{ deploy_helper.new_release_path }}/{{ item.path  | default('') }}"
+    path: "{{ deploy_helper.new_release_path }}/{{ item.path }}"
     state: absent
   with_items: "{{ project_shared_children }}"
-  when: item.type | default('directory') | lower != 'absent'
 
 - name: Create shared symlinks
   file:
-    path: "{{ deploy_helper.new_release_path }}/{{ item.path | default('') }}"
+    path: "{{ deploy_helper.new_release_path }}/{{ item.path }}"
     src: "{{ deploy_helper.shared_path }}/{{ item.src }}"
     state: link
   with_items: "{{ project_shared_children }}"
-  when: item.type | default('directory') | lower != 'absent'
 
 - include: "{{ deploy_share_after | default('../hooks/example.yml') }}"
   tags: deploy-share-after


### PR DESCRIPTION
Fixes this [discourse thread](https://discourse.roots.io/t/create-symlinks-for-files/7086).

The "[Ensure shared sources are present](https://github.com/roots/trellis/blob/8453c53213eb722e5293dded8cceff3ebf33a493/roles/deploy/tasks/share.yml#L5-L10)" task uses the [file module](http://docs.ansible.com/ansible/file_module.html) to create directories or files in the `shared` directory.

The [comments for `project_shared_children`](https://github.com/roots/trellis/blob/8453c53213eb722e5293dded8cceff3ebf33a493/roles/deploy/defaults/main.yml#L25) in the deploy/defaults indicates that items in the list "are created if they don't exist." The problem is that if a user specifies `type: file`, this is fed to the `state` option for the file module, but when `state` is "`file`, the file will NOT be created if it does not exist." 

In addition, the file module will not create the subdirectories a file may be in, if they are missing. 

This PR splits the "Ensure shared sources are present" task in two. The first task creates all the shared directories, including the parent directories of shared files. The second task touches the files.
> If `touch` (new in 1.4), an empty file will be created if the `path` does not exist, while an existing file or directory will receive updated file access and modification times  [-- ref](http://docs.ansible.com/ansible/file_module.html) 

Touch is necessary if we actually want to create files, but unfortunately it is never idempotent.

This approach should still allow for `type`/`state` values such as `absent`.