### PR TITLE
Vagrant: add automatic support for landrush 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* `Vagrantfile`: add automatic support for landrush ([#724](https://github.com/roots/trellis/pull/724))
 * Suppress extra output in SSL certificates ([#723](https://github.com/roots/trellis/pull/723))
 * Fix #718 - improve method of updating theme paths ([#720](https://github.com/roots/trellis/pull/720))
 * Create `/home/vagrant/trellis` bindfs mount with proper permissions ([#705](https://github.com/roots/trellis/pull/705))


### PR DESCRIPTION
Previously we documented these changes that people would need to manually make. This handles it automatically so landrush is supported out of the box if the user installs the plugin.