### PR TITLE
Consolidate multisite config into env vars only

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -159,7 +159,7 @@ def local_site_path(site)
 end
 
 def multisite_subdomains?(wordpress_sites)
-  wordpress_sites.any? { |(_name, site)| site['multisite'].fetch('enabled', false) && site['multisite'].fetch('subdomains', false) }
+  wordpress_sites.any? { |(_name, site)| site.fetch('env', false) && site['env'].fetch('multisite', false) && site['env'].fetch('subdomain_install', false) }
 end
 
 def nfs_path(site_name)

--- a/deploy.yml
+++ b/deploy.yml
@@ -42,5 +42,11 @@
           > https://roots.io/trellis/docs/deploys/
       when: project.repo is not defined or not project.repo | match(".*@.*:.*\.git")
 
+    - name: Validate multisite configuration
+      debug:
+        msg: "{{ lookup('template', playbook_dir + '/roles/common/templates/multisite_config.j2') }}"
+      when: project.multisite is defined
+      failed_when: project.multisite.enabled | default(false) and (project.env | default({})).multisite is not defined
+
   roles:
     - deploy

--- a/group_vars/development/wordpress_sites.yml
+++ b/group_vars/development/wordpress_sites.yml
@@ -10,8 +10,6 @@ wordpress_sites:
           - www.example.dev
     local_path: ../site # path targeting local Bedrock site directory (relative to Ansible root)
     admin_email: admin@example.dev
-    multisite:
-      enabled: false
     ssl:
       enabled: false
       provider: self-signed

--- a/group_vars/production/wordpress_sites.yml
+++ b/group_vars/production/wordpress_sites.yml
@@ -12,8 +12,6 @@ wordpress_sites:
     repo: git@github.com:example/example.com.git # replace with your Git repo URL
     repo_subtree_path: site # relative path to your Bedrock/WP directory in your repo
     branch: master
-    multisite:
-      enabled: false
     ssl:
       enabled: false
       provider: letsencrypt

--- a/group_vars/staging/wordpress_sites.yml
+++ b/group_vars/staging/wordpress_sites.yml
@@ -12,8 +12,6 @@ wordpress_sites:
     repo: git@github.com:example/example.com.git # replace with your Git repo URL
     repo_subtree_path: site # relative path to your Bedrock/WP directory in your repo
     branch: master
-    multisite:
-      enabled: false
     ssl:
       enabled: false
       provider: letsencrypt

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -17,6 +17,14 @@
   when: item.value.site_hosts | rejectattr('canonical', 'defined') | list | count
   tags: [letsencrypt, wordpress]
 
+- name: Validate multisite configuration
+  debug:
+    msg: "{{ lookup('template', 'multisite_config.j2') }}"
+  with_dict: "{{ wordpress_sites }}"
+  when: item.value.multisite is defined
+  failed_when: item.value.multisite.enabled | default(false) and (item.value.env | default({})).multisite is not defined
+  tags: [wordpress]
+
 - name: Validate Ubuntu version
   debug:
     msg: |

--- a/roles/common/templates/multisite_config.j2
+++ b/roles/common/templates/multisite_config.j2
@@ -1,0 +1,22 @@
+{% if site is not defined %}
+{% set site=item.key %}
+{% set project=item.value %}
+{% endif -%}
+
+Warning! The old `multisite.enabled` and `multisite.subdomains`
+settings are now ignored. Multisite must be configured ONLY in
+the `env` vars of `group_vars/{{ env }}/wordpress_sites.yml`.
+
+{% if not project.multisite.enabled | default(false) and not (project.env | default({})).multisite | default(false) %}
+You don't have multisite enabled for {{ site }} so you may completely omit any multisite config for {{ site }} in `group_vars/{{ env }}/wordpress_sites`
+
+{% else %}
+wordpress_sites:
+  {{ site }}:
+    ...
+    env:
+      multisite: {{ (project.env | default({})).multisite | default(project.multisite.enabled | default('false')) | lower }}                      # default: false
+      subdomain_install: {{ (project.env | default({})).subdomain_install | default(project.multisite.subdomains | default('false')) | lower }}              # default: false
+
+{% endif %}
+See https://roots.io/trellis/docs/multisite/

