### PR TITLE
Added home_root to group_vars/main with /home/ as default

### DIFF
--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -5,7 +5,6 @@ apt_cache_valid_time: 3600
 ntp_timezone: Etc/UTC
 ntp_manage_config: true
 www_root: /srv/www
-home_root: /home/
 ip_whitelist:
   - "{{ (env == 'development') | ternary(ansible_default_ipv4.gateway, ipify_public_ip | default('')) }}"
 

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -5,6 +5,7 @@ apt_cache_valid_time: 3600
 ntp_timezone: Etc/UTC
 ntp_manage_config: true
 www_root: /srv/www
+home_root: /home/
 ip_whitelist:
   - "{{ (env == 'development') | ternary(ansible_default_ipv4.gateway, ipify_public_ip | default('')) }}"
 

--- a/roles/deploy/tasks/update.yml
+++ b/roles/deploy/tasks/update.yml
@@ -6,7 +6,7 @@
   known_hosts:
     name: "{{ item.name }}"
     key: "{{ item.key | default(omit) }}"
-    path: "{{ item.path | default(home_root + ansible_user + '/.ssh/known_hosts') }}"
+    path: "{{ item.path | default(omit) }}"
     state: "{{ item.state | default('present') }}"
   with_items: "{{ known_hosts | default([]) }}"
 

--- a/roles/deploy/tasks/update.yml
+++ b/roles/deploy/tasks/update.yml
@@ -6,7 +6,7 @@
   known_hosts:
     name: "{{ item.name }}"
     key: "{{ item.key | default(omit) }}"
-    path: "{{ item.path | default('/home/' + ansible_user + '/.ssh/known_hosts') }}"
+    path: "{{ item.path | default(home_root + ansible_user + '/.ssh/known_hosts') }}"
     state: "{{ item.state | default('present') }}"
   with_items: "{{ known_hosts | default([]) }}"
 

--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -20,7 +20,7 @@
   known_hosts:
     name: "{{ item.name }}"
     key: "{{ item.key | default(omit) }}"
-    path: "{{ item.path | default('/home/' + ansible_user + '/.ssh/known_hosts') }}"
+    path: "{{ item.path | default(home_root + ansible_user + '/.ssh/known_hosts') }}"
     state: "{{ item.state | default('present') }}"
   with_items: "{{ known_hosts | default([]) }}"
 

--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -20,8 +20,9 @@
   known_hosts:
     name: "{{ item.name }}"
     key: "{{ item.key | default(omit) }}"
-    path: "{{ item.path | default(home_root + ansible_user + '/.ssh/known_hosts') }}"
+    path: "{{ item.path | default(omit) }}"
     state: "{{ item.state | default('present') }}"
+  become: no
   with_items: "{{ known_hosts | default([]) }}"
 
 - name: Setup packagist.com authentication


### PR DESCRIPTION
Fixes problem when deploying to servers not provisioned with Trellis. I run a mix of sites on the same Trellis box. Some servers I deploy to use different users than Trellis default. 

When a server has a different directory for /home/ this causes problems when Ansible wants to modify `known_hosts` as in latest version of Trellis. 

For example one server uses `/mnt/persist/home/` and that gave me the problem discussed here https://discourse.roots.io/t/failed-to-connect-to-the-host-via-ssh-openssh-6-2p2-osslshim-0-9-8r-8-dec-2011-command-line-line-0-bad-protocol-2-host-key-algorithms-ssh-ed25519-cert-v01-openssh-com-ssh-rsa-cert-v01-openssh-com-ssh-ed25519-ssh-rsa/9142/5?u=stefanlindberg

I suggest adding a variable to `group_vars` called home_root (similar to web_root) that can be overwritted on a per site basis with `host_vars`. 

The default is `/home/` which so out of the box it works as before. 