### PR TITLE
Check Ansible version before Ansible validates task attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Check Ansible version before Ansible validates task attributes ([#797](https://github.com/roots/trellis/pull/797))
 * Add additional Nginx sites configurations support ([#793](https://github.com/roots/trellis/pull/793))
 * Change `remote-user` role to `connection` role: tests host key, user ([#745](https://github.com/roots/trellis/pull/745))
 * Allow customization of PHP extensions ([#787](https://github.com/roots/trellis/pull/787))

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,6 +16,7 @@ ENV['ANSIBLE_CALLBACK_PLUGINS'] = "~/.ansible/plugins/callback_plugins/:/usr/sha
 ENV['ANSIBLE_FILTER_PLUGINS'] = "~/.ansible/plugins/filter_plugins/:/usr/share/ansible_plugins/filter_plugins:#{File.join(ANSIBLE_PATH, 'lib/trellis/plugins/filter')}"
 ENV['ANSIBLE_LIBRARY'] = "/usr/share/ansible:#{File.join(ANSIBLE_PATH, 'lib/trellis/modules')}"
 ENV['ANSIBLE_ROLES_PATH'] = File.join(ANSIBLE_PATH, 'vendor', 'roles')
+ENV['ANSIBLE_VARS_PLUGINS'] = "~/.ansible/plugins/vars_plugins/:/usr/share/ansible_plugins/vars_plugins:#{File.join(ANSIBLE_PATH, 'lib/trellis/plugins/vars')}"
 
 config_file = File.join(ANSIBLE_PATH, 'group_vars', 'development', 'wordpress_sites.yml')
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -7,6 +7,7 @@ force_handlers = True
 inventory = hosts
 nocows = 1
 roles_path = vendor/roles
+vars_plugins = ~/.ansible/plugins/vars_plugins/:/usr/share/ansible_plugins/vars_plugins:lib/trellis/plugins/vars
 
 [ssh_connection]
 ssh_args = -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s -o HostKeyAlgorithms=ssh-ed25519-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ssh-ed25519,ssh-rsa

--- a/lib/trellis/plugins/callback/output.py
+++ b/lib/trellis/plugins/callback/output.py
@@ -5,12 +5,6 @@ __metaclass__ = type
 import os.path
 import sys
 
-from ansible import __version__
-from ansible.errors import AnsibleError
-
-if __version__.startswith('1'):
-    raise AnsibleError('Trellis no longer supports Ansible 1.x. Please upgrade to Ansible 2.x.')
-
 from ansible.plugins.callback.default import CallbackModule as CallbackModule_default
 
 try:

--- a/lib/trellis/plugins/vars/version.py
+++ b/lib/trellis/plugins/vars/version.py
@@ -1,0 +1,20 @@
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible import __version__
+from ansible.errors import AnsibleError
+from distutils.version import LooseVersion
+from operator import ge
+
+version_requirement = '2.2.0.0'
+if not ge(LooseVersion(__version__), LooseVersion(version_requirement)):
+    raise AnsibleError(('Trellis no longer supports Ansible {}.\n'
+        'Please upgrade to Ansible {} or higher.').format(__version__, version_requirement))
+
+
+class VarsModule(object):
+    ''' Creates and modifies host variables '''
+
+    def __init__(self, inventory):
+        pass

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,7 +1,3 @@
-ansible_requirements:
-  - version: 2.2.0.0
-    operator: '>='
-
 ntp_timezone: Etc/UTC
 
 apt_packages_default:

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,15 +1,4 @@
 ---
-- name: Validate Ansible version
-  fail:
-    msg: |
-      Your Ansible version is {{ ansible_version.full | default('unknown') }}.
-      Please install a version of Ansible that meets these requirements:
-      {% for item in ansible_requirements %}
-        {{ item.operator }} {{ item.version }}
-      {% endfor %}
-  when: ansible_version is not defined or false in [{% for item in ansible_requirements %}{{ ansible_version.full | version_compare(item.version, item.operator) }},{% endfor %}]
-  run_once: true
-
 - name: Validate format of site_hosts
   fail:
     msg: "{{ lookup('template', 'site_hosts.j2') }}"


### PR DESCRIPTION
Avoids `ERROR! 'check_mode' is not a valid attribute for a Task` for Ansible < 2.2 ([example](https://discourse.roots.io/t/error-check-mode-is-not-a-valid-attribute-for-a-task/8984)).

The challenge is that Ansible validates task attributes before running a playbook, before the [current version check](https://github.com/roots/trellis/blob/acfb5fd78df73977b735f0021736f0f8fd8f5401/roles/common/tasks/main.yml#L2-L11) can run, and even before the [callback plugin](https://github.com/roots/trellis/blob/acfb5fd78df73977b735f0021736f0f8fd8f5401/lib/trellis/plugins/callback/output.py#L11-L12) is processed.

A vars plugin will load before Ansible validates task attributes, so it appeared to be the only option for performing a version check and helpful "please upgrade" message.

This PR adds back a vars plugin as a bit of a hack for the sake of the Ansible version check. Trellis formerly had a vars plugin (removed in #684 and #707).
**Edit:** Modeled after Ansible's [`version_compare`](https://github.com/ansible/ansible/blob/0c449598009fb440e150e9578ab3a18958cfca41/lib/ansible/plugins/test/core.py#L112-L113) test.