### PR TITLE
Use ipify_facts module instead of lookup plugin for IP lookup

### DIFF
--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -6,7 +6,7 @@ ntp_timezone: Etc/UTC
 ntp_manage_config: true
 www_root: /srv/www
 ip_whitelist:
-  - "{{ (env == 'development') | ternary(ansible_default_ipv4.gateway, ssh_client_ip.stdout | default('')) }}"
+  - "{{ (env == 'development') | ternary(ansible_default_ipv4.gateway, ipify_public_ip | default('')) }}"
 
 # Values of raw_vars will be wrapped in `{% raw %}` to avoid templating problems if values include `{%` and `{{`.
 # Will recurse dicts/lists. `*` is wildcard for one or more dict keys, list indices, or strings. Example:

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -6,7 +6,7 @@ ntp_timezone: Etc/UTC
 ntp_manage_config: true
 www_root: /srv/www
 ip_whitelist:
-  - "{{ lookup('pipe', 'curl -4 -s https://api.ipify.org') }}"
+  - "{{ (env == 'development') | ternary(ansible_default_ipv4.gateway, ssh_client_ip.stdout | default('')) }}"
 
 # Values of raw_vars will be wrapped in `{% raw %}` to avoid templating problems if values include `{%` and `{{`.
 # Will recurse dicts/lists. `*` is wildcard for one or more dict keys, list indices, or strings. Example:

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -77,3 +77,12 @@
     name: vagrant
     generate_ssh_key: yes
   when: env == 'development'
+
+- name: Retrieve SSH client IP
+  command: curl -4 -s https://api.ipify.org
+  args:
+    warn: false
+  changed_when: false
+  register: ssh_client_ip
+  when: env != 'development' and ssh_client_ip_lookup | default(true)
+  tags: [fail2ban, ferm]

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -79,10 +79,8 @@
   when: env == 'development'
 
 - name: Retrieve SSH client IP
-  command: curl -4 -s https://api.ipify.org
-  args:
-    warn: false
-  changed_when: false
-  register: ssh_client_ip
+  ipify_facts:
+  connection: local
+  become: no
   when: env != 'development' and ssh_client_ip_lookup | default(true)
   tags: [fail2ban, ferm]


### PR DESCRIPTION
>Lookup plugins are lazy evaluated and this may occur at multiple points in time. _[--reference](https://github.com/ansible/ansible/issues/9623#issuecomment-64452130)_

This PR changes the IP lookup to use the command module instead of a lookup.
* This ensures only a single connection to api.ipify.org (e.g., because no connection should be made during deploys, as unfortunately occurred in [this example](https://discourse.roots.io/t/deploys-on-a-slow-connection/8785)). This should reduce how often users have connectivity issues with api.ipify.org.
* It also avoids confusion of potential failures at random points during the playbook ([example](https://discourse.roots.io/t/ansible-fails-at-ensure-fail2ban-is-configured/8698)).

Users can disable the api.ipify.org connection by adding a new variable to group_vars:
`ssh_client_ip_lookup: false`

____

This PR accounts for how a `vagrant ssh` connection to the VM uses the IP in `ansible_default_ipv4.gateway` (e.g., `10.0.2.2`) instead of the public IP from api.ipify.org.

____

I was disappointed that the [`ansible_env["SSH_CLIENT"]`](http://stackoverflow.com/a/33961318/6847025) fact is not available when the play parameter `become: yes` is used. Otherwise, we could have avoided the need to query api.ipify.org and used the IP retrieved from `ansible_env` instead. The `ansible_env` var  is populated during the setup task. The ad hoc commands below demonstrate how `ansible_env` differs when `become: yes`.

```
# SSH_CLIENT is present in output
ansible 138.68.53.198 -m setup -u admin

# `-b` is become: yes, SSH_CLIENT is absent from output
ansible 138.68.53.198 -m setup -b -u admin -K
```

