### PR TITLE
Add additional nginx sites configurations support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Add additional Nginx sites configurations support ([#793](https://github.com/roots/trellis/pull/793))
 * Change `remote-user` role to `connection` role: tests host key, user ([#745](https://github.com/roots/trellis/pull/745))
 * Allow customization of PHP extensions ([#787](https://github.com/roots/trellis/pull/787))
 * Allow for per-project packagist.com authentication ([#762](https://github.com/roots/trellis/pull/762))

--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -5,6 +5,8 @@ nginx_logs_root: /var/log/nginx
 nginx_user: www-data
 nginx_fastcgi_buffers: 8 8k
 nginx_fastcgi_buffer_size: 8k
+nginx_sites_confs:
+  - src: no-default.conf.j2
 
 # Fastcgi cache params
 nginx_cache_path: /var/cache/nginx

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -50,8 +50,20 @@
     state: absent
   notify: reload nginx
 
-- name: Enable better default site to drop unknown requests
-  command: cp {{ nginx_path }}/h5bp-server-configs/sites-available/no-default {{ nginx_path }}/sites-enabled/no-default.conf
-  args:
-    creates: "{{ nginx_path }}/sites-enabled/no-default.conf"
+- name: Create Nginx available sites
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ nginx_path }}/sites-available/{{ item.src | basename | regex_replace('.j2$', '') }}"
+  with_items: "{{ nginx_sites_confs }}"
+  when: item.enabled | default(true)
+  tags: nginx-sites
+
+- name: Enable or disable Nginx sites
+  file:
+    path: "{{ nginx_path }}/sites-enabled/{{ item.src | basename | regex_replace('.j2$', '') }}"
+    src: "{{ nginx_path }}/sites-available/{{ item.src | basename | regex_replace('.j2$', '') }}"
+    state: "{{ item.enabled | default(true) | ternary('link', 'absent') }}"
+    force: yes
+  with_items: "{{ nginx_sites_confs }}"
   notify: reload nginx
+  tags: nginx-sites

--- a/roles/nginx/templates/no-default.conf.j2
+++ b/roles/nginx/templates/no-default.conf.j2
@@ -1,0 +1,13 @@
+# {{ ansible_managed }}
+
+# Drop requests for unknown hosts
+#
+# If no default server is defined, nginx will use the first found server.
+# To prevent host header attacks, or other potential problems when an unknown
+# servername is used in a request, it's recommended to drop the request
+# returning 444 "no response".
+
+server {
+  listen 80 default_server;
+  return 444;
+}


### PR DESCRIPTION
closes #786

Add a nginx_sites_conf array
to allow users to specify custom nginx confs to be templated to the server's
nginx/sites-available folder, that are then symlinked to nginx/sites-enabled.
Array element properties:
  - src: jinja template path
  - enabled: whether to enable / disable the site conf 
by symlinking it to nginx/sites-enabled / removing it (default true)

Default:
```
nginx_sites_confs:
  - src: no-default.conf.j2
```

Add nginx-sites playbook tag.