### PR TITLE
Add self signed certificates subdomains

### DIFF
--- a/group_vars/all/helpers.yml
+++ b/group_vars/all/helpers.yml
@@ -13,4 +13,5 @@ site_env: "{{ wordpress_env_defaults | combine(item.value.env | default({}), vau
 site_hosts_canonical: "{{ item.value.site_hosts | map(attribute='canonical') | list }}"
 site_hosts_redirects: "{{ item.value.site_hosts | selectattr('redirects', 'defined') | sum(attribute='redirects', start=[]) | list }}"
 site_hosts: "{{ site_hosts_canonical | union(site_hosts_redirects) }}"
+multisite_subdomains_wildcards: "{{ item.value.multisite.subdomains | default(false) | ternary( site_hosts_canonical | map('regex_replace', '^(www\\.)?(.*)$', '*.\\2') | list, [] ) }}"
 ssl_enabled: "{{ item.value.ssl is defined and item.value.ssl.enabled | default(false) }}"

--- a/roles/wordpress-setup/tasks/self-signed-certificate.yml
+++ b/roles/wordpress-setup/tasks/self-signed-certificate.yml
@@ -14,7 +14,7 @@ EOF\n
     -keyout {{ item.key | quote }}.key -out {{ item.key | quote }}.cert"
   args:
     executable: "/bin/bash"
-    chdir: "{{ nginx_path }}/ssl"
+    chdir: "{{ nginx_ssl_path }}"
     creates: "{{ item.key }}.*"
   with_dict: "{{ wordpress_sites }}"
   when: ssl_enabled and item.value.ssl.provider | default('manual') == 'self-signed'

--- a/roles/wordpress-setup/tasks/self-signed-certificate.yml
+++ b/roles/wordpress-setup/tasks/self-signed-certificate.yml
@@ -1,10 +1,19 @@
 ---
 - name: Generate self-signed certificates
-  shell: >
-    openssl req -subj "/CN={{ item.value.site_hosts[0].canonical }}" -new
-    -newkey rsa:2048 -days 3650 -nodes -x509 -sha256
-    -keyout {{ item.key }}.key -out {{ item.key }}.cert
+  shell: "openssl req -subj \"/CN={{ item.value.site_hosts[0].canonical }}\" -new \
+    -newkey rsa:2048 -days 3650 -nodes -x509 -sha256 \
+    -extensions req_ext -config <( \
+cat <<\" EOF\"\n
+[req]\n
+distinguished_name = dn\n
+[ dn ]\n
+[ req_ext ]\n
+subjectAltName = {{ site_hosts | union(multisite_subdomains_wildcards) | map('regex_replace', '(.*)', 'DNS:\\1') | join(',') }}\n
+EOF\n
+    ) \
+    -keyout {{ item.key | quote }}.key -out {{ item.key | quote }}.cert"
   args:
+    executable: "/bin/bash"
     chdir: "{{ nginx_path }}/ssl"
     creates: "{{ item.key }}.*"
   with_dict: "{{ wordpress_sites }}"

--- a/roles/wordpress-setup/tasks/self-signed-certificate.yml
+++ b/roles/wordpress-setup/tasks/self-signed-certificate.yml
@@ -1,13 +1,15 @@
 ---
 - name: Generate self-signed certificates
-  shell: "openssl req -subj \"/CN={{ item.value.site_hosts[0].canonical }}\" -new \
-    -newkey rsa:2048 -days 3650 -nodes -x509 -sha256 \
+  shell: "openssl req -new -newkey rsa:2048 \
+    -days 3650 -nodes -x509 -sha256 \
     -extensions req_ext -config <( \
-cat <<\" EOF\"\n
+cat <<' EOF'\n
 [req]\n
-distinguished_name = dn\n
-[ dn ]\n
-[ req_ext ]\n
+prompt = no\n
+distinguished_name = req_dn\n
+[req_dn]\n
+commonName = {{ item.value.site_hosts[0].canonical }}\n
+[req_ext]\n
 subjectAltName = {{ site_hosts | union(multisite_subdomains_wildcards) | map('regex_replace', '(.*)', 'DNS:\\1') | join(',') }}\n
 EOF\n
     ) \

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -5,7 +5,7 @@
 server {
   {% block server_id -%}
   listen {{ ssl_enabled | ternary('443 ssl http2', '80') }};
-  server_name {{ site_hosts_canonical | join(' ') }}{% if item.value.multisite.subdomains | default(false) %} *.{{ site_hosts_canonical | map('regex_replace', '^www\.', '') | join(' *.') }}{% endif %};
+  server_name {{ site_hosts_canonical | union(multisite_subdomains_wildcards) | join(' ') }};
   {% endblock %}
 
   {% block logs -%}
@@ -45,7 +45,7 @@ server {
 
   {% endif -%}
   {% endblock -%}
-  
+
   {% block multisite_rewrites -%}
   {% if item.value.multisite.enabled | default(false) -%}
   # Multisite rewrites
@@ -157,7 +157,7 @@ server {
 # Redirect to https
 server {
   listen 80;
-  server_name {{ site_hosts | join(' ') }}{% if item.value.multisite.subdomains | default(false) %} *.{{ site_hosts_canonical | map('regex_replace', '^www\.', '') | join(' *.') }}{% endif %};
+  server_name {{ site_hosts | union(multisite_subdomains_wildcards) | join(' ') }};
 
   {{ self.acme_challenge() -}}
 


### PR DESCRIPTION
closes #809 

Add support for all alternate hosts and subdomains in self-signed certificates
The `subjectAltName` certificate field now contains the DNS entries of all canonical and redirect hosts of a site, along with all wildcard domain names (for a site with multisite and subdomains enabled).

Add `multisite_subdomains_wildcards` helper variable
Replace server_name expression in wordpress sites template by `multisite_subdomains_wildcards` helper variable for clearer code