### PR TITLE
Fix nginx_includes_d_cleanup variable

### DIFF
--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -7,6 +7,7 @@ ntp_manage_config: true
 www_root: /srv/www
 ip_whitelist:
   - "{{ (env == 'development') | ternary(ansible_default_ipv4.gateway, ipify_public_ip | default('')) }}"
+nginx_includes_d_cleanup: true
 
 # Values of raw_vars will be wrapped in `{% raw %}` to avoid templating problems if values include `{%` and `{{`.
 # Will recurse dicts/lists. `*` is wildcard for one or more dict keys, list indices, or strings. Example:

--- a/roles/wordpress-setup/defaults/main.yml
+++ b/roles/wordpress-setup/defaults/main.yml
@@ -21,4 +21,3 @@ nginx_skip_cache_cookie: comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpres
 nginx_includes_templates_path: nginx-includes
 nginx_includes_deprecated: roles/wordpress-setup/templates/includes.d
 nginx_includes_pattern: "^({{ nginx_includes_templates_path | regex_escape }}|{{ nginx_includes_deprecated | regex_escape }})/(.*)\\.j2$"
-nginx_includes_d_cleanup: true


### PR DESCRIPTION
Move nginx_includes_d_cleanup variable to group_vars instead of wordpress-setup defaults, otherwise it is not taken into account