### PR TITLE
Add additional nginx sites-enabled templates support

### DIFF
--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -5,6 +5,9 @@ nginx_logs_root: /var/log/nginx
 nginx_user: www-data
 nginx_fastcgi_buffers: 8 8k
 nginx_fastcgi_buffer_size: 8k
+nginx_default_site_enabled: true
+nginx_sites_enabled_cleanup: true
+nginx_sites_enabled_templates: []
 
 # Fastcgi cache params
 nginx_cache_path: /var/cache/nginx

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -55,3 +55,36 @@
   args:
     creates: "{{ nginx_path }}/sites-enabled/no-default.conf"
   notify: reload nginx
+  tags: nginx-sites
+  when: nginx_default_site_enabled
+
+- name: Disable better default site
+  file:
+    path: "{{ nginx_path }}/sites-enabled/no-default.conf"
+    state: absent
+  notify: reload nginx
+  tags: nginx-sites
+  when: not nginx_default_site_enabled
+
+- name: Create sites-enabled/extras directory
+  file:
+    mode: 0755
+    path: "{{ nginx_path }}/sites-enabled/extras"
+    state: directory
+  tags: nginx-sites
+
+- name: Remove nginx extra enabled sites
+  file:
+    state: absent
+    path: "{{ nginx_path }}/sites-enabled/extras/"
+  notify: reload nginx
+  tags: nginx-sites
+  when: nginx_sites_enabled_cleanup
+
+- name: Create Nginx extra enabled sites
+  template:
+    src: "{{ item }}"
+    dest: "{{ nginx_path }}/sites-enabled/extras/{{ item | basename | regex_replace('.j2$', '') }}"
+  with_items: "{{ nginx_sites_enabled_templates }}"
+  notify: reload nginx
+  tags: nginx-sites

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -74,9 +74,9 @@
   tags: nginx-sites
 
 - name: Remove Nginx extra enabled sites
-  file:
-    state: absent
-    path: "{{ nginx_path }}/sites-enabled/extras/"
+  command: rm -f {{ nginx_path }}/sites-enabled/extras/*
+  args:
+    warn: false
   notify: reload nginx
   tags: nginx-sites
   when: nginx_sites_enabled_cleanup

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -73,7 +73,7 @@
     state: directory
   tags: nginx-sites
 
-- name: Remove nginx extra enabled sites
+- name: Remove Nginx extra enabled sites
   file:
     state: absent
     path: "{{ nginx_path }}/sites-enabled/extras/"

--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -169,6 +169,7 @@ http {
   {% endblock %}
 
   {% block sites_enabled -%}
-  include sites-enabled/*;
+  include sites-enabled/*.conf;
+  include sites-enabled/extras/*.conf;
   {% endblock %}
 }


### PR DESCRIPTION
closes #786 

Add a `nginx_sites_enabled_templates` array
to allow users to specify custom files to be templated to the server
sites-enabled/extras folder, that are automatically included by nginx.
Default empty.

Add a `nginx_sites_enabled_cleanup` boolean variable that enforces
removing all files in sites-enabled/extras before copying new ones.
Default true.

Add a `nginx_default_site_enabled` boolean variable,
which defines whether to enable or disable trellis' default site
configuration.
Default true.

Add `nginx-sites` playbook tag.