### PR TITLE
Fix #731 - Use option stdout to fix theme paths

### DIFF
--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -37,7 +37,7 @@
   command: wp option set {{ item }} {{ deploy_helper.new_release_path }}/web/wp/wp-content/themes
   args:
     chdir: "{{ deploy_helper.current_path }}"
-  when: wp_installed | success and wp_template_root != '/themes' and wp_template_root != ''
+  when: wp_installed | success and wp_template_root.stdout != '' and wp_template_root.stdout != '/themes'
   with_items:
     - stylesheet_root
     - template_root

--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -7,40 +7,42 @@
   changed_when: false
   failed_when: wp_installed.stderr != ""
 
-- name: Update WP database
-  command: wp core update-db
-  args:
-    chdir: "{{ deploy_helper.current_path }}"
-  when: wp_installed | success and not project.multisite.enabled | default(false)
+- block:
+  - name: Update WP database
+    command: wp core update-db
+    args:
+      chdir: "{{ deploy_helper.current_path }}"
+    when: project.multisite.enabled | default(false)
 
-- name: Warn about updating network database.
-  debug:
-    msg: "Updating the network database could take a long time with a large number of sites."
-  when: wp_installed | success and project.multisite.enabled | default(false)
+  - name: Warn about updating network database.
+    debug:
+      msg: "Updating the network database could take a long time with a large number of sites."
+    when: project.multisite.enabled | default(false)
 
-- name: Update WP network database
-  command: wp core update-db --network
-  args:
-    chdir: "{{ deploy_helper.current_path }}"
-  when: wp_installed | success and project.multisite.enabled | default(false)
+  - name: Update WP network database
+    command: wp core update-db --network
+    args:
+      chdir: "{{ deploy_helper.current_path }}"
+    when: project.multisite.enabled | default(false)
 
-- name: Get WP theme template root
-  command: wp option get template_root
-  args:
-    chdir: "{{ deploy_helper.current_path }}"
-  register: wp_template_root
-  changed_when: false
-  failed_when: wp_template_root.stderr != ""
+  - name: Get WP theme template root
+    command: wp option get template_root
+    args:
+      chdir: "{{ deploy_helper.current_path }}"
+    register: wp_template_root
+    changed_when: false
+    failed_when: wp_template_root.stderr != ""
+
+  - name: Update WP theme paths
+    command: wp option set {{ item }} {{ deploy_helper.new_release_path }}/web/wp/wp-content/themes
+    args:
+      chdir: "{{ deploy_helper.current_path }}"
+    when: wp_template_root.stdout != '' and wp_template_root.stdout != '/themes'
+    with_items:
+      - stylesheet_root
+      - template_root
+
   when: wp_installed | success
-
-- name: Update WP theme paths
-  command: wp option set {{ item }} {{ deploy_helper.new_release_path }}/web/wp/wp-content/themes
-  args:
-    chdir: "{{ deploy_helper.current_path }}"
-  when: wp_installed | success and wp_template_root.stdout != '' and wp_template_root.stdout != '/themes'
-  with_items:
-    - stylesheet_root
-    - template_root
 
 - name: Reload php-fpm
   shell: sudo service php7.1-fpm reload


### PR DESCRIPTION
`wp_template_root` was just the registered Ansible var. The values needed to be checked against the `stdout` which is the actual output of the `wp get option` command.