### PR TITLE
Integrate Content Security Policy

### DIFF
--- a/group_vars/development/wordpress_sites.yml
+++ b/group_vars/development/wordpress_sites.yml
@@ -17,3 +17,7 @@ wordpress_sites:
       provider: self-signed
     cache:
       enabled: false
+    csp:
+      enabled: false
+      directives:
+        - "default-src 'none'"

--- a/group_vars/production/wordpress_sites.yml
+++ b/group_vars/production/wordpress_sites.yml
@@ -19,3 +19,5 @@ wordpress_sites:
       provider: letsencrypt
     cache:
       enabled: false
+    csp:
+      enabled: false

--- a/group_vars/staging/wordpress_sites.yml
+++ b/group_vars/staging/wordpress_sites.yml
@@ -19,3 +19,5 @@ wordpress_sites:
       provider: letsencrypt
     cache:
       enabled: false
+    csp:
+      enabled: false

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -45,7 +45,7 @@ server {
 
   {% endif -%}
   {% endblock -%}
-  
+
   {% block multisite_rewrites -%}
   {% if item.value.multisite.enabled | default(false) -%}
   # Multisite rewrites
@@ -100,6 +100,13 @@ server {
   {% block includes_d -%}
   include includes.d/{{ item.key }}/*.conf;
 
+  {% endblock -%}
+
+  {% block csp -%}
+  {% if item.value.csp is defined and item.value.csp.enabled | default(false) -%}
+  add_header Content-Security-Policy "{% for source in item.value.csp.directives %}{{ source }}; {% endfor %}";
+
+  {% endif -%}
   {% endblock -%}
 
   {% block location_uploads_php -%}


### PR DESCRIPTION
[Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) is a large part of a security workflow for websites, and it is only becoming more popular with CSP3 coming soon.

I've added a very simple way to create this nginx header for each site host. This can be easily enabled and configured for each WordPress site (`item.key`). Only a single directive was defined in `group_vars/development/wordpress_sites.yml` file to show how it works.

This would output the following nginx header in `/etc/nginx/sites-available/example.com.conf`

```nginx
add_header Content-Security-Policy "default-src 'none'; ";
```