### PR TITLE
Make the to_env filter escape single quote chars

### DIFF
--- a/lib/trellis/plugins/filter/filters.py
+++ b/lib/trellis/plugins/filter/filters.py
@@ -8,7 +8,7 @@ from ansible import errors
 from ansible.compat.six import string_types
 
 def to_env(dict_value):
-    envs = ["{0}='{1}'".format(key.upper(), value) for key, value in sorted(dict_value.items())]
+    envs = ["{0}='{1}'".format(key.upper(), str(value).replace("'","\\'")) for key, value in sorted(dict_value.items())]
     return "\n".join(envs)
 
 def underscore(value):


### PR DESCRIPTION
The `to_env` filter wraps values in single quotes. A single quote in a var value leads phpdotenv to misinterpret the value. Consider the following value in `.env` (currently possible):
```
EXAMPLE_VAR: 'xxxx'xxxxx'
```

This PR escapes single quote chars, resulting in a `.env` like this:
```
EXAMPLE_VAR: 'xxxx\'xxxxx'
```

phpdotenv correctly interprets the escaped version above:
```
$ wp eval 'echo getenv("EXAMPLE_VAR");'
xxxx'xxxxx
```

Fixes problems like [this](https://discourse.roots.io/t/error-on-deploy-at-task-wordpress-installed/8160/7) and other db connection problems like this:
```
TASK [wordpress-install : Install WP] ******************************************
PHP Warning:  mysqli_real_connect(): (HY000/1045): Access denied for user
'example_com'@'localhost' (using password: YES) in
/srv/www/example.com/current/web/wp/wp-includes/wp-db.php on line 1538
```