### PR TITLE
Begin adding configuration for SSL termination

### DIFF
--- a/group_vars/all/helpers.yml
+++ b/group_vars/all/helpers.yml
@@ -12,3 +12,5 @@ site_hosts_canonical: "{{ item.value.site_hosts | map(attribute='canonical') | l
 site_hosts_redirects: "{{ item.value.site_hosts | selectattr('redirects', 'defined') | sum(attribute='redirects', start=[]) | list }}"
 site_hosts: "{{ site_hosts_canonical | union(site_hosts_redirects) }}"
 ssl_enabled: "{{ item.value.ssl is defined and item.value.ssl.enabled | default(false) }}"
+load_balancer_enabled: "{{ item.value.load_balancer is defined and item.value.load_balancer.enabled | default(false) }}"
+ssl_terminated: "{{ load_balancer_enabled and item.value.load_balancer.ssl_terminated | default(false) }}"

--- a/roles/wordpress-setup/defaults/main.yml
+++ b/roles/wordpress-setup/defaults/main.yml
@@ -3,3 +3,4 @@ nginx_includes_templates_path: nginx-includes
 nginx_includes_deprecated: roles/wordpress-setup/templates/includes.d
 nginx_includes_pattern: "^({{ nginx_includes_templates_path | regex_escape }}|{{ nginx_includes_deprecated | regex_escape }})/(.*)\\.j2$"
 nginx_includes_d_cleanup: true
+ssl_terminated_http_port: 8080

--- a/roles/wordpress-setup/defaults/main.yml
+++ b/roles/wordpress-setup/defaults/main.yml
@@ -3,4 +3,4 @@ nginx_includes_templates_path: nginx-includes
 nginx_includes_deprecated: roles/wordpress-setup/templates/includes.d
 nginx_includes_pattern: "^({{ nginx_includes_templates_path | regex_escape }}|{{ nginx_includes_deprecated | regex_escape }})/(.*)\\.j2$"
 nginx_includes_d_cleanup: true
-ssl_terminated_http_port: 8080
+ssl_terminated_http_port: "{{ load_balancer_enabled and item.value.load_balancer.http_port | ternary(item.value.load_balancer.http_port, 8080) }}"

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -66,17 +66,20 @@ server {
     include fastcgi_params;
     fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
     fastcgi_param DOCUMENT_ROOT $realpath_root;
+    {% if ssl_terminated -%}
+    fastcgi_param HTTPS on;
+    {% endif %}
     fastcgi_pass unix:/var/run/php-fpm-wordpress.sock;
   }
 }
 
-{% if ssl_enabled %}
+{% if ssl_enabled or ssl_terminated %}
 server {
-  listen 80;
+  listen {{ (ssl_terminated and not ssl_enabled) | ternary('8080', '80') }};
 
   server_name {{ site_hosts | join(' ') }}{% if item.value.multisite.subdomains | default(false) %} *.{{ site_hosts_canonical | join(' *.') }}{% endif %};
 
-  {% if item.value.ssl.provider | default('manual') == 'letsencrypt' -%}
+  {% if ssl_enabled and item.value.ssl.provider | default('manual') == 'letsencrypt' -%}
   include acme-challenge-location.conf;
 
   location / {

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -75,7 +75,7 @@ server {
 
 {% if ssl_enabled or ssl_terminated %}
 server {
-  listen {{ (ssl_terminated and not ssl_enabled) | ternary('8080', '80') }};
+  listen {{ (ssl_terminated and not ssl_enabled) | ternary(ssl_terminated_http_port, '80') }};
 
   server_name {{ site_hosts | join(' ') }}{% if item.value.multisite.subdomains | default(false) %} *.{{ site_hosts_canonical | join(' *.') }}{% endif %};
 


### PR DESCRIPTION
This PR adds the `load_balancer_enabled` and `ssl_terminated` helpers.
It checks for the `load_balancer` key on a site. For example:

```yaml
wordpress_sites:
  example.com:
    // blah blah
    ssl:
      enabled: false
    load_balancer:
      enabled: true
      ssl_terminated: true
    // blah blah
```

The pattern it follows is the load balancer will send https traffic to
port 80 and http traffic to port 8080. Because SSL has already been
handled, the server doesn't need to do anything over 443, so it can be
treated like a normal web request (thus leaving everything alone and
communicating over port 80). Port 8080 is then used to receive http
traffic and then force redirect to the https version of the site. To
coerce WordPress into thinking this is an HTTPS request, we set the
`HTTPS` PHP `$_SERVER` variable to make `is_ssl()` work inside
WordPress.