### PR TITLE
Update nginx wiki link

### DIFF
--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -13,7 +13,7 @@ server {
   charset utf-8;
 
   {% if env == 'development' -%}
-  # See Virtualbox section at http://wiki.nginx.org/Pitfalls
+  # https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/#virtualbox
   sendfile off;
   {%- endif %}
 


### PR DESCRIPTION
I linked to the paragraph _above_ Virtualbox since linking directly to VirtualBox cut off the top part of the paragraph when I tested.