### PR TITLE
Validate SSH client/server compat only if client is OpenSSH 6.8+

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -17,6 +17,7 @@ apt_packages_default:
 apt_packages_custom: []
 apt_packages_install: "{{ apt_packages_default + apt_packages_custom }}"
 
+openssh_6_8_plus: "{{ (lookup('pipe', 'ssh -V 2>&1')) | regex_replace('(.*OpenSSH_([\\d\\.]*).*)', '\\2') | version_compare('6.8', '>=') }}"
 overlapping_ciphers: "[{% for cipher in (sshd_ciphers_default + sshd_ciphers_extra) if cipher in ssh_client_ciphers %}'{{ cipher }}',{% endfor %}]"
 overlapping_kex: "[{% for kex in (sshd_kex_algorithms_default + sshd_kex_algorithms_extra) if kex in ssh_client_kex %}'{{ kex }}',{% endfor %}]"
 overlapping_macs: "[{% for mac in (sshd_macs_default + sshd_macs_extra) if mac in ssh_client_macs %}'{{ mac }}',{% endfor %}]"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -50,7 +50,7 @@
     ssh_client_kex: "{{ lookup('pipe', 'ssh -ttG ' + ansible_host + ' | grep kexalgorithms') }}"
     ssh_client_macs: "{{ lookup('pipe', 'ssh -ttG ' + ansible_host + ' | grep macs') }}"
     ssh_client_host_key_algorithms: "{{ lookup('pipe', 'ssh -ttG ' + ansible_host + ' | grep hostkeyalgorithms') }}"
-  when: validate_ssh | default(true)
+  when: openssh_6_8_plus and validate_ssh | default(true)
   tags: [sshd]
 
 - name: Validate compatible settings between SSH client and server
@@ -61,7 +61,7 @@
       - overlapping_macs | count
       - overlapping_host_keys | count
     msg: "{{ lookup('template', 'validate_ssh_msg.j2') }}"
-  when: validate_ssh | default(true)
+  when: openssh_6_8_plus and validate_ssh | default(true)
   tags: [sshd]
 
 - name: Checking essentials


### PR DESCRIPTION
Fixes #768 and [discourse thread](https://discourse.roots.io/t/error-retrieve-local-ssh-clients-settings-per-host/8801).

Retrieves client's OpenSSH version and makes validation conditional on
version 6.8+. Validation's -G option is available only in OpenSSH 6.8+.

----

This disables the compatibility check for SSH clients running older versions of OpenSSH. Unfortunately, incompatibility is more likely in older clients and will no longer be detected to prevent users from losing SSH access to their servers.

We could consider adding this protection:
- add `backup: yes` to the template task creating the `sshd_config` on the server
- augment the `restart ssh` handler to perform some kind of local action ssh connection test to the server after loading the new `sshd_config`
(conditional on `sshd_config` changed and `openssh_6_8_plus` == `true`)
- if local action connection test fails
  - restore the `sshd_config` to the backup created in template task and restart ssh.
I think the playbook will still be able to connect and make this change because the original SSH connection should stay alive for 60s, due to [`-o ControlMaster=auto -o ControlPersist=60s`](https://github.com/roots/trellis/blob/5cd8c27cbb176415a98ae3c9f141302d84cd8a83/ansible.cfg#L12)
  - present some debug msg along the lines of "The sshd changes were reverted because your SSH client failed to connect to the server when the new config was in effect. Do this: x, y, z."