### PR TITLE
Add vault_wordpress_sites validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Add vault_wordpress_sites validation ([#823](https://github.com/roots/trellis/pull/823))
 * Use dynamic HostKeyAlgorithms SSH option for unknown hosts ([#798](https://github.com/roots/trellis/pull/798))
 * Accommodate deploy hook vars formatted as lists of includes ([#815](https://github.com/roots/trellis/pull/815))
 * Check Ansible version before Ansible validates task attributes ([#797](https://github.com/roots/trellis/pull/797))

--- a/local.yml
+++ b/local.yml
@@ -1,0 +1,11 @@
+---
+- name: "WordPress Server: Install LEMP Stack with PHP 7.0 and MariaDB MySQL"
+  hosts: localhost
+  connection: local
+
+  tasks:
+    - name: Validate wordpress_sites
+      fail:
+        msg: "test"
+      when: wordpress_sites.keys() | sort != vault_wordpress_sites.keys() | sort
+      tags: [wordpress]

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Validate wordpress_sites
+  fail:
+    msg: "{{ lookup('template', 'wordpress_sites.j2') }}"
+  when: wordpress_sites.keys() | difference(vault_wordpress_sites.keys()) | count
+  tags: [wordpress]
+
 - name: Validate format of site_hosts
   fail:
     msg: "{{ lookup('template', 'site_hosts.j2') }}"

--- a/roles/common/templates/wordpress_sites.j2
+++ b/roles/common/templates/wordpress_sites.j2
@@ -1,0 +1,10 @@
+Invalid WordPress sites configuration: site names in `wordpress_sites` must have matching entry in `vault_wordpress_sites`.
+
+Sites without a matching vault entry:
+{% for name in wordpress_sites.keys() | difference(vault_wordpress_sites.keys()) %}
+* `{{ name }}`
+{% endfor %}
+
+Update `group_vars/{{ env }}/vault_wordpress_sites.yml` to continue.
+
+Docs: https://roots.io/trellis/docs/wordpress-sites/#passwordssecrets


### PR DESCRIPTION
This will catch a common error of forgetting to update site names/keys in both `wordpress_sites` and `vault_wordpress_sites`.

Example output:

```plain
Invalid WordPress sites configuration: site names in `wordpress_sites` must
have matching entry in `vault_wordpress_sites`.

Sites without a matching vault entry:
* `example.com`

Update `group_vars/development/vault_wordpress_sites.yml` to continue.

Docs: https://roots.io/trellis/docs/wordpress-sites/#passwordssecrets
```