### PR TITLE
letsencrypt: suppress extra output in certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Suppress extra output in SSL certificates ([#723](https://github.com/roots/trellis/pull/723))
 * Fix #718 - improve method of updating theme paths ([#720](https://github.com/roots/trellis/pull/720))
 * Create `/home/vagrant/trellis` bindfs mount with proper permissions ([#705](https://github.com/roots/trellis/pull/705))
 

--- a/roles/letsencrypt/templates/renew-certs.py
+++ b/roles/letsencrypt/templates/renew-certs.py
@@ -26,6 +26,7 @@ for site in sites:
     print 'Generating certificate for ' + site
 
     cmd = ('/usr/bin/env python {{ acme_tiny_software_directory }}/acme_tiny.py '
+           '--quiet '
            '--ca {{ letsencrypt_ca }} '
            '--account-key {{ letsencrypt_account_key }} '
            '--csr {{ acme_tiny_data_directory }}/csrs/{0}.csr '


### PR DESCRIPTION
Adds `--quiet` option for acme-tiny to get rid of unwanted logging output from appearing in certificates.

Example:

```plain
Parsing account key...
Parsing CSR...
Registering account...
Registered!
Verifying example.com...
example.com verified!
Signing certificate...
Certificate signed!
```