### PR TITLE
Parallels tools MUST BE installed first time that vagrant is run.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -148,6 +148,7 @@ Vagrant.configure('2') do |config|
   config.vm.provider 'parallels' do |prl, override|
     prl.name = config.vm.hostname
     prl.cpus = cpus
+    prl.update_guest_tools = true
     prl.memory = memory
   end
 


### PR DESCRIPTION
If you are using Parallels with vagrant, the initial vagrant up on a new trellis install will fail because Parallels Guest Tools aren't installed, which means that the NFS mount will fail.