### PR TITLE
Run WordPress installed check before finalizing deploy

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -18,6 +18,7 @@
   vars:
     deploy_build_before: "{{ playbook_dir }}/deploy-hooks/build-before.yml"
     deploy_build_after: "{{ playbook_dir }}/roles/deploy/hooks/build-after.yml"
+    deploy_finalize_before: "{{ playbook_dir }}/roles/deploy/hooks/finalize-before.yml"
     deploy_finalize_after: "{{ playbook_dir }}/roles/deploy/hooks/finalize-after.yml"
     project: "{{ wordpress_sites[site] }}"
     project_root: "{{ www_root }}/{{ site }}"

--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -1,17 +1,4 @@
 ---
-- name: Create file with multisite constants defined as false
-  copy:
-    src: "tmp_multisite_constants.php"
-    dest: "{{ deploy_helper.shared_path }}/tmp_multisite_constants.php"
-
-- name: WordPress Installed?
-  command: wp core is-installed --require={{ deploy_helper.shared_path }}/tmp_multisite_constants.php
-  args:
-    chdir: "{{ deploy_helper.current_path }}"
-  register: wp_installed
-  changed_when: false
-  failed_when: wp_installed.stderr != ""
-
 - block:
   - name: Update WP database
     command: wp core update-db

--- a/roles/deploy/hooks/finalize-before.yml
+++ b/roles/deploy/hooks/finalize-before.yml
@@ -1,0 +1,13 @@
+---
+- name: Create file with multisite constants defined as false
+  copy:
+    src: "tmp_multisite_constants.php"
+    dest: "{{ deploy_helper.shared_path }}/tmp_multisite_constants.php"
+
+- name: WordPress Installed?
+  command: wp core is-installed --require={{ deploy_helper.shared_path }}/tmp_multisite_constants.php
+  args:
+    chdir: "{{ deploy_helper.new_release_path }}"
+  register: wp_installed
+  changed_when: false
+  failed_when: wp_installed.stderr != ""


### PR DESCRIPTION
The "WordPress installed?" deploy task occasionally detects
errors. It would be helpful to detect such errors and fail before
finalizing the deploy (before creating symlink to release dir).

This PR moves the two tasks related to "WordPress installed?"
from `finalize-after.yml` to a new `finalize-before.yml`, with one change:
```diff
- chdir: "{{ deploy_helper.current_path }}"
+ chdir: "{{ deploy_helper.new_release_path }}"
```

```
# Deploy steps

initialize.yml

update.yml

prepare.yml

build.yml

share.yml
                <-- tasks now here, in finalize-before.yml
finalize.yml
                <-- tasks formerly here, in finalize-after.yml
```

**Edit.** Moved the two new tasks from `build-after.yml` to a new `finalize-before.yml`.

