### PR TITLE
Move MySQL restart to handler for idempotence

### DIFF
--- a/roles/mariadb/handlers/main.yml
+++ b/roles/mariadb/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: restart mysql server
+  service:
+    name: mysql
+    state: restarted
+    enabled: true

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -19,12 +19,7 @@
       owner: root
       group: root
     when: mysql_binary_logging_disabled
-
-  - name: Restart MySQL Server
-    service:
-      name: mysql
-      state: restarted
-      enabled: true
+    notify: restart mysql server
 
   - name: Set root user password
     mysql_user:


### PR DESCRIPTION
Fixes #775 -- Thanks for reporting this, @strarsis

When the `service` module's `state: restarted`, the task will always run, which is not idempotent.

This PR moves the MySQL restart task to a handler notified when MySQL config changes are made in the "Disable MariaDB binary logging" task.

As noted in d05170b the "Install MySQL client" task starts the MySQL server, so it is unnecessary for the install task to notify the handler.