### PR TITLE
Create includes.d even if nginx-includes has no subdirs

### DIFF
--- a/roles/wordpress-setup/tasks/nginx-includes.yml
+++ b/roles/wordpress-setup/tasks/nginx-includes.yml
@@ -22,8 +22,9 @@
     mode: 0755
   with_items: "{{ nginx_includes_templates.files | map(attribute='path') |
                   map('regex_replace', nginx_includes_pattern, '\\2') |
-                  map('dirname') | unique | select | list | sort
+                  map('dirname') | unique | list | sort
                }}"
+  when: nginx_includes_templates.files | count
 
 - name: Template files out to includes.d
   template:


### PR DESCRIPTION
**The problem**

Fixes a problem that occurs if `nginx-includes` has templates only in the directory root, not in subdirectories. The "Create includes.d directories" task skips, then a failure occurs: `Destination directory /etc/nginx/includes.d does not exist`.

```
TASK [wordpress-setup : Create includes.d directories] *************************

TASK [wordpress-setup : Template files out to includes.d] **********************
System info:
  Ansible 2.2.1.0; Darwin
  Trellis at "Change `remote-user` role to `connection` role: tests host key, user"
---------------------------------------------------
Destination directory /etc/nginx/includes.d does not exist
failed: [test] (item=nginx-includes/some-site.conf.j2) => {"changed": true, "failed": true, "item": "nginx-includes/some-site.conf.j2"}
```

**Explanation**

Examining the relevant `with_items`, the `dirname` filter retrieves a template's subdirectory (within `nginx-includes`), then the `select` filter removed empty values created by templates in the `nginx-includes` root. I originally used the `select` filter to make the task to skip if nginx-includes was empty.

**Solution**

This PR removes the select filter so that `includes.d` will still be created if the only templates are in the `nginx-includes` root. The PR adds a `when` condition to make the task skip if `nginx-includes` is empty.

**Background**

Apparently I never tested an `nginx-includes` without subdirectories, probably because normal nginx-includes need to be in subdirs by site name, and child template tests used the `*.child` extension that didn't match the requirements for being templated to `includes.d`. I _do_ think Trellis should enable templating confs that aren't part of sitename subdirs so people's child templates have the option of `include` statements pointing to these extra includes that aren't part of the default nginx-includes.

