### PR TITLE
Remove creation of unused socket directory

### DIFF
--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -30,11 +30,6 @@
     state: started
     enabled: true
 
-- name: Create socket directory
-  file:
-    path: /var/run/php7.1-fpm/
-    state: directory
-
 - name: PHP configuration file
   template:
     src: php.ini.j2


### PR DESCRIPTION
The php7.1-fpm socket is created at /var/run so no need for this directory to be created