### PR TITLE
Set multisite constants false while checking wp core is-installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Set multisite constants false while checking `wp core is-installed` ([#766](https://github.com/roots/trellis/pull/766))
 * Forward extra bin/deploy.sh parameters to ansible-playbook ([#748](https://github.com/roots/trellis/pull/748))
 * Update WP-CLI to 1.1.0 ([#759](https://github.com/roots/trellis/pull/759))
 * Add DOMAIN_CURRENT_SITE to default env variables ([#760](https://github.com/roots/trellis/pull/760))

--- a/roles/deploy/files/tmp_multisite_constants.php
+++ b/roles/deploy/files/tmp_multisite_constants.php
@@ -1,0 +1,4 @@
+<?php
+error_reporting(E_ALL & ~E_NOTICE);
+define('MULTISITE', false);
+define('SUBDOMAIN_INSTALL', false);

--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -1,6 +1,11 @@
 ---
+- name: Create file with multisite constants defined as false
+  copy:
+    src: "tmp_multisite_constants.php"
+    dest: "{{ deploy_helper.shared_path }}/tmp_multisite_constants.php"
+
 - name: WordPress Installed?
-  command: wp core is-installed {{ project.multisite.enabled | default(false) | ternary('--network', '') }}
+  command: wp core is-installed --require={{ deploy_helper.shared_path }}/tmp_multisite_constants.php
   args:
     chdir: "{{ deploy_helper.current_path }}"
   register: wp_installed


### PR DESCRIPTION
Creates php file that defines multisite constants false, then uses the
file in `--require` param of task that checks `wp core is-installed`.

Prevents `WordPress database error Table 'tablename' doesn't exist`
that occurs when WordPress loads with...
  - constants set true for MULTISITE and SUBDOMAIN_INSTALL
  - no DB tables

------

This is the final product of the work in #754.
Fixes #554.
Closes #754.
Closes #765.