### PR TITLE
Fix #727 - HSTS: default preload to off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* [BREAKING] Fix #727 - HSTS: default preload to off ([#728](https://github.com/roots/trellis/pull/728))
 * `Vagrantfile`: add automatic support for landrush ([#724](https://github.com/roots/trellis/pull/724))
 * Suppress extra output in SSL certificates ([#723](https://github.com/roots/trellis/pull/723))
 * Fix #718 - improve method of updating theme paths ([#720](https://github.com/roots/trellis/pull/720))

--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -9,7 +9,7 @@ nginx_ssl_path: "{{ nginx_path }}/ssl"
 # HSTS defaults
 nginx_hsts_max_age: 31536000
 nginx_hsts_include_subdomains: true
-nginx_hsts_preload: true
+nginx_hsts_preload: false
 
 # Fastcgi cache params
 nginx_cache_path: /var/cache/nginx


### PR DESCRIPTION
The HSTS `preload` option defaulted to true. This turns it off by default since the HSTS preload list should be opt-in as it also requires a submission to https://hstspreload.org.

**NOTE**: If you submitted your site to the HSTS preload list and want to keep using the `preload` option, then set the variable:

```yaml
# group_vars/production/wordpress_sites.yml (example)

example.com:
  # rest of site config
  ssl:
    enabled: true
    provider: letsencrypt
    hsts_max_age: 31536000
    hsts_include_subdomains: true
    hsts_preload: true
```

Or set the global default:

```yaml
nginx_hsts_preload: true
```

See https://roots.io/trellis/docs/ssl/ for more information.
