### PR TITLE
Avoid loop.first when working with users and vault_users data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Avoid `loop.first` variable in conditional jinja loops ([#729](https://github.com/roots/trellis/pull/729))
 * Use dynamic `local_path` to accommodate Ansible running on VM ([#725](https://github.com/roots/trellis/pull/725))
 * [BREAKING] Fix #727 - HSTS: default preload to off ([#728](https://github.com/roots/trellis/pull/728))
 * `Vagrantfile`: add automatic support for landrush ([#724](https://github.com/roots/trellis/pull/724))

--- a/group_vars/all/helpers.yml
+++ b/group_vars/all/helpers.yml
@@ -12,4 +12,3 @@ site_hosts_canonical: "{{ item.value.site_hosts | map(attribute='canonical') | l
 site_hosts_redirects: "{{ item.value.site_hosts | selectattr('redirects', 'defined') | sum(attribute='redirects', start=[]) | list }}"
 site_hosts: "{{ site_hosts_canonical | union(site_hosts_redirects) }}"
 ssl_enabled: "{{ item.value.ssl is defined and item.value.ssl.enabled | default(false) }}"
-ansible_become_pass: "{% set passwords = vault_users | default([]) | selectattr('name', 'equalto', admin_user) | selectattr('password', 'defined') | map(attribute='password') | list %}{{ passwords | ternary(passwords | first, None) }}"

--- a/group_vars/all/helpers.yml
+++ b/group_vars/all/helpers.yml
@@ -12,3 +12,4 @@ site_hosts_canonical: "{{ item.value.site_hosts | map(attribute='canonical') | l
 site_hosts_redirects: "{{ item.value.site_hosts | selectattr('redirects', 'defined') | sum(attribute='redirects', start=[]) | list }}"
 site_hosts: "{{ site_hosts_canonical | union(site_hosts_redirects) }}"
 ssl_enabled: "{{ item.value.ssl is defined and item.value.ssl.enabled | default(false) }}"
+ansible_become_pass: "{% set passwords = vault_users | default([]) | selectattr('name', 'equalto', admin_user) | selectattr('password', 'defined') | map(attribute='password') | list %}{{ passwords | ternary(passwords | first, None) }}"

--- a/roles/remote-user/tasks/main.yml
+++ b/roles/remote-user/tasks/main.yml
@@ -24,6 +24,6 @@
 
 - name: Load become password
   set_fact:
-    ansible_become_pass: "{% for user in vault_users | default([]) if user.name == ansible_user and user.password is defined %}{% if loop.first %}{{ user.password }}{% endif %}{% endfor %}"
+    ansible_become_pass: "{% for user in vault_users | default([]) if user.name == ansible_user %}{{ '{% raw %}' }}{{ user.password | default('') }}{{ '{% endraw %}' }}{% endfor %}"
   when: ansible_user != 'root' and not cli_ask_become_pass | default(false) and ansible_become_pass is not defined
   no_log: true

--- a/roles/remote-user/tasks/main.yml
+++ b/roles/remote-user/tasks/main.yml
@@ -21,9 +21,3 @@
 - name: Announce which user was selected
   debug:
     msg: "Note: Ansible will attempt connections as user = {{ ansible_user }}"
-
-- name: Load become password
-  set_fact:
-    ansible_become_pass: "{% for user in vault_users | default([]) if user.name == ansible_user and user.password is defined %}{% if loop.first %}{{ user.password }}{% endif %}{% endfor %}"
-  when: ansible_user != 'root' and not cli_ask_become_pass | default(false) and ansible_become_pass is not defined
-  no_log: true

--- a/roles/remote-user/tasks/main.yml
+++ b/roles/remote-user/tasks/main.yml
@@ -21,3 +21,9 @@
 - name: Announce which user was selected
   debug:
     msg: "Note: Ansible will attempt connections as user = {{ ansible_user }}"
+
+- name: Load become password
+  set_fact:
+    ansible_become_pass: "{% for user in vault_users | default([]) if user.name == ansible_user and user.password is defined %}{% if loop.first %}{{ user.password }}{% endif %}{% endfor %}"
+  when: ansible_user != 'root' and not cli_ask_become_pass | default(false) and ansible_become_pass is not defined
+  no_log: true

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -16,8 +16,8 @@
 - name: Fail if root login will be disabled but admin_user will not be a sudoer
   assert:
     that:
-      - "{% for user in users if user.name == admin_user %}{% if loop.first %}{{ 'sudo' in user.groups }}{% endif %}{% else %}{{ false }}{% endfor %}"
-      - "{% for user in vault_users | default([]) if user.name == admin_user %}{% if loop.first %}{{ user.password is defined }}{% endif %}{% else %}{{ false }}{% endfor %}"
+      - "{% for user in users if user.name == admin_user %}{{ 'sudo' in user.groups }}{% else %}{{ false }}{% endfor %}"
+      - "{% for user in vault_users | default([]) if user.name == admin_user %}{{ user.password is defined }}{% else %}{{ false }}{% endfor %}"
     msg: |
       When `sshd_permit_root_login: false`, you must add `sudo` to the `groups` for admin_user (in `users` hash), and set a password for admin_user in `vault_users` (in `group_vars/{{ env }}/vault.yml`). Otherwise Ansible could lose the ability to run the necessary sudo commands. {% if sudoer_passwords is defined or vault_sudoer_passwords is defined %}
 
@@ -33,7 +33,7 @@
     name: "{{ item.name }}"
     group: "{{ item.groups[0] }}"
     groups: "{{ item.groups | join(',') }}"
-    password: '{% for user in vault_users | default([]) if user.name == item.name and user.password is defined %}{% if loop.first %}{{ user.password | password_hash("sha512", user.salt[:16] | default(None) | regex_replace("[^\.\/a-zA-Z0-9]", "x")) }}{% endif %}{% else %}{{ None }}{% endfor %}'
+    password: '{% for user in vault_users | default([]) if user.name == item.name and user.password is defined %}{{ user.password | password_hash("sha512", user.salt | default("") | truncate(16, true, "") | regex_replace("[^\.\/a-zA-Z0-9]", "x")) }}{% else %}{{ None }}{% endfor %}'
     state: present
     shell: /bin/bash
     update_password: always

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -16,8 +16,8 @@
 - name: Fail if root login will be disabled but admin_user will not be a sudoer
   assert:
     that:
-      - "{% for user in users if user.name == admin_user %}{% if loop.first %}{{ 'sudo' in user.groups }}{% endif %}{% else %}{{ false }}{% endfor %}"
-      - "{% for user in vault_users | default([]) if user.name == admin_user %}{% if loop.first %}{{ user.password is defined }}{% endif %}{% else %}{{ false }}{% endfor %}"
+      - "{{ 'sudo' in users | selectattr('name', 'equalto', admin_user) | selectattr('groups', 'defined') | sum(attribute='groups', start=[]) | list }}"
+      - "{{ ansible_become_pass | default('') | length }}"
     msg: |
       When `sshd_permit_root_login: false`, you must add `sudo` to the `groups` for admin_user (in `users` hash), and set a password for admin_user in `vault_users` (in `group_vars/{{ env }}/vault.yml`). Otherwise Ansible could lose the ability to run the necessary sudo commands. {% if sudoer_passwords is defined or vault_sudoer_passwords is defined %}
 
@@ -33,11 +33,14 @@
     name: "{{ item.name }}"
     group: "{{ item.groups[0] }}"
     groups: "{{ item.groups | join(',') }}"
-    password: '{% for user in vault_users | default([]) if user.name == item.name and user.password is defined %}{% if loop.first %}{{ user.password | password_hash("sha512", user.salt[:16] | default(None) | regex_replace("[^\.\/a-zA-Z0-9]", "x")) }}{% endif %}{% else %}{{ None }}{% endfor %}'
+    password: '{{ user_secrets | ternary(user_secrets.password | default("") | password_hash("sha512", user_secrets.salt | default("") | truncate(16, true, "") | regex_replace("[^\.\/a-zA-Z0-9]", "x")), None) }}'
     state: present
     shell: /bin/bash
     update_password: always
   with_items: "{{ users }}"
+  vars:
+    user_secrets_list: "{{ vault_users | default([]) | selectattr('name', 'equalto', item.name) | selectattr('password', 'defined') | list }}"
+    user_secrets: "{{ user_secrets_list | ternary(user_secrets_list | first, None) }}"
 
 - name: Add web user sudoers items for services
   template:

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -16,8 +16,8 @@
 - name: Fail if root login will be disabled but admin_user will not be a sudoer
   assert:
     that:
-      - "{{ 'sudo' in users | selectattr('name', 'equalto', admin_user) | selectattr('groups', 'defined') | sum(attribute='groups', start=[]) | list }}"
-      - "{{ ansible_become_pass | default('') | length }}"
+      - "{% for user in users if user.name == admin_user %}{% if loop.first %}{{ 'sudo' in user.groups }}{% endif %}{% else %}{{ false }}{% endfor %}"
+      - "{% for user in vault_users | default([]) if user.name == admin_user %}{% if loop.first %}{{ user.password is defined }}{% endif %}{% else %}{{ false }}{% endfor %}"
     msg: |
       When `sshd_permit_root_login: false`, you must add `sudo` to the `groups` for admin_user (in `users` hash), and set a password for admin_user in `vault_users` (in `group_vars/{{ env }}/vault.yml`). Otherwise Ansible could lose the ability to run the necessary sudo commands. {% if sudoer_passwords is defined or vault_sudoer_passwords is defined %}
 
@@ -33,14 +33,11 @@
     name: "{{ item.name }}"
     group: "{{ item.groups[0] }}"
     groups: "{{ item.groups | join(',') }}"
-    password: '{{ user_secrets | ternary(user_secrets.password | default("") | password_hash("sha512", user_secrets.salt | default("") | truncate(16, true, "") | regex_replace("[^\.\/a-zA-Z0-9]", "x")), None) }}'
+    password: '{% for user in vault_users | default([]) if user.name == item.name and user.password is defined %}{% if loop.first %}{{ user.password | password_hash("sha512", user.salt[:16] | default(None) | regex_replace("[^\.\/a-zA-Z0-9]", "x")) }}{% endif %}{% else %}{{ None }}{% endfor %}'
     state: present
     shell: /bin/bash
     update_password: always
   with_items: "{{ users }}"
-  vars:
-    user_secrets_list: "{{ vault_users | default([]) | selectattr('name', 'equalto', item.name) | selectattr('password', 'defined') | list }}"
-    user_secrets: "{{ user_secrets_list | ternary(user_secrets_list | first, None) }}"
 
 - name: Add web user sudoers items for services
   template:


### PR DESCRIPTION
Fixes `variable referenced before assignment in enclosing scope` error reported in https://discourse.roots.io/t/8488/. Python 2.7.12 seems to handle the `{% if loop.first %}` jinja control structure differently than 2.7.11. Examples of `loop.first` in Trellis: [first](https://github.com/roots/trellis/blob/991c83dd21e6c97a1d3a378990630a56ec9dbded/roles/remote-user/tasks/main.yml#L27), [second](https://github.com/roots/trellis/blob/991c83dd21e6c97a1d3a378990630a56ec9dbded/roles/users/tasks/main.yml#L19-L20), [third](https://github.com/roots/trellis/blob/991c83dd21e6c97a1d3a378990630a56ec9dbded/roles/users/tasks/main.yml#L36).

### `loop.first`
This PR removes use of `{% if loop.first %}`, which was used in the context of retrieving user `password` from `vault_users` (a list) or `groups` from `users` (a list). To retrieve a specific user from the list, the code looped over all users, selecting the user with the correct `name`.

The purpose of `loop.first` in this looping was to only retrieve one value per user in case someone had naively listed a particular user multiple times in `users` or `vault_users`. However, this use of `loop.first` causes the error above with in python 2.7.12.

There is no failure if the instances of `{% if loop.first %}` are removed, but then there would be an error in the rare case that someone naively duplicates a user in these lists. So, this PR takes a different approach, avoiding `{% ... %}` blocks as much as possible.

### `salt` optional
This PR also fixes a templating error that would have occurred if `salt` (from `vault_users`) were undefined. Password creation in the [Setup users](https://github.com/roots/trellis/blob/991c83dd21e6c97a1d3a378990630a56ec9dbded/roles/users/tasks/main.yml#L36) task will no longer fail if someone omits the `salt`.

### `first` filter
The [`first` filter](http://jinja.pocoo.org/docs/2.9/templates/#first) throws an error if applied to an empty list. Some variables are defined in two steps to avoid such an error.
 
The revised definition of `ansible_become_pass` is split in two assignments. First the `passwords` temporary variable is created. Then `passwords | ternary(passwords | first, None)` only applies the `first` filter if `passwords` is not an empty list. (The temporary `passwords` list variable would be empty if no password were defined for `admin_user` in `vault_users`.)

The other example is that `user_secrets_list` gathers the list of passwords and salts for a user. This could be an empty list if the user has no secrets in `vault_users`, or there could be multiple secrets for users who are duplicated in `vault_users`. The `user_secrets` variable only applies the `first` filter if the `user_secrets_list` is not empty.