### PR TITLE
Enable admin_user to invoke sudo with xdebug-tunnel.yml

### DIFF
--- a/roles/xdebug-tunnel/tasks/main.yml
+++ b/roles/xdebug-tunnel/tasks/main.yml
@@ -7,6 +7,7 @@
       ssh -S '{{ xdebug_tunnel_control_socket }}' -O exit '{{ xdebug_tunnel_control_identity }}'
     {% endif %}
   connection: local
+  become: no
   register: xdebug_tunnel
   ignore_errors: true
 

--- a/xdebug-tunnel.yml
+++ b/xdebug-tunnel.yml
@@ -7,6 +7,7 @@
 
 - name: Enable or Disable Xdebug and SSH Tunnel
   hosts: "{{ xdebug_tunnel_inventory_host }}"
+  become: yes
   roles:
     - { role: xdebug, tags: [xdebug] }
     - { role: xdebug-tunnel, tags: [xdebug-tunnel] }


### PR DESCRIPTION
When `sshd_permit_root_login: false` the `admin_user` will connect to run the `xdebug-tunnel.yml` playbook. The `admin_user` needs to invoke `sudo` in order to install and configure Xdebug.  