### PR TITLE
Specify MySQL user host

### DIFF
--- a/group_vars/all/helpers.yml
+++ b/group_vars/all/helpers.yml
@@ -2,6 +2,7 @@ wordpress_env_defaults:
   db_host: localhost
   db_name: "{{ item.key | underscore }}_{{ env }}"
   db_user: "{{ item.key | underscore }}"
+  db_user_host: localhost
   disable_wp_cron: true
   wp_env: "{{ env }}"
   wp_home: "{{ ssl_enabled | ternary('https', 'http') }}://{{ site_hosts_canonical | first }}"

--- a/roles/wordpress-setup/tasks/database.yml
+++ b/roles/wordpress-setup/tasks/database.yml
@@ -13,6 +13,7 @@
   mysql_user:
     name: "{{ site_env.db_user }}"
     password: "{{ site_env.db_password }}"
+    host: "{{ site_env.db_user_host }}"
     append_privs: yes
     priv: "{{ site_env.db_name }}.*:ALL"
     state: present


### PR DESCRIPTION
This adds the ability to specify what host a mysql user will be authenticating from, defaulting to `localhost`. This is helpful in the case of using an external database and wanting to make sure a MySQL user can authenticate only from a single ip, or group of IP's. For example, if you wanted to enable an entire subnet of servers to be able to use this user and password, you could specify the `db_user_host` as `10.30.%.%` when the subnet has a CIDR of `10.30.0.0/16`.