### PR TITLE
Disable Let's Encrypt challenge sites as part of WordPress setup

### DIFF
--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -1,10 +1,6 @@
 ---
 - name: disable temporary challenge sites
-  file:
-    path: "{{ nginx_path }}/sites-enabled/letsencrypt-{{ item.key }}.conf"
-    state: absent
-  with_dict: "{{ wordpress_sites }}"
-  notify: reload nginx
+  include: disable_challenge_sites.yml
 
 - name: restart memcached
   service:

--- a/roles/common/tasks/disable_challenge_sites.yml
+++ b/roles/common/tasks/disable_challenge_sites.yml
@@ -1,0 +1,7 @@
+---
+- name: disable temporary challenge sites
+  file:
+    path: "{{ nginx_path }}/sites-enabled/letsencrypt-{{ item }}.conf"
+    state: absent
+  with_items: "{{ wordpress_sites.keys() }}"
+  notify: reload nginx

--- a/roles/wordpress-setup/tasks/nginx.yml
+++ b/roles/wordpress-setup/tasks/nginx.yml
@@ -15,6 +15,8 @@
   with_dict: "{{ wordpress_sites }}"
   when: ssl_enabled and item.value.ssl.key is defined
 
+- include: "{{ playbook_dir }}/roles/common/tasks/disable_challenge_sites.yml"
+
 - name: Create Nginx conf for challenges location
   template:
     src: "{{ playbook_dir }}/roles/letsencrypt/templates/acme-challenge-location.conf.j2"


### PR DESCRIPTION
### Problem
If `/etc/nginx/sites-enabled/letsencrypt-example.com.conf` is not removed, it can lead to Nginx conflicts such as https://discourse.roots.io/t/8669.

### Background
#722 put the removal task in a handler, probably improving the likelihood of successful removal, because handlers still run when Ansible fails gracefully.

However, if there is a critical failure before the handler runs, or if the user delivers a keyboard interrupt, the handler will not run. When the user runs the `letsencrypt` role again, the [Enable Nginx sites](https://github.com/roots/trellis/blob/2065d2cd0085e76d1fd1bf3b5abaaba2e8ab195b/roles/letsencrypt/tasks/nginx.yml#L24-L32) task will return status `ok` (vs. `changed`) and thus will not notify the "disable temporary challenge sites" handler. The `/etc/nginx/sites-enabled/letsencrypt-example.com.conf` is still not removed and likely Nginx conflicts persist.

### PR's proposed solution
As a failsafe for when the handler doesn't run, this PR repeats the "disable temporary challenge sites" task within the `wordpress-setup` role.

I put this task in the `wordpress-setup` role instead of the `letsencrypt` role because the task really only comes into play when a user reruns `server.yml` after a failure with `letsencrypt` . Some users might respond to the initial failed `letsencrypt` by disabling SSL and running `--tags wordpress-setup`, which would miss the "disable temporary challenge sites" task if it were only in the `letsencrypt` role.

### Retaining the handler
If we now have an explicit task in `wordpress-setup` to the "disable temporary challenge sites", do we still need the handler in `letsencrypt`?

We could possibly remove the handler if we could guarantee that users would always respond to a failed `letsencrypt` role by running the `wordpress-setup` role, which would remove the lingering `letsencrypt-example.com.conf`. But consider users facing the rather common acme challenge failure. In such situations, the handler can usually successfully remove the `letsencrypt-example.com.conf`, sparing these users from having to know that they should rerun anything.

In addition, keeping the handler also avoids making the `letsencrypt` role have an absolute dependence on the `wordpress-setup` role. 