### PR TITLE
Accommodate Ansible 2.1's new loop_var in output formatting

### DIFF
--- a/lib/trellis/utils/output.py
+++ b/lib/trellis/utils/output.py
@@ -50,11 +50,16 @@ def reset_task_info(obj, task=None):
 
 # Display dict key only, instead of full json dump
 def replace_item_with_key(obj, result):
-    if not obj._display.verbosity:
-        if 'key' in result._result['item']:
-            result._result['item'] = result._result['item']['key']
-        elif 'item' in result._result['item'] and 'key' in result._result['item']['item']:
-            result._result['item'] = result._result['item']['item']['key']
+    if not obj._display.verbosity and 'label' not in result._task._ds.get('loop_control', {}):
+        item = '_ansible_item_label' if '_ansible_item_label' in result._result else 'item'
+        if 'key' in result._result[item]:
+            result._result[item] = result._result[item]['key']
+        elif type(result._result[item]) is dict:
+            subitem = '_ansible_item_label' if '_ansible_item_label' in result._result[item] else 'item'
+            if 'key' in result._result[item].get(subitem, {}):
+                result._result[item] = result._result[item][subitem]['key']
+            elif '_ansible_item_label' in result._result[item]:
+                result._result[item] = result._result[item]['_ansible_item_label']
 
 def display(obj, result):
     msg = ''


### PR DESCRIPTION
Usage of Ansible's new [`loop_var`](http://docs.ansible.com/ansible/playbooks_loops.html#loop-control) causes the following warning about failure in custom output plugin:
```
[WARNING]: Failure using method (v2_runner_item_on_skipped) in callback plugin (<ansible.plugins.callback.output.CallbackModule object at 0x108c3b8d0>): 'item'
```

This PR prevents the error by no longer hard-coding the 'item' `loop_var`.

A playbook to demonstrate the error on current master, vs. no error on PR branch:
```
- gather_facts: false
  hosts: localhost
  vars:
    some_dict:
      example.com:
        foo: bar
      site.com:
        foo: bar
  tasks:
    - command: echo {{ some_loop_var }}
      register: some
      with_dict: "{{ some_dict }}"
      loop_control:
        loop_var: some_loop_var
    - command: echo {{ item }}
      with_items: "{{ some.results }}"
```

The purpose of the `replace_item_with_key()` feature that this PR adjusts is to truncate output. Ansible 2.2's new new loop_control `label` parameter seems targeted at the same purpose, so this PR makes Trellis only use its feature if the `label` parameter is absent (conditional on `'label' not in result._task._ds.get('loop_control', {})`).