### PR TITLE
Ansible 2.3 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Ansible 2.3 compatibility ([#813](https://github.com/roots/trellis/pull/813))
 * Remove potentially dangerous `db_import` option ([#825](https://github.com/roots/trellis/pull/825))
 
 ### 1.0.0-rc.1: April 7th, 2017

--- a/roles/connection/tasks/main.yml
+++ b/roles/connection/tasks/main.yml
@@ -52,7 +52,7 @@
 - block:
   - name: Set remote user for each host
     set_fact:
-      ansible_user: "{{ ansible_user | default(('root' in connection_status.stdout_lines) | ternary('root', admin_user)) }}"
+      ansible_user: "{{ ansible_user | default((connection_status.stdout_lines | intersect(['root', '\e[0;32mroot']) | count) | ternary('root', admin_user)) }}"
     check_mode: no
 
   - name: Announce which user was selected

--- a/roles/letsencrypt/defaults/main.yml
+++ b/roles/letsencrypt/defaults/main.yml
@@ -1,7 +1,6 @@
 sites_using_letsencrypt: "[{% for name, site in wordpress_sites.iteritems() if site.ssl.enabled and site.ssl.provider | default('manual') == 'letsencrypt' %}'{{ name }}',{% endfor %}]"
-letsencrypt_enabled: "{{ sites_using_letsencrypt | count }}"
-site_uses_letsencrypt: "{{ ssl_enabled and item.value.ssl.provider | default('manual') == 'letsencrypt' }}"
-missing_hosts: "{{ site_uses_letsencrypt | ternary(site_hosts, []) | difference((current_hosts.results | selectattr('item.key', 'equalto', item.key) | selectattr('stdout_lines', 'defined') | sum(attribute='stdout_lines', start=[]) | map('trim') | list | join(' ')).split(' ')) }}"
+site_uses_letsencrypt: ssl_enabled and item.value.ssl.provider | default('manual') == 'letsencrypt'
+missing_hosts: "{{ site_hosts | difference((current_hosts.results | selectattr('item.key', 'equalto', item.key) | selectattr('stdout_lines', 'defined') | sum(attribute='stdout_lines', start=[]) | map('trim') | list | join(' ')).split(' ')) }}"
 letsencrypt_cert_ids: "{ {% for item in (generate_cert_ids | default({'results':[{'skipped':True}]})).results if not item | skipped %}'{{ item.item.key }}':'{{ item.stdout }}', {% endfor %} }"
 
 acme_tiny_repo: 'https://github.com/diafygi/acme-tiny.git'

--- a/roles/letsencrypt/tasks/nginx.yml
+++ b/roles/letsencrypt/tasks/nginx.yml
@@ -18,7 +18,9 @@
     src: nginx-challenge-site.conf.j2
     dest: "{{ nginx_path }}/sites-available/letsencrypt-{{ item.key }}.conf"
   register: challenge_site_confs
-  when: missing_hosts | count
+  when:
+    - site_uses_letsencrypt
+    - missing_hosts | count
   with_dict: "{{ wordpress_sites }}"
 
 - name: Enable Nginx sites
@@ -27,7 +29,9 @@
     dest: "{{ nginx_path }}/sites-enabled/letsencrypt-{{ item.key }}.conf"
     state: link
   register: challenge_sites_enabled
-  when: missing_hosts | count
+  when:
+    - site_uses_letsencrypt
+    - missing_hosts | count
   with_dict: "{{ wordpress_sites }}"
   notify: disable temporary challenge sites
 

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -21,7 +21,7 @@
   args:
     chdir: "{{ nginx_path }}/ssl"
     creates: "{{ nginx_path }}/ssl/dhparams.pem"
-  when: true in [{% for key, site in wordpress_sites.iteritems() %}{{ site.ssl.enabled }},{% endfor %}]
+  when: wordpress_sites.values() | map(attribute='ssl') | selectattr('enabled') | list | count
   notify: reload nginx
   tags: [diffie-hellman]
 

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -33,7 +33,7 @@
     name: "{{ item.name }}"
     group: "{{ item.groups[0] }}"
     groups: "{{ item.groups | join(',') }}"
-    password: '{% for user in vault_users | default([]) if user.name == item.name and user.password is defined %}{{ user.password | password_hash("sha512", user.salt | default("") | truncate(16, true, "") | regex_replace("[^\.\/a-zA-Z0-9]", "x")) }}{% else %}{{ None }}{% endfor %}'
+    password: '{% for user in vault_users | default([]) if user.name == item.name and user.password is defined %}{{ user.password | password_hash("sha512", (user.salt | default(""))[:16] | regex_replace("[^\.\/a-zA-Z0-9]", "x")) }}{% else %}{{ None }}{% endfor %}'
     state: present
     shell: /bin/bash
     update_password: always

--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -14,7 +14,7 @@
   command: rsync -ac --info=NAME /tmp/{{ item.key }}.env {{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/.env
   with_dict: "{{ wordpress_sites }}"
   register: env_file
-  changed_when: env_file.stdout == "{{ item.key }}.env"
+  changed_when: env_file.stdout == item.key + '.env'
 
 - name: Add known_hosts
   known_hosts:

--- a/roles/wp-cli/tasks/main.yml
+++ b/roles/wp-cli/tasks/main.yml
@@ -9,7 +9,7 @@
   args:
     warn: false
   register: wp_cli
-  changed_when: wp_cli.stdout == "wp-cli{{ wp_cli_version }}.phar"
+  changed_when: wp_cli.stdout == 'wp-cli-' + wp_cli_version + '.phar'
 
 - name: Retrieve WP-CLI tab completions
   command: curl -4Ls {{ wp_cli_completion_url }} -o /tmp/wp-completion-{{ wp_cli_version }}.bash
@@ -22,4 +22,4 @@
   args:
     warn: false
   register: wp_cli_completion
-  changed_when: wp_cli_completion.stdout == "wp-completion-{{ wp_cli_version }}.bash"
+  changed_when: wp_cli_completion.stdout == 'wp-completion-' + wp_cli_version + '.bash'

--- a/server.yml
+++ b/server.yml
@@ -38,5 +38,5 @@
     - { role: logrotate, tags: [logrotate] }
     - { role: composer, tags: [composer] }
     - { role: wp-cli, tags: [wp-cli] }
-    - { role: letsencrypt, tags: [letsencrypt], when: letsencrypt_enabled }
+    - { role: letsencrypt, tags: [letsencrypt], when: sites_using_letsencrypt | count }
     - { role: wordpress-setup, tags: [wordpress, wordpress-setup, letsencrypt] }


### PR DESCRIPTION
Broken out into separate commits, each with a commit message explaining. One commit prevents Ansible's new [`dense.py`](https://github.com/ansible/ansible/blob/v2.3.0.0-0.2.rc2/lib/ansible/plugins/callback/dense.py#L89) callback from causing Trellis ssh connection tests to always show `root` as failing to connect. The other commits just prevent Ansible's [new warning message](https://github.com/ansible/ansible/commit/ff20ab7d4439ad6e5ca099c428ac6d3f25a154e7) about jinja delimiters.

```
[WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}.
```

----

The commit `Avoid single var containing jinja delimiters in when parameter` deserves some explanation but don't expect this explanation to stand on its own without examining the commit's diff.

Consider a `when` parameter with  a single var, e.g., [`when: site_uses_letsencrypt`](https://github.com/roots/trellis/blob/41b7f641d650af26d51800943045b5a412763168/roles/letsencrypt/tasks/nginx.yml#L13). The var [will be expanded](https://github.com/ansible/ansible/blob/v2.3.0.0-0.2.rc2/lib/ansible/playbook/conditional.py#L138-L139) and the var's jinja delimiters [will trigger](https://github.com/ansible/ansible/blob/v2.3.0.0-0.2.rc2/lib/ansible/playbook/conditional.py#L141) related warnings. This PR's commit avoids the warnings by removing jinja delimiters from the var value/definition:

```diff
# roles/letsencrypt/defaults.main.yml
- site_uses_letsencrypt: "{{ ssl_enabled and item.value.ssl.provider | default('manual') == 'letsencrypt' }}"
+ site_uses_letsencrypt: ssl_enabled and item.value.ssl.provider | default('manual') == 'letsencrypt'
```

That change prevents the warnings, but makes the `site_uses_letsencrypt` var not function in contexts that aren't part of the `when` task parameter. This accounts for why the commit in question removes `site_uses_letsencrypt` from the definition of `missing_hosts`
```diff
# roles/letsencrypt/defaults.main.yml
- missing_hosts: "{{ site_uses_letsencrypt | ternary(site_hosts, []) | difference(... bunch of stuff
+ missing_hosts: "{{ site_hosts | difference(... bunch of stuff
```

This change to `missing_hosts` means its two appearances in the form
`when: missing_hosts | count` must be adjusted. However, it turns out that the lack of jinja delimiters in `site_uses_letsencrypt` causes this adjustment to be ineffective:

```diff
- when: missing_hosts | count
+ when: missing_hosts | count and site_uses_letsencrypt
```

This accounts for why the commit in question uses the strategy below, leaving the `site_uses_letsencrypt` alone in a single item (vs. the compound item in the diff above).

```diff
- when: missing_hosts | count
+ when:
+   - site_uses_letsencrypt
+   - missing_hosts | count
```

----

Tested on Ansible [branch 2.3-stable](https://github.com/ansible/ansible/commits/stable-2.3) as of `07ea6a6` and on Ansible 2.2.0.0. Tests included default configs and alternative configs such as Let's Encrypt enabled, nginx-includes, and `root` login disabled, on DigitalOcean and AWS EC2.