### PR TITLE
Permit TCP port forwarding for 127.0.0.1:3306

### DIFF
--- a/roles/sshd/defaults/main.yml
+++ b/roles/sshd/defaults/main.yml
@@ -15,7 +15,7 @@ sshd_accept_env: []
 
 sshd_address_family: inet
 sshd_allow_agent_forwarding: true
-sshd_allow_tcp_forwarding: false
+sshd_allow_tcp_forwarding: local
 sshd_challenge_response_authentication: false
 
 sshd_ciphers_default:

--- a/roles/sshd/templates/sshd_config.j2
+++ b/roles/sshd/templates/sshd_config.j2
@@ -14,7 +14,7 @@ Protocol {{ sshd_protocol }}
 AcceptEnv {{ sshd_accept_env | join(' ') }}
 AddressFamily {{ sshd_address_family }}
 AllowAgentForwarding {{ sshd_allow_agent_forwarding | ternary('yes', 'no') }}
-AllowTcpForwarding {{ sshd_allow_tcp_forwarding | ternary('yes', 'no') }}
+AllowTcpForwarding {{ sshd_allow_tcp_forwarding is string | ternary(sshd_allow_tcp_forwarding, sshd_allow_tcp_forwarding | ternary('yes', 'no')) }}
 ChallengeResponseAuthentication {{ sshd_challenge_response_authentication | ternary('yes', 'no') }}
 Ciphers {{ (sshd_ciphers_default + sshd_ciphers_extra) | join(',') }}
 ClientAliveInterval {{ sshd_client_alive_interval }}


### PR DESCRIPTION
#744 changed `AllowTcpForwarding` from `yes` to `no`. This blocks tools like Sequel Pro from being able to access the DB on port 3306 (example [discourse thread](https://discourse.roots.io/t/error-connecting-to-vagrant-db-with-sequel-pro/8835)).

The PR allows local port forwarding and limits it to the host `127.0.0.1` and port `3306`, re-enabling DB access for tools like Sequel Pro. 