### PR TITLE
Enable SKIP_GALAXY env var to skip galaxy install

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -103,7 +103,9 @@ Vagrant.configure('2') do |config|
     end
 
     ansible.playbook = File.join(provisioning_path, 'dev.yml')
-    ansible.galaxy_role_file = File.join(provisioning_path, 'requirements.yml')
+    unless ENV['SKIP_GALAXY']
+      ansible.galaxy_role_file = File.join(provisioning_path, 'requirements.yml')
+    end
     ansible.galaxy_roles_path = File.join(provisioning_path, 'vendor/roles')
 
     ansible.groups = {


### PR DESCRIPTION
This would add the ability to skip the Ansible Galaxy requirements installation step by prefixing `vagrant up` or `vagrant provision` commands with the env var `SKIP_GALAXY=1`. Any non-empty value will work. For example:

```sh
SKIP_GALAXY=1 vagrant provision
```

Installing the requirements on every provision can get tiresome when running playbooks over and over (say when you have a modified version of Trellis, for instance).