### PR TITLE
Fix #522 - Check if branch is master and prompt to continue

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -5,6 +5,9 @@ DEPLOY_CMD="ansible-playbook deploy.yml -e env=$1 -e site=$2"
 ENVIRONMENTS=( hosts/* )
 ENVIRONMENTS=( "${ENVIRONMENTS[@]##*/}" )
 NUM_ARGS=2
+BRANCH_NAME="$(git symbolic-ref HEAD 2>/dev/null)" ||
+BRANCH_NAME="(unnamed branch)"     # detached HEAD
+BRANCH_NAME=${BRANCH_NAME##refs/heads/}
 
 show_usage() {
   echo "Usage: deploy <environment> <site name>
@@ -33,4 +36,15 @@ if [[ ! -e $HOSTS_FILE ]]; then
   exit 0
 fi
 
-$DEPLOY_CMD
+if [[ $BRANCH_NAME != 'master' ]]
+then
+  echo -e 'You are not on master branch. Are you sure you want to continue? [y/N]'
+  read -r RESPONSE
+fi
+if [[ $RESPONSE =~ ^([yY][eE][sS]|[yY])$ ]]
+  then
+    $DEPLOY_CMD
+  else
+    echo -e 'Aborted'
+    exit 0
+fi


### PR DESCRIPTION
Before executing the deploy command. Verify if the actual branch is master, if not prompt a warning asking to continue or abort the deploy. 