### PR TITLE
Make Diffie-Hellman creation conditional on ssl enabled

### DIFF
--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -21,6 +21,7 @@
   args:
     chdir: "{{ nginx_path }}/ssl"
     creates: "{{ nginx_path }}/ssl/dhparams.pem"
+  when: true in [{% for key, site in wordpress_sites.iteritems() %}{{ site.ssl.enabled }},{% endfor %}]
   notify: reload nginx
   tags: [diffie-hellman]
 


### PR DESCRIPTION
Discussion in #253 

The "Generate strong unique Diffie-Hellman group" task can take a long time to run and is only necessary if SSL will be needed. This PR makes the task conditional on SSL enabled for at least one site.