--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -1,6 +1,6 @@
 ---
 - name: WordPress Installed?
-  command: wp core is-installed {{ project.multisite.enabled | default(false) | ternary('--network', '') }}
+  shell: MULTISITE=false SUBDOMAIN_INSTALL=false wp core is-installed
   args:
     chdir: "{{ deploy_helper.current_path }}"
   register: wp_installed
@@ -12,18 +12,18 @@
     command: wp core update-db
     args:
       chdir: "{{ deploy_helper.current_path }}"
-    when: not project.multisite.enabled | default(false)
+    when: not site_env.multisite | default(false)
 
   - name: Warn about updating network database.
     debug:
       msg: "Updating the network database could take a long time with a large number of sites."
-    when: project.multisite.enabled | default(false)
+    when: site_env.multisite | default(false)
 
   - name: Update WP network database
     command: wp core update-db --network
     args:
       chdir: "{{ deploy_helper.current_path }}"
-    when: project.multisite.enabled | default(false)
+    when: site_env.multisite | default(false)
 
   - name: Get WP theme template root
     command: wp option get template_root

--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -33,12 +33,12 @@
   with_dict: "{{ wordpress_sites }}"
 
 - name: Install WP
-  command: wp core {{ item.value.multisite.enabled | default(false) | ternary('multisite-install', 'install') }}
+  command: wp core {{ site_env.multisite | default(false) | ternary('multisite-install', 'install') }}
            --allow-root
            --url="{{ site_env.wp_home }}"
-           {% if item.value.multisite.enabled | default(false) %}
-           --base="{{ item.value.multisite.base_path | default('/') }}"
-           --subdomains="{{ item.value.multisite.subdomains | default('false') }}"
+           {% if site_env.multisite | default(false) %}
+           --base="{{ site_env.path_current_site | default('/') }}"
+           --subdomains="{{ site_env.subdomain_install | default('false') }}"
            {% endif %}
            --title="{{ item.value.site_title | default(item.key) }}"
            --admin_user="{{ item.value.admin_user | default('admin') }}"
@@ -63,4 +63,4 @@
   args:
     chdir: "{{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/"
   with_dict: "{{ wordpress_sites }}"
-  when: item.value.site_install | default(true) and item.value.multisite.enabled | default(false)
+  when: item.value.site_install | default(true) and site_env.multisite | default(false)

--- a/roles/wordpress-setup/tasks/main.yml
+++ b/roles/wordpress-setup/tasks/main.yml
@@ -49,4 +49,4 @@
     job: "cd {{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }} && wp cron event run --due-now > /dev/null 2>&1"
     cron_file: "wordpress-{{ item.key | replace('.', '_') }}"
   with_dict: "{{ wordpress_sites }}"
