### PR TITLE
Don't load plugins when running `wp core is-installed`

### DIFF
--- a/roles/deploy/files/tmp_multisite_constants.php
+++ b/roles/deploy/files/tmp_multisite_constants.php
@@ -2,3 +2,6 @@
 error_reporting(E_ALL & ~E_NOTICE);
 define('MULTISITE', false);
 define('SUBDOMAIN_INSTALL', false);
+define('WPMU_PLUGIN_DIR', null);
+define('WP_PLUGIN_DIR', null);
+define('WP_USE_THEMES', false);

--- a/roles/deploy/hooks/finalize-before.yml
+++ b/roles/deploy/hooks/finalize-before.yml
@@ -5,7 +5,7 @@
     dest: "{{ deploy_helper.shared_path }}/tmp_multisite_constants.php"
 
 - name: WordPress Installed?
-  command: wp core is-installed --require={{ deploy_helper.shared_path }}/tmp_multisite_constants.php
+  command: wp core is-installed --skip-plugins --skip-themes --require={{ deploy_helper.shared_path }}/tmp_multisite_constants.php
   args:
     chdir: "{{ deploy_helper.new_release_path }}"
   register: wp_installed


### PR DESCRIPTION
Certain plugins return early or die() if they're activated but the site isn't multisite. To resolve this, we can use `--skip-plugins`, but that doesn't unload mu-plugins. To address the latter, we can `define('WPMU_PLUGIN_DIR', null)`, which causes WordPress to not load any mu-plugins. Since some themes rely on mu-plugins, we can use `define('WP_USE_THEMES', false)` to minimize the number of theme-related events that are fired. But since that doesn't fully prevent the theme from being loaded, we also use `--skip-themes`. All of this combined should hopefully minimize the amount of WordPress that gets loaded to the point where we don't have any fatal errors arising from forcing a multisite installation to be loaded as non-multisite.

We think this should work for _**most**_ situations.

Another solution we've come up with is using a shell script to sniff out the error message returned by wp-cli when it's supposed to be multisite setup but WordPress isn't installed, something like this:

```yaml
- name: WordPress Installed?
  shell: |
    WP_INSTALLED=$(wp core is-installed {{ project.multisite.enabled | default(false) | ternary('--network', '') }} 2>&1)
    [ -z "${WP_INSTALLED}" ] && exit 0
    if [[ ! $WP_INSTALLED =~ "WordPress database error Table '{{ site_env.db_name }}.wp_blogs' doesn't exist" ]]; then
      echo $WP_INSTALLED 1>&2
    fi
    exit 1
  args:
    chdir: "{{ deploy_helper.current_path }}"
    executable: /bin/bash
  register: wp_installed
  changed_when: false
  failed_when: wp_installed.stderr != ""
```

But that will also fail if the error message is in a different language (not sure if wp-cli translates its error messages) or if the database prefix isn't `wp_`. So if we go this other route, it would also come with some potential pitfalls.

Input from the community is welcome.