### PR TITLE
Always set_fact for ansible_user, even if CLI --check or --user

### DIFF
--- a/roles/remote-user/tasks/main.yml
+++ b/roles/remote-user/tasks/main.yml
@@ -10,13 +10,14 @@
   local_action: command ansible {{ inventory_hostname }} -m raw -a whoami -u root {{ cli_options | default('') }}
   failed_when: false
   changed_when: false
+  check_mode: no
   register: root_status
   tags: [connection-tests]
 
 - name: Set remote user for each host
   set_fact:
-    ansible_user: "{{ ('root' in root_status.stdout_lines) | ternary('root', admin_user) }}"
-  when: ansible_user is not defined
+    ansible_user: "{{ ansible_user | default(('root' in root_status.stdout_lines) | ternary('root', admin_user)) }}"
+  check_mode: no
 
 - name: Announce which user was selected
   debug:


### PR DESCRIPTION
Fixes #779 -- thank you for the report, @strarsis

In check mode, remote user test and assignment skips. No `ansible_user` is set despite being needed.

This PR adds [`check_mode: no`](http://docs.ansible.com/ansible/playbooks_checkmode.html#enabling-or-disabling-check-mode-for-tasks), forcing the relevant `remote-user` tasks to run in normal mode even when the playbook is running in check mode (e.g., via `--check`).

Note that [check mode usually doesn't make sense for the first playbook run](http://blog.nordeus.com/dev-ops/ansible-check-mode-tips.htm) of `server.yml`.

----

Testing this PR revealed another problem addressed in ansible/ansible#22156. Ansible's magic var for `ansible_user` is apparently not available for consumption in explicit redefinition of the `ansible_become_pass` magic var.

For example, if you pass `ansible-playbook -u admin`, the Trellis `set_fact` task for `ansible_user` skips because `ansible_user` **is already defined**, as a magic var in this case. Trellis explicitly defines  `ansible_become_pass` (normally a magic var) using `ansible_user`, but an error occurs because `ansible_user` **is somehow `undefined` in this unique context**:
```
TASK [Install Python 2.x] ******************************************************
System info:
  Ansible 2.2.0.0; Darwin
  Trellis at "Allow for per-project packagist.com authentication"
---------------------------------------------------
the field 'become_pass' has an invalid value, which appears to include a
variable that is undefined. The error was: 'ansible_user' is undefined
fatal: [test]: FAILED! => {"failed": true}
```

The second part of this PR prevents the error above by causing the `set_fact` for `ansible_user` to always run, ensuring that `ansible_user` is always **explicitly defined** (not just a magic var).