### PR TITLE
Generate multi-domain self-signed certificate with Subject Alternative Names (SAN)

### DIFF
--- a/roles/wordpress-setup/tasks/self-signed-certificate.yml
+++ b/roles/wordpress-setup/tasks/self-signed-certificate.yml
@@ -11,7 +11,7 @@
     -newkey rsa:2048 -days 3650 -nodes -x509 -sha256
     -keyout {{ item.key }}.key -out {{ item.key }}.cert
   args:
-    chdir: "{{ nginx_path }}/ssl"
+    chdir: "{{ nginx_ssl_path }}"
     creates: "{{ item.key }}.*"
   with_dict: "{{ wordpress_sites }}"
   when: ssl_enabled and item.value.ssl.provider | default('manual') == 'self-signed'

--- a/roles/wordpress-setup/tasks/self-signed-certificate.yml
+++ b/roles/wordpress-setup/tasks/self-signed-certificate.yml
@@ -7,8 +7,14 @@
 
 - name: Generate self-signed certificates
   shell: >
-    openssl req -subj "/CN={{ item.value.site_hosts[0].canonical }}" -new
-    -newkey rsa:2048 -days 3650 -nodes -x509 -sha256
+    openssl req
+    -new
+    -newkey rsa:2048
+    -days 3650
+    -nodes
+    -x509
+    -sha256
+    -config openssl.cnf
     -keyout {{ item.key }}.key -out {{ item.key }}.cert
   args:
     chdir: "{{ nginx_ssl_path }}"

--- a/roles/wordpress-setup/tasks/self-signed-certificate.yml
+++ b/roles/wordpress-setup/tasks/self-signed-certificate.yml
@@ -1,4 +1,10 @@
 ---
+- name: Add canonical domains as Subject Alternative Name
+  template:
+    src: "{{ playbook_dir }}/roles/wordpress-setup/templates/openssl.conf.j2"
+    dest: "{{ nginx_ssl_path }}/openssl.cnf"
+  with_dict: "{{ wordpress_sites }}"
+
 - name: Generate self-signed certificates
   shell: >
     openssl req -subj "/CN={{ item.value.site_hosts[0].canonical }}" -new

--- a/roles/wordpress-setup/templates/openssl.conf.j2
+++ b/roles/wordpress-setup/templates/openssl.conf.j2
@@ -1,0 +1,19 @@
+[req]
+distinguished_name = req_distinguished_name
+req_extensions = v3_req
+x509_extensions = v3_ca
+prompt = no
+
+[req_distinguished_name]
+commonName = {{ item.key }}
+
+[v3_req]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+[v3_ca]
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer:always
+basicConstraints = CA:TRUE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment, keyAgreement, keyCertSign
+subjectAltName = {% for domain in item.value.site_hosts %}DNS:{{ domain.canonical }}{% if not loop.last %}, {% endif %}{% endfor %}


### PR DESCRIPTION
Generate a self-signed certificate with SAN (Subject Alternative Name) based on wordpress_sites dict.
All canonical domains will be included in the snakeoil certificate.

`group_vars/development/wordpress_sites.yml`
```
wordpress_sites:
  example.com:
    site_hosts:
      - canonical: example-a.test
      - canonical: example-b.test
      - canonical: example-c.test

…
```