### PR TITLE
Include wp-*.php rewrite rule in nginx config for non-multisite sites.

### DIFF
--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -19,11 +19,11 @@ server {
 
   {% if item.value.multisite.enabled | default(false) -%}
     {% if item.value.multisite.subdomains | default(false) -%}
-      rewrite ^/(wp-.*.php)$ /wp/$1 last;
-      rewrite ^/(wp-(content|admin|includes).*) /wp/$1 last;
-    {%- else -%}
       include wordpress_multisite_subdirectories.conf;
     {%- endif %}
+  {%- else -%}
+    rewrite ^/(wp-.*.php)$ /wp/$1 last;
+    rewrite ^/(wp-(content|admin|includes).*) /wp/$1 last;
   {%- endif %}
 
   add_header Fastcgi-Cache $upstream_cache_status;


### PR DESCRIPTION
## Why
`wp-*.php` to `/wp/$1` nginx rewrite was not present for non-multisite sites.

The wp-*.php rewrite condition in the wordpress-site.conf.j2 was never being included in `/etc/sites-enabled/<sitename>.conf` nginx configs. Without this, all requests to /wp-*.php files 404.