### PR TITLE
Fix apt_packages_custom

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -17,4 +17,4 @@ apt_packages_default:
   - libnss-myhostname
 
 apt_packages_custom: []
-apt_packages_install: "{{ default_apt_packages + custom_apt_packages }}"
+apt_packages_install: "{{ apt_packages_default + apt_packages_custom }}"


### PR DESCRIPTION
Commit #54ab64c0b3f376ac98c377eebdd825be033b4388 from yesterday breaks provisioning with the following error: "the python mysqldb module is required"

This PR fixes it.