### PR TITLE
Fix nginx server name wildcard entry in multisite subdomain installs

### DIFF
--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -5,7 +5,7 @@
 server {
   {% block server_id -%}
   listen {{ ssl_enabled | ternary('443 ssl http2', '80') }};
-  server_name  {% for host in site_hosts_canonical %}{{ host }} {% if item.value.multisite.subdomains | default(false) %}*.{{ host }} {% endif %}{% endfor %};
+  server_name  {% for host in site_hosts_canonical %}{{ host }}{% endfor %} {% if item.value.multisite.subdomains | default(false) %}*.{{ item.value.env.domain_current_site }} {% endif %};
   {% endblock %}
 
   {% block logs -%}

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -157,7 +157,7 @@ server {
 # Redirect to https
 server {
   listen 80;
-  server_name {{ site_hosts | join(' ') }}{% if item.value.multisite.subdomains | default(false) %} *.{{ site_hosts_canonical | join(' *.') }}{% endif %};
+  server_name {{ site_hosts | join(' ') }}{% if item.value.multisite.subdomains | default(false) %} *.{{ item.value.env.domain_current_site }}{% endif %};
 
   {{ self.acme_challenge() -}}
 


### PR DESCRIPTION
fixes #806 

Use `domain_current_site` host variable instead of `canonical` variable