### PR TITLE
Ensure all groups from users.yml are present on server

### DIFF
--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
-- name: Ensure sudo group is present
+- name: Ensure requested groups are present
   group:
-    name: sudo
+    name: "{{ item }}"
     state: present
+  with_items: "{{ users | sum(attribute='groups', start=[]) | list | unique }}"
 
 - name: Ensure sudo group has sudo privileges
   lineinfile:


### PR DESCRIPTION
If someone adds a `nonexistent-group` to `users` in `group_vars/all/users.yml`, "Setup users" will fail:
```
TASK [users : Setup users] *****************************************************
System info:
  Ansible 2.2.0.0; Darwin
  Trellis 0.9.9: December 14th, 2016
---------------------------------------------------
Group nonexistent-group does not exist
```
It is probably expected that just as Trellis creates the users in `users`, Trellis should create the `groups`.

This PR adjusts the task "Ensure sudo group is present" to check for and create all `groups` from `users`. Borrows this [`sum(attribute='...',...)`](https://github.com/roots/trellis/blob/ad8910b1c80f2782e1b9fcf336f5e07d6759129b/group_vars/all/helpers.yml#L12) technique Trellis uses already.