### PR TITLE
Fix #718 - change method of updating theme paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Fix #718 - improve method of updating theme paths ([#720](https://github.com/roots/trellis/pull/720))
 * Create `/home/vagrant/trellis` bindfs mount with proper permissions ([#705](https://github.com/roots/trellis/pull/705))
 
 ### 0.9.9: December 14th, 2016

--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -24,11 +24,23 @@
     chdir: "{{ deploy_helper.current_path }}"
   when: wp_installed | success and project.multisite.enabled | default(false)
 
-- name: Update WP theme paths
-  command: wp eval 'wp_clean_themes_cache(); switch_theme(get_stylesheet());'
+- name: Get WP theme template root
+  command: wp option get template_root
   args:
     chdir: "{{ deploy_helper.current_path }}"
+  register: wp_template_root
+  changed_when: false
+  failed_when: wp_template_root.stderr != ""
   when: wp_installed | success
+
+- name: Update WP theme paths
+  command: wp option set {{ item }} {{ deploy_helper.new_release_path }}/web/wp/wp-content/themes
+  args:
+    chdir: "{{ deploy_helper.current_path }}"
+  when: wp_installed | success and wp_template_root != '/themes' and wp_template_root != ''
+  with_items:
+    - stylesheet_root
+    - template_root
 
 - name: Reload php-fpm
   shell: sudo service php7.1-fpm reload


### PR DESCRIPTION
After a deploy we were running `switch_theme` would had the side effect of sometimes making sidebar widgets inactive.

This uses a simpler, more direct method of updating `stylesheet_root` and `template_root` which should be less error-prone since it does less.