### PR TITLE
Ansible 2.2.2 compatibility

### DIFF
--- a/roles/deploy/tasks/prepare.yml
+++ b/roles/deploy/tasks/prepare.yml
@@ -16,7 +16,7 @@
 - name: Fail if repo_subtree_path is set incorrectly
   fail:
     msg: "repo subtree is set to '{{ project.repo_subtree_path }}' but that path does not exist in the repo. Edit `repo_subtree_path` for '{{ site }}' in `wordpress_sites.yml`."
-  when: project_subtree_full_path is defined and not project_subtree_full_path.stat.exists
+  when: project.repo_subtree_path is defined and not project_subtree_full_path.stat.exists
 
 - name: Create new release dir
   file:


### PR DESCRIPTION
Fixes https://discourse.roots.io/t/deploy-fail-if-repo-subtree-path-is-set-incorrectly/9235

Prior to Ansible 2.2.2, a registered var from a non-looping skipped
task was undefined. As of Ansible 2.2.2, such a var is defined.
This commit changes a subsequent task's conditional to no longer rely
on the registered var's inconsistent status as defined/undefined.

I found no other instances of this type of problem, nor of any other Ansible 2.2.2 incompatibility.