### PR TITLE
Move vars out of deploy.yml

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -14,29 +14,12 @@
 - name: Deploy WP site
   hosts: web:&{{ env }}
   remote_user: "{{ web_user }}"
-
-  vars:
-    project: "{{ wordpress_sites[site] }}"
-    project_root: "{{ www_root }}/{{ site }}"
-    wordpress_env_defaults:
-      db_host: localhost
-      db_name: "{{ site | underscore }}_{{ env }}"
-      db_user: "{{ site | underscore }}"
-      disable_wp_cron: true
-      wp_env: "{{ env }}"
-      wp_home: "{{ project.ssl.enabled | default(false) | ternary('https', 'http') }}://{{ project.site_hosts | map(attribute='canonical') | first }}"
-      wp_siteurl: "{{ project.ssl.enabled | default(false) | ternary('https', 'http') }}://{{ project.site_hosts | map(attribute='canonical') | first }}/wp"
-      domain_current_site: "{{ project.site_hosts | map(attribute='canonical') | first }}"
-    site_env: "{{ wordpress_env_defaults | combine(project.env | default({}), vault_wordpress_sites[site].env) }}"
-    project_local_path: "{{ (lookup('env', 'USER') == 'vagrant') | ternary(project_root + '/' + project_current_path, project.local_path) }}"
-
   pre_tasks:
     - name: Ensure site is valid
       connection: local
       fail:
         msg: "Site `{{ site | default('') }}` is not valid. Available sites to deploy: {{ wordpress_sites.keys() | join(', ') }}"
       when: wordpress_sites[site | default('')] is not defined
-
     - name: Ensure repo is valid
       connection: local
       fail:
@@ -46,6 +29,5 @@
           More info:
           > https://roots.io/trellis/docs/deploys/
       when: project.repo is not defined or not project.repo | match(".*@.*:.*\.git")
-
   roles:
     - deploy

--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -45,6 +45,11 @@ project_environment:
 # - default is 'current'
 project_current_path: "{{ project.current_path | default('current') }}"
 
+# Helpers
+project: "{{ wordpress_sites[site] }}"
+project_root: "{{ www_root }}/{{ site }}"
+project_local_path: "{{ (lookup('env', 'USER') == 'vagrant') | ternary(project_root + '/' + project_current_path, project.local_path) }}"
+
 
 # Deploy hooks
 # For list of hooks and explanation, see https://roots.io/trellis/docs/deploys/#hooks

--- a/roles/deploy/vars/main.yml
+++ b/roles/deploy/vars/main.yml
@@ -1,0 +1,11 @@
+wordpress_env_defaults:
+  db_host: localhost
+  db_name: "{{ site | underscore }}_{{ env }}"
+  db_user: "{{ site | underscore }}"
+  disable_wp_cron: true
+  wp_env: "{{ env }}"
+  wp_home: "{{ project.ssl.enabled | default(false) | ternary('https', 'http') }}://{{ project.site_hosts | map(attribute='canonical') | first }}"
+  wp_siteurl: "{{ project.ssl.enabled | default(false) | ternary('https', 'http') }}://{{ project.site_hosts | map(attribute='canonical') | first }}/wp"
+  domain_current_site: "{{ project.site_hosts | map(attribute='canonical') | first }}"
+
+site_env: "{{ wordpress_env_defaults | combine(project.env | default({}), vault_wordpress_sites[site].env) }}"


### PR DESCRIPTION
For tidier `deploy.yml` and consistency of role vars in `defaults/main.yml`:
* Moves unique vars to `roles/deploy/defaults/main.yml`
* Moves duplicate vars that must take precedence over `group_vars/all/helpers.yml` to a new `roles/deploy/vars/main.yml`

(Ansible docs on [variable precedence](http://docs.ansible.com/ansible/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable))