### PR TITLE
Fix #772 - Move $skip_cache before multisite rewrites

### DIFF
--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -29,6 +29,23 @@ server {
   {% endif -%}
   {% endblock -%}
 
+  {% block cache_conditions -%}
+  {% if item.value.cache is defined and item.value.cache.enabled | default(false) -%}
+  # Fastcgi cache conditions
+  set $skip_cache 0;
+  if ($query_string != "") {
+    set $skip_cache 1;
+  }
+  if ($request_uri ~* "{{ item.value.cache.skip_cache_uri | default(nginx_skip_cache_uri) }}") {
+    set $skip_cache 1;
+  }
+  if ($http_cookie ~* "{{ item.value.cache.skip_cache_cookie | default(nginx_skip_cache_cookie) }}") {
+    set $skip_cache 1;
+  }
+
+  {% endif -%}
+  {% endblock -%}
+  
   {% block multisite_rewrites -%}
   {% if item.value.multisite.enabled | default(false) -%}
   # Multisite rewrites
@@ -78,23 +95,6 @@ server {
   {% block acme_challenge -%}
   include acme-challenge-location.conf;
 
-  {% endblock -%}
-
-  {% block cache_conditions -%}
-  {% if item.value.cache is defined and item.value.cache.enabled | default(false) -%}
-  # Fastcgi cache conditions
-  set $skip_cache 0;
-  if ($query_string != "") {
-    set $skip_cache 1;
-  }
-  if ($request_uri ~* "{{ item.value.cache.skip_cache_uri | default(nginx_skip_cache_uri) }}") {
-    set $skip_cache 1;
-  }
-  if ($http_cookie ~* "{{ item.value.cache.skip_cache_cookie | default(nginx_skip_cache_cookie) }}") {
-    set $skip_cache 1;
-  }
-
-  {% endif -%}
   {% endblock -%}
 
   {% block includes_d -%}


### PR DESCRIPTION
See https://github.com/roots/trellis/issues/772#issuecomment-282106396

For whatever reason, moving the skip cache section before the multisite rewrites section makes fasctcgi caching work as expected. What's still confusing about this is that cookies should have invalidated the cache... maybe I'll understand that [another day](https://www.youtube.com/watch?v=EXGUNvIFTQw).