### PR TITLE
Remove unused registered var generate_account_key

### DIFF
--- a/roles/letsencrypt/tasks/setup.yml
+++ b/roles/letsencrypt/tasks/setup.yml
@@ -36,7 +36,6 @@
   shell: openssl genrsa 4096 > {{ letsencrypt_account_key }}
   args:
     creates: "{{ letsencrypt_account_key }}"
-  register: generate_account_key
   when: letsencrypt_account_key_source_content is not defined and letsencrypt_account_key_source_file is not defined
 
 - name: Download intermediate certificate


### PR DESCRIPTION
The registered var `generate_account_key ` is [not used](https://github.com/roots/trellis/search?utf8=%E2%9C%93&q=generate_account_key&type=). It appears to be an unused leftover from the [original role](https://github.com/andreaswolf/ansible-role-letsencrypt/blob/0e292997640c8bd002e6abed3b727a6b473c2b79/tasks/main.yml#L91-L106).