### PR TITLE
Update WP-CLI to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Update WP-CLI to 1.0.0 ([#708](https://github.com/roots/trellis/pull/708))
 * Ansible-Local for Vagrant boxes on Windows ([#690](https://github.com/roots/trellis/pull/690))
 * Install MariaDB via Ubuntu's official distro packages ([#693](https://github.com/roots/trellis/pull/693))
 * Fix 404s by moving skip_cache conditions to server block ([#692](https://github.com/roots/trellis/pull/692))

--- a/roles/wp-cli/defaults/main.yml
+++ b/roles/wp-cli/defaults/main.yml
@@ -1,4 +1,4 @@
-wp_cli_version: 0.25.0
+wp_cli_version: 1.0.0
 wp_cli_bin_path: /usr/bin/wp
 wp_cli_phar_url: "https://github.com/wp-cli/wp-cli/releases/download/v{{ wp_cli_version }}/wp-cli-{{ wp_cli_version }}.phar"
 wp_cli_completion_url: "https://raw.githubusercontent.com/wp-cli/wp-cli/v{{ wp_cli_version }}/utils/wp-completion.bash"

--- a/roles/wp-cli/tasks/main.yml
+++ b/roles/wp-cli/tasks/main.yml
@@ -1,10 +1,15 @@
 ---
-- name: Install WP-CLI
+- name: Download WP-CLI
   get_url:
     url: "{{ wp_cli_phar_url }}"
-    dest: "{{ wp_cli_bin_path }}"
-    force: true
-    mode: 0755
+    dest: /tmp/wp-cli-{{ wp_cli_version }}.phar
+
+- name: Install WP-CLI
+  command: rsync -c --chmod=0755 --info=name /tmp/wp-cli-{{ wp_cli_version }}.phar {{ wp_cli_bin_path }}
+  args:
+    warn: false
+  register: wp_cli
+  changed_when: wp_cli.stdout == "wp-cli{{ wp_cli_version }}.phar"
 
 - name: Retrieve WP-CLI tab completions
   command: curl -4Ls {{ wp_cli_completion_url }} -o /tmp/wp-completion-{{ wp_cli_version }}.bash


### PR DESCRIPTION
Also improve the WP-CLI download/install process.

Removes the need to `force` meaning we can skip downloading every time regardless if it's already installed.