### PR TITLE
Remove obsolete references to vars_plugins path

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,6 @@ ENV['ANSIBLE_CALLBACK_PLUGINS'] = "~/.ansible/plugins/callback_plugins/:/usr/sha
 ENV['ANSIBLE_FILTER_PLUGINS'] = "~/.ansible/plugins/filter_plugins/:/usr/share/ansible_plugins/filter_plugins:#{File.join(ANSIBLE_PATH, 'lib/trellis/plugins/filter')}"
 ENV['ANSIBLE_LIBRARY'] = "/usr/share/ansible:#{File.join(ANSIBLE_PATH, 'lib/trellis/modules')}"
 ENV['ANSIBLE_ROLES_PATH'] = File.join(ANSIBLE_PATH, 'vendor', 'roles')
-ENV['ANSIBLE_VARS_PLUGINS'] = "~/.ansible/plugins/vars_plugins/:/usr/share/ansible_plugins/vars_plugins:#{File.join(ANSIBLE_PATH, 'lib/trellis/plugins/vars')}"
 
 config_file = File.join(ANSIBLE_PATH, 'group_vars', 'development', 'wordpress_sites.yml')
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -7,7 +7,6 @@ force_handlers = True
 inventory = hosts
 nocows = 1
 roles_path = vendor/roles
-vars_plugins = ~/.ansible/plugins/vars_plugins/:/usr/share/ansible_plugins/vars_plugins:lib/trellis/plugins/vars
 
 [ssh_connection]
 ssh_args = -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s


### PR DESCRIPTION
When #548 added `lib/trellis/plugins/vars/vars.py` it added the `vars_plugins` config to `ansible.cfg`. 

Later, #684 removed `lib/trellis/plugins/vars/vars.py` but neglected to remove the `vars_plugins` config from `ansible.cfg` and `Vagrantfile`. This PR fixes that.