### PR TITLE
Make handler out of task disabling acme challenge sites

### DIFF
--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -1,4 +1,11 @@
 ---
+- name: disable temporary challenge sites
+  file:
+    path: "{{ nginx_path }}/sites-enabled/letsencrypt-{{ item.key }}.conf"
+    state: absent
+  with_dict: "{{ wordpress_sites }}"
+  notify: reload nginx
+
 - name: restart memcached
   service:
     name: memcached

--- a/roles/letsencrypt/tasks/certificates.yml
+++ b/roles/letsencrypt/tasks/certificates.yml
@@ -1,3 +1,4 @@
+---
 - name: Generate private keys
   shell: openssl genrsa 4096 > {{ letsencrypt_keys_dir }}/{{ item.key }}.key
   args:
@@ -29,12 +30,4 @@
     chdir: "{{ acme_tiny_data_directory }}"
   register: generate_initial_cert
   changed_when: generate_initial_cert.stdout is defined and 'Created' in generate_initial_cert.stdout
-  notify: reload nginx
-
-- name: Disable Nginx site
-  file:
-    path: "{{ nginx_path }}/sites-enabled/letsencrypt-{{ item.key }}.conf"
-    state: absent
-  with_dict: "{{ wordpress_sites }}"
-  when: sites_need_confs
   notify: reload nginx

--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - include: setup.yml
 - include: nginx.yml
 - include: certificates.yml

--- a/roles/letsencrypt/tasks/nginx.yml
+++ b/roles/letsencrypt/tasks/nginx.yml
@@ -1,3 +1,4 @@
+---
 - name: Check for existing Nginx conf per site
   stat:
     path: "{{ nginx_path }}/sites-enabled/{{ item.key }}.conf"
@@ -25,6 +26,7 @@
     state: link
   when: not item | skipped and not item.stat.exists
   with_items: "{{ nginx_confs.results }}"
+  notify: disable temporary challenge sites
 
 - include: "{{ playbook_dir }}/roles/common/tasks/reload_nginx.yml"
   when: sites_need_confs

--- a/roles/letsencrypt/tasks/setup.yml
+++ b/roles/letsencrypt/tasks/setup.yml
@@ -1,3 +1,4 @@
+---
 - name: Create directories and set permissions
   file:
     mode: "{{ item.mode | default(omit) }}"

--- a/roles/wordpress-setup/tasks/self-signed-certificate.yml
+++ b/roles/wordpress-setup/tasks/self-signed-certificate.yml
@@ -9,5 +9,4 @@
     creates: "{{ item.key }}.*"
   with_dict: "{{ wordpress_sites }}"
   when: ssl_enabled and item.value.ssl.provider | default('manual') == 'self-signed'
-  notify:
-    - reload nginx
+  notify: reload nginx


### PR DESCRIPTION
Originally part of #630:

In current Trellis, suppose the playbook fails after the "[Enable Nginx sites](https://github.com/roots/trellis/blob/6ad6fcbb6e0c0cfdaaf7ecb734c2e867ff0437a7/roles/letsencrypt/tasks/nginx.yml#L21)" task, but before the "[Disable Nginx site](https://github.com/roots/trellis/blob/6ad6fcbb6e0c0cfdaaf7ecb734c2e867ff0437a7/roles/letsencrypt/tasks/certificates.yml#L34)" task. Some `letsencrypt-example.com.conf` files would remain enabled and their server blocks would have the potential to interfere with future Nginx confs, depending on how the user responds to the failed playbook.

This PR moves the "Disable" task to a handler so it will always run and disable temp confs/sites, regardless whether the playbook fails. I placed the handler in `roles/common` before the `reload nginx` handler so that it would run before Nginx is reloaded. If the handler were in the `letsencrypt` role, it would be run after the Nginx reload handler.

> Notify handlers are always run in the same order they are defined, _not_ in the order listed in the notify-statement. -- _[Ansible handler docs](http://docs.ansible.com/ansible/playbooks_intro.html#handlers-running-operations-on-change)_ 
