### PR TITLE
Add generate_cert_ids default to avoid variable undefined error

### DIFF
--- a/roles/letsencrypt/defaults/main.yml
+++ b/roles/letsencrypt/defaults/main.yml
@@ -2,7 +2,7 @@ sites_using_letsencrypt: "[{% for name, site in wordpress_sites.iteritems() if s
 letsencrypt_enabled: "{{ sites_using_letsencrypt | count }}"
 site_uses_letsencrypt: "{{ ssl_enabled and item.value.ssl.provider | default('manual') == 'letsencrypt' }}"
 missing_hosts: "{{ site_uses_letsencrypt | ternary(site_hosts, []) | difference((current_hosts.results | selectattr('item.key', 'equalto', item.key) | selectattr('stdout_lines', 'defined') | sum(attribute='stdout_lines', start=[]) | map('trim') | list | join(' ')).split(' ')) }}"
-letsencrypt_cert_ids: "{ {% for item in generate_cert_ids.results if not item | skipped %}'{{ item.item.key }}':'{{ item.stdout }}', {% endfor %} }"
+letsencrypt_cert_ids: "{ {% for item in (generate_cert_ids | default({'results':[{'skipped':True}]})).results if not item | skipped %}'{{ item.item.key }}':'{{ item.stdout }}', {% endfor %} }"
 
 acme_tiny_repo: 'https://github.com/diafygi/acme-tiny.git'
 acme_tiny_commit: '5a7b4e79bc9bd5b51739c0d8aaf644f62cc440e6'


### PR DESCRIPTION
[Some users](https://discourse.roots.io/t/ansibleundefinedvariable-generate-cert-ids-is-undefined/8719) have reported receiving this error:
```
AnsibleUndefinedVariable: 'generate_cert_ids' is undefined
```

I can reproduce on Ansible 2.0.2.0.

Although upgrading Ansible resolves the problem in my tests, some users report the problem persisting. 

This PR adds a default value for `generate_cert_ids` in order to avoid the problem of being `undefined`.