### PR TITLE
Use dynamic local_path to accommodate Ansible running on VM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Use dynamic `local_path` to accommodate Ansible running on VM ([#725](https://github.com/roots/trellis/pull/725))
 * [BREAKING] Fix #727 - HSTS: default preload to off ([#728](https://github.com/roots/trellis/pull/728))
 * `Vagrantfile`: add automatic support for landrush ([#724](https://github.com/roots/trellis/pull/724))
 * Suppress extra output in SSL certificates ([#723](https://github.com/roots/trellis/pull/723))

--- a/deploy-hooks/build-before.yml
+++ b/deploy-hooks/build-before.yml
@@ -8,7 +8,7 @@
 #   command: yarn install
 #   connection: local
 #   args:
-#     chdir: "{{ project.local_path }}/web/app/themes/sage"
+#     chdir: "{{ project_local_path }}/web/app/themes/sage"
 #
 # - name: Install Composer dependencies
 #   command: composer install --no-ansi --no-dev --no-interaction --no-progress --optimize-autoloader --no-scripts
@@ -19,11 +19,11 @@
 #   command: yarn run build:production
 #   connection: local
 #   args:
-#     chdir: "{{ project.local_path }}/web/app/themes/sage"
+#     chdir: "{{ project_local_path }}/web/app/themes/sage"
 #
 # - name: Copy project local files
 #   synchronize:
-#     src: "{{ project.local_path }}/web/app/themes/sage/dist"
+#     src: "{{ project_local_path }}/web/app/themes/sage/dist"
 #     dest: "{{ deploy_helper.new_release_path }}/web/app/themes/sage"
 #     group: no
 #     owner: no

--- a/deploy.yml
+++ b/deploy.yml
@@ -22,6 +22,7 @@
       wp_home: "{{ project.ssl.enabled | default(false) | ternary('https', 'http') }}://{{ project.site_hosts | map(attribute='canonical') | first }}"
       wp_siteurl: "{{ project.ssl.enabled | default(false) | ternary('https', 'http') }}://{{ project.site_hosts | map(attribute='canonical') | first }}/wp"
     site_env: "{{ wordpress_env_defaults | combine(project.env | default({}), vault_wordpress_sites[site].env) }}"
+    project_local_path: "{{ (lookup('env', 'USER') == 'vagrant') | ternary(project_root + '/' + project_current_path, project.local_path) }}"
 
   pre_tasks:
     - name: Ensure site is valid


### PR DESCRIPTION
Here are the two changes **Windows users** face after #705 and this PR #725:

1. Windows users who want to avoid the `.vault_pass` executable problem will need to run Ansible commands from `~/trellis` (#705).
2. Windows users will need to recognize that they no longer need to do anything about `local_path` (see https://discourse.roots.io/t/7825/7). They don't need to redefine `local_path` nor do they need to move the `Vagrantfile` (#725).

I'm not aware of any reason to NOT run Ansible commands from `~/trellis`, so we could potentially disable the default `/vagrant` sync directory. That way we would just have a single option that works (`~/trellis`), instead of two options, one of which doesn't work with `.vault_pass`.

----

Here is a verbose representation of what #705 and #725 did and didn't change for **Windows users**:

| | Before | After #705<br/>(`/vagrant`) | After<br/>#705<br/>(`~/trellis`) | After<br/>#725<br/>(this PR) |
| :--- | :---: | :---: | :---: | :---: |
| Ansible succeeds with `.vault_pass` | no | no | yes | yes<br/>(if running in `~/trellis`) |
| executable hosts are NOT a problem<br/>(fixed in Ansible 2.0 ansible/ansible#11643)  | yes | yes | yes | yes |
| default `local_path: ../site` works without moving `Vagrantfile` | no | no | no | yes<br/>(dynamically changed) |
| users can redefine `local_path: /srv/www/example.com/current` | yes | yes | yes | yes<br/>(but unnecessary to redefine) |
| users can move `Vagrantfile` and run commands from `/vagrant/trellis` | yes | yes | yes | yes<br/>(but not needed for `local_path`) |

-----

Details on permissions of vagrant sync directories.

```
                    ------ Permissions -----
                    Before #705   After #705
                    -----------   ----------
# Setup A (no winnfsd)
vagrant/
  .vaultpass         -rwxrwxrwx   -rwxrwxrwx   <-- 1a .vault_pass executable problem unchanged
  hosts/             drwxrwxrwx   drwxrwxrwx
    production       -rw-r--r--   -rwxrwxrwx   <-- 2a Ansible 2.0 allows hosts to be executable
                                                      https://github.com/ansible/ansible/pull/11643
                                                      so the extra sync dirs from #460 were removed
# Setup B (with winnfsd)
vagrant/
  .vaultpass         -rwxrwxrwx   -rwxrwxrwx   <-- 1b .vault_pass executable problem unchanged
  hosts/             drwxrwxrwx   drwxrwxrwx
    production       -rwxrwxrwx   -rwxrwxrwx   <-- 2b hosts executable, but not a problem

# Setup C (any)
~/trellis/
  .vault_pass                     -rw-r--r--   <-- 1c .vault_pass executable problem fixed
  hosts/                          drwxr-xr-x
    production                    -rw-r--r--   <-- 2c hosts changed to non-executable
  bin/                            drwxr-xr-x
    deploy.sh                     -rwxr-xr-x   <-- 3  scripts appropriately executable
```

The final Setup C is the recommended setup for Windows users. Run all your Ansible commands on the VM in `~/trellis`, whether using `winnfsd` or not.