### PR TITLE
Add basic git repo host keys to known_hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Add basic git repo host keys to `known_hosts` ([#751](https://github.com/roots/trellis/pull/751))
 * Accommodate template inheritance for nginx confs ([#740](https://github.com/roots/trellis/pull/740))
 * Add `apt_packages_custom` to customize Apt packages ([#735](https://github.com/roots/trellis/pull/735))
 * Enable Let's Encrypt to detect updated `site_hosts` ([#630](https://github.com/roots/trellis/pull/630))

--- a/group_vars/all/known_hosts.yml
+++ b/group_vars/all/known_hosts.yml
@@ -1,0 +1,18 @@
+# Documentation: https://roots.io/trellis/docs/troubleshooting/#composer-install-host-key-verification-failed
+
+# Host keys to add to known_hosts, e.g.,
+#   - git host for Bedrock-based project (`repo` variable in `wordpress_sites`)
+#   - git hosts in Bedrock project's composer.json
+known_hosts:
+  - name: github.com
+    key: github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
+  - name: bitbucket.org
+    key: bitbucket.org ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==
+  - name: gitlab.com
+    key: gitlab.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAfuCHKVTjquxvt6CM6tdG4SLp1Btn/nOeHHE5UOzRdf
+  - name: gitlab.com
+    key: gitlab.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsj2bNKTBSpIYDEGk9KxsGh3mySTRgMtXL583qmBpzeQ+jqCMRgBqB98u3z++J1sKlXHWfM9dyhSevkMwSbhoR8XIq/U0tCNyokEi/ueaBMCvbcTHhO7FcwzY92WK4Yt0aGROY5qX2UKSeOvuP4D6TPqKF1onrSzH9bx9XUf2lEdWT/ia1NEKjunUqu1xOB/StKDHMoX4/OKyIzuS0q/T1zOATthvasJFoPrAjkohTyaDUz2LN5JoH839hViyEG82yB+MjcFV5MU3N1l1QL3cVUCh93xSaua1N85qivl+siMkPGbO5xR/En4iEY6K2XPASUEMaieWVNTRCtJ4S8H+9
+
+# Whether to automatically accept the host key for your `repo` (in `wordpress_sites`) during git clone.
+# To avoid man-in-the-middle attacks, set this to `false` and add repo host key to `known_hosts` above.
+repo_accept_hostkey: true

--- a/roles/deploy/tasks/update.yml
+++ b/roles/deploy/tasks/update.yml
@@ -2,6 +2,14 @@
 - include: "{{ deploy_update_before | default('../hooks/example.yml') }}"
   tags: deploy-update-before
 
+- name: Add known_hosts
+  known_hosts:
+    name: "{{ item.name }}"
+    key: "{{ item.key | default(omit) }}"
+    path: "{{ item.path | default('/home/' + ansible_user + '/.ssh/known_hosts') }}"
+    state: "{{ item.state | default('present') }}"
+  with_items: "{{ known_hosts | default([]) }}"
+
 - name: Check whether project source path is a git repo
   stat:
     path: "{{ project_source_path }}/.git"
@@ -26,7 +34,7 @@
     repo: "{{ project_git_repo }}"
     dest: "{{ project_source_path }}"
     version: "{{ project_version }}"
-    accept_hostkey: yes
+    accept_hostkey: "{{ repo_accept_hostkey | default(true) }}"
   ignore_errors: true
   no_log: true
   register: git_clone

--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -16,6 +16,14 @@
   register: env_file
   changed_when: env_file.stdout == "{{ item.key }}.env"
 
+- name: Add known_hosts
+  known_hosts:
+    name: "{{ item.name }}"
+    key: "{{ item.key | default(omit) }}"
+    path: "{{ item.path | default('/home/' + ansible_user + '/.ssh/known_hosts') }}"
+    state: "{{ item.state | default('present') }}"
+  with_items: "{{ known_hosts | default([]) }}"
+
 - name: Install Dependencies with Composer
   composer:
     no_dev: no


### PR DESCRIPTION
https://github.com/roots/trellis/pull/475#issuecomment-217995557 describes how to populate a remote server's `known_hosts` via deploy hook. The purpose is to avoid the `host key verification failed` error during the composer install task.

This PR makes the `known_hosts` handling part of Trellis core:
* avoids the error for the Vagrant VM (`wordpress-install` role) too
* users no longer need the deploy hook

I included both `rsa` and `ed25519` key types for GitLab. These work with current master and with the `HostKeyAlgorithms` that #744 will apply to the SSH client. I avoided the `ecdsa` type for GitLab because it will be disallowed after #744. 

GitHub and Bitbucket seem to only offer the `rsa` type, before and after #744.

Docs in roots/docs#78