### PR TITLE
add ability to pass extra parameters to bin/deploy.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Forward extra bin/deploy.sh parameters to ansible-playbook ([#748](https://github.com/roots/trellis/pull/748))
 * Accommodate template inheritance for nginx confs ([#740](https://github.com/roots/trellis/pull/740))
 * Add `apt_packages_custom` to customize Apt packages ([#735](https://github.com/roots/trellis/pull/735))
 * Enable Let's Encrypt to detect updated `site_hosts` ([#630](https://github.com/roots/trellis/pull/630))

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -21,6 +21,8 @@ Examples:
 "
 }
 
+[[ $# -lt 2 ]] && { show_usage; exit 0; }
+
 for arg
 do
   [[ $arg = -h ]] && { show_usage; exit 0; }

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
 shopt -s nullglob
 
-DEPLOY_CMD="ansible-playbook deploy.yml -e env=$1 -e site=$2"
 ENVIRONMENTS=( hosts/* )
 ENVIRONMENTS=( "${ENVIRONMENTS[@]##*/}" )
-NUM_ARGS=2
 
 show_usage() {
-  echo "Usage: deploy <environment> <site name>
+  echo "Usage: deploy <environment> <site name> [options]
 
 <environment> is the environment to deploy to ("staging", "production", etc)
 <site name> is the WordPress site to deploy (name defined in "wordpress_sites")
+[options] is any number of parameters that will be passed to ansible-playbook
 
 Available environments:
 `( IFS=$'\n'; echo "${ENVIRONMENTS[*]}" )`
@@ -18,15 +17,23 @@ Available environments:
 Examples:
   deploy staging example.com
   deploy production example.com
+  deploy staging example.com -vv -T 60
 "
 }
 
-HOSTS_FILE="hosts/$1"
+for arg
+do
+  [[ $arg = -h ]] && { show_usage; exit 0; }
+done
 
-[[ $# -ne $NUM_ARGS || $1 = -h ]] && { show_usage; exit 0; }
+ENV="$1"; shift
+SITE="$1"; shift
+EXTRA_PARAMS=$@
+DEPLOY_CMD="ansible-playbook deploy.yml -e env=$ENV -e site=$SITE $EXTRA_PARAMS"
+HOSTS_FILE="hosts/$ENV"
 
 if [[ ! -e $HOSTS_FILE ]]; then
-  echo "Error: $1 is not a valid environment ($HOSTS_FILE does not exist)."
+  echo "Error: $ENV is not a valid environment ($HOSTS_FILE does not exist)."
   echo
   echo "Available environments:"
   ( IFS=$'\n'; echo "${ENVIRONMENTS[*]}" )


### PR DESCRIPTION
This makes it simpler to modify the `ansible-playbook` command, especially in the instance of debugging via `-vvv` or limiting what hosts getting deployed to using `--limit`.