### PR TITLE
Update finalize after hooks with better paths

### DIFF
--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -2,21 +2,15 @@
 - name: WordPress Installed?
   command: wp core is-installed {{ project.multisite.enabled | default(false) | ternary('--network', '') }}
   args:
-    chdir: "{{ deploy_helper.new_release_path }}"
+    chdir: "{{ deploy_helper.current_path }}"
   register: wp_installed
   changed_when: false
   failed_when: wp_installed.stderr != ""
 
-- name: Update WP theme paths
-  command: wp eval 'wp_clean_themes_cache(); switch_theme(get_stylesheet());'
-  args:
-    chdir: "{{ deploy_helper.new_release_path }}"
-  when: wp_installed | success
-
 - name: Update WP database
   command: wp core update-db
   args:
-    chdir: "{{ deploy_helper.new_release_path }}"
+    chdir: "{{ deploy_helper.current_path }}"
   when: wp_installed | success and not project.multisite.enabled | default(false)
 
 - name: Warn about updating network database.
@@ -27,11 +21,16 @@
 - name: Update WP network database
   command: wp core update-db --network
   args:
-    chdir: "{{ deploy_helper.new_release_path }}"
+    chdir: "{{ deploy_helper.current_path }}"
   when: wp_installed | success and project.multisite.enabled | default(false)
+
+- name: Update WP theme paths
+  command: wp eval 'wp_clean_themes_cache(); switch_theme(get_stylesheet());'
+  args:
+    chdir: "{{ deploy_helper.current_path }}"
+  when: wp_installed | success
 
 - name: Reload php-fpm
   shell: sudo service php7.1-fpm reload
   args:
-    chdir: "{{ deploy_helper.new_release_path }}"
     warn: false


### PR DESCRIPTION
Ref: https://github.com/roots/trellis/issues/718 - don't think this fixes it, just something I noticed while debugging.

`new_release_path` was being used but at this point the symlink has already been created and the deploy finalized so we should use `current_path`.

This also moves the themes path update task after DB updates.