### PR TITLE
Require Ansible 2.2 for better SSH error output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Require Ansible 2.2.0.0 or greater ([#726](https://github.com/roots/trellis/pull/726))
 * [BREAKING] Use more secure sshd defaults ([#744](https://github.com/roots/trellis/pull/744))
 * Add basic git repo host keys to `known_hosts` ([#751](https://github.com/roots/trellis/pull/751))
 * Accommodate template inheritance for nginx confs ([#740](https://github.com/roots/trellis/pull/740))

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Trellis will configure a server with the following and more:
 
 Make sure all dependencies have been installed before moving on:
 
-* [Ansible](http://docs.ansible.com/ansible/intro_installation.html#latest-releases-via-pip) >= 2.0.2 (except 2.1.0)
+* [Ansible](http://docs.ansible.com/ansible/intro_installation.html#latest-releases-via-pip) >= 2.2
 * [Virtualbox](https://www.virtualbox.org/wiki/Downloads) >= 4.3.10
 * [Vagrant](https://www.vagrantup.com/downloads.html) >= 1.8.5
 * [vagrant-bindfs](https://github.com/gael-ian/vagrant-bindfs#installation) >= 0.3.1 (Windows users may skip this)

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,8 +1,6 @@
 ansible_requirements:
-  - version: 2.0.2.0
+  - version: 2.2.0.0
     operator: '>='
-  - version: 2.1.0.0
-    operator: '!='
 
 ntp_timezone: Etc/UTC
 

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -12,5 +12,4 @@
     name: php7.1-fpm
     state: reloaded
 
-- name: reload nginx
-  include: reload_nginx.yml
+- include: reload_nginx.yml

--- a/roles/common/tasks/reload_nginx.yml
+++ b/roles/common/tasks/reload_nginx.yml
@@ -1,8 +1,7 @@
 ---
 - name: reload nginx
   command: nginx -t
-  register: nginx_test
-  notify: "{{ (ansible_version.full | version_compare('2.1.1.0', '>=') and role_path | basename == 'common') | ternary('perform nginx reload', omit) }}"
+  notify: "{{ (role_path | basename == 'common') | ternary('perform nginx reload', omit) }}"
 
 - name: perform nginx reload
   service:


### PR DESCRIPTION
Ansible 2.2 (released Oct 31, 2016) displays [additional SSH error output](https://github.com/ansible/ansible/commit/9ec69ee). It would be particularly useful for Trellis users to see the previously hidden `WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!` message, especially because #716 plans to change host keys.