### PR TITLE
Allow customization of PHP extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Allow customization of PHP extensions ([#787](https://github.com/roots/trellis/pull/787))
 * Allow for per-project packagist.com authentication ([#762](https://github.com/roots/trellis/pull/762))
 * Set multisite constants false while checking `wp core is-installed` ([#766](https://github.com/roots/trellis/pull/766))
 * Forward extra bin/deploy.sh parameters to ansible-playbook ([#748](https://github.com/roots/trellis/pull/748))

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -15,7 +15,7 @@ apt_packages_default:
   - libnss-myhostname
 
 apt_packages_custom: []
-apt_packages_install: "{{ apt_packages_default + apt_packages_custom }}"
+apt_packages: "{{ apt_packages_default + apt_packages_custom }}"
 
 openssh_6_8_plus: "{{ (lookup('pipe', 'ssh -V 2>&1')) | regex_replace('(.*OpenSSH_([\\d\\.]*).*)', '\\2') | version_compare('6.8', '>=') }}"
 overlapping_ciphers: "[{% for cipher in (sshd_ciphers_default + sshd_ciphers_extra) if cipher in ssh_client_ciphers %}'{{ cipher }}',{% endfor %}]"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -70,7 +70,7 @@
     state: present
     update_cache: true
     cache_valid_time: "{{ apt_cache_valid_time }}"
-  with_items: "{{ apt_packages_install }}"
+  with_items: "{{ apt_packages }}"
 
 - name: Validate timezone variable
   stat:

--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -1,6 +1,24 @@
 disable_default_pool: true
 memcached_sessions: false
 
+php_extensions_default:
+  - php7.1-cli
+  - php7.1-common
+  - php7.1-curl
+  - php7.1-dev
+  - php7.1-fpm
+  - php7.1-gd
+  - php7.1-mbstring
+  - php7.1-mcrypt
+  - php7.1-mysql
+  - php7.1-opcache
+  - php7.1-xml
+  - php7.1-xmlrpc
+  - php7.1-zip
+
+php_extensions_custom: []
+php_extensions: "{{ php_extensions_default + php_extensions_custom }}"
+
 php_error_reporting: 'E_ALL & ~E_DEPRECATED & ~E_STRICT'
 php_display_errors: 'Off'
 php_display_startup_errors: 'Off'

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -9,20 +9,7 @@
     name: "{{ item }}"
     state: present
     force: yes
-  with_items:
-  - php7.1-cli
-  - php7.1-common
-  - php7.1-curl
-  - php7.1-dev
-  - php7.1-fpm
-  - php7.1-gd
-  - php7.1-mbstring
-  - php7.1-mcrypt
-  - php7.1-mysql
-  - php7.1-opcache
-  - php7.1-xml
-  - php7.1-xmlrpc
-  - php7.1-zip
+  with_items: "{{ php_extensions }}"
 
 - name: Start php7.1-fpm service
   service:


### PR DESCRIPTION
Adds a `php_extensions_custom` variable to allow users to specific custom extensions to be installed.

`php_extensions_default` can also be defined to change the default extensions.

This follows the pattern set in https://github.com/roots/trellis/pull/735 but updates the naming.