### PR TITLE
Fix conditional for dynamic HostKeyAlgorithms msg

### DIFF
--- a/roles/connection/tasks/main.yml
+++ b/roles/connection/tasks/main.yml
@@ -59,7 +59,7 @@
     debug:
       msg: |
         Note: Ansible will attempt connections as user = {{ ansible_user }}
-        {% if preferred_host_key_algorithms | changed %}
+        {% if not preferred_host_key_algorithms | skipped %}
 
         Note: The host `{{ ansible_host }}` was not detected in known_hosts
         so Trellis prompted the host to offer a key type that will work with


### PR DESCRIPTION
#### Summary
The critical functionality of #798 is intact, but the message about how Trellis dynamically added the HostKeyAlgorithms ssh arg does not display. When the `set_fact` task runs, it has status 'ok', not 'changed'. Thus to check whether the `ansible_ssh_extra_args` var was dynamically set, the condition must check whether or not the `set_fact` task skipped (vs. changed).

#### How did this happen?
I think during all my testing I had the condition `ansible_ssh_extra_args != ''` but right before submitting the PR I realized that when a user passes the `--extra-ssh-args` CLI option...
- it populates the `ansible_ssh_extra_args` var
- causing the condition to be `true`
- causing the message to display when it shouldn't because the dynamic HostKeyAlgorithms are NOT applied when the `--extra-ssh-args` CLI option is used.

So, I realized the solution would be to only display the message if the `set_fact` task had taken action, dynamically populating the `ansible_ssh_extra_args` var. Typical tasks would indicate they had done something with a status of 'changed' so I mistakenly thought the `| changed ` filter would handle it. Turns out that `set_fact` never has the status changed, just `ok`, `skipped`, etc.

#### The fix
This PR changes the condition, causing the message to only show if the `set_fact` doesn't skip. I tested this and all the other functioning of #798 again and it all works.