-  when: site_env.disable_wp_cron and not item.value.multisite.enabled | default(false)
+  when: site_env.disable_wp_cron and not site_env.multisite | default(false)

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -5,7 +5,7 @@
 server {
   {% block server_id -%}
   listen {{ ssl_enabled | ternary('443 ssl http2', '80') }};
-  server_name  {% for host in site_hosts_canonical %}{{ host }} {% if item.value.multisite.subdomains | default(false) %}*.{{ host }} {% endif %}{% endfor %};
+  server_name  {% for host in site_hosts_canonical %}{{ host }} {% if site_env.multisite | default(false) %}*.{{ host }} {% endif %}{% endfor %};
   {% endblock %}
 
   {% block logs -%}
@@ -30,9 +30,9 @@ server {
   {% endblock -%}
 
   {% block multisite_rewrites -%}
-  {% if item.value.multisite.enabled | default(false) -%}
+  {% if site_env.multisite | default(false) -%}
   # Multisite rewrites
-  {% if item.value.multisite.subdomains | default(false) -%}
+  {% if site_env.subdomain_install | default(false) -%}
   rewrite ^/(wp-.*.php)$ /wp/$1 last;
   rewrite ^/(wp-(content|admin|includes).*) /wp/$1 last;
 
@@ -157,7 +157,7 @@ server {
 # Redirect to https
 server {
   listen 80;
-  server_name {{ site_hosts | join(' ') }}{% if item.value.multisite.subdomains | default(false) %} *.{{ site_hosts_canonical | join(' *.') }}{% endif %};
+  server_name {{ site_hosts | join(' ') }}{% if site_env.subdomain_install | default(false) %} *.{{ site_hosts_canonical | join(' *.') }}{% endif %};
 
   {{ self.acme_challenge() -}}
 


### PR DESCRIPTION
This PR is an alternative to #754. Fixes #554.

As in #754, this PR proposes the usage of env vars for `MULTISITE` and `SUBDOMAIN_INSTALL` as part of changes that prevent the `wp core is-installed` check from failing ([solution from](https://github.com/roots/trellis/pull/754#issuecomment-280131261) @QWp6t).

### One multisite config only

The difference from #754 is that this PR proposes to use the new env vars to control all of the Trellis multisite setup. This feels conceptually cleaner than how #754 uses the old `multisite.enabled` and `multisite.subdomains` configs as indirect controls of the configs WP uses directly (the env vars).

The changes from current master are not drastic. Changes are quite simple, like this example:
```diff
-    when: project.multisite.enabled | default(false)
+    when: site_env.multisite | default(false)
```

### Breaking change to `wordpress_sites`

This would be a breaking change to the structure/expectations of `wordpress_sites`. The majority of the edits in this PR are validations of the multisite configs, with messages to help users make the transition. Aside from these validations and messages, there are no new lines of code, only simple changes to existing lines, as in the diff above.

Here is the message users would see if the old `multisite.enabled` setting is present but `false`:
```
Warning! The old `multisite.enabled` and `multisite.subdomains`
settings are now ignored. Multisite must be configured ONLY in
the `env` vars of `group_vars/production/wordpress_sites.yml`.

You don't have multisite enabled for domain.com so you may completely omit
any multisite config for domain.com in
`group_vars/production/wordpress_sites`

See https://roots.io/trellis/docs/multisite/
```

Or if `multisite.enabled` setting is present and `true`:
```
Warning! The old `multisite.enabled` and `multisite.subdomains`
settings are now ignored. Multisite must be configured ONLY in
the `env` vars of `group_vars/production/wordpress_sites.yml`.

wordpress_sites:
  domain.com:
    ...
    env:
      multisite: true                      # default: false
      subdomain_install: true              # default: false

See https://roots.io/trellis/docs/multisite/
```

The playbook will warn and continue if the new `env.multisite` is present; Presumably the user has consciously set an appropriate value and provisioning/deployment will be appropriate. However, if the old `multisite.enabled` is present as `true` and `env.multisite` is not defined, the playbook will fail because it will not provision/deploy a multisite setup, as was apparently intended.

### Simpler than #754

Compared to #754, this PR allows users who aren't using multisite to simplify their `wordpress_sites` to omit any `multisite` config without getting an `undefined variable` warning, as in current master. In addition, this PR avoids having to set several new default env vars (as were required in #754).

### Less chance for error than #754 

#754 leaves it possible for users to set `multisite.enabled: true` and `env.multisite: false`, which entanglement might happen after a new user's iterations of trying out trellis and multisite. This would yield nginx confs set up for multisite, but WP constants _not_ set for multisite. The current PR avoids the problem by having only one possible place for the config.

### Required changes to docs

To illustrate what would change for users, here are the primary changes to the [multisite docs](https://roots.io/trellis/docs/multisite/):

1. Suggest defining the constants in a way that loads the env vars:

```
define('MULTISITE', env('MULTISITE') ?? true);
define('SUBDOMAIN_INSTALL', env('SUBDOMAIN_INSTALL') ?? true); // Set to false if using subdirectories
```

2. Switch to illustrating the new env vars instead of `multisite.enabled`.

```
wordpress_sites:
  example.com:
    ...
    env:
      multisite: true
      subdomain_install: true  # omit or set to false if using subdirectories
```