### PR TITLE
Remove unnecessary with_dict loop in creating web root

### DIFF
--- a/roles/wordpress-setup/tasks/main.yml
+++ b/roles/wordpress-setup/tasks/main.yml
@@ -11,7 +11,6 @@
     group: "{{ web_group }}"
     mode: 0755
     state: directory
-  with_dict: "{{ wordpress_sites }}"
 
 - name: Create logs folder of sites
   file:


### PR DESCRIPTION
No need to loop over `wordpress_sites` while creating the single web root. 