### PR TITLE
Fix #439 - Add ansible_local support for non-Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Add ansible_local support for non-Windows ([#824](https://github.com/roots/trellis/pull/824))
 * Add `fastcgi_read_timeout` to Nginx config ([#860](https://github.com/roots/trellis/pull/860))
 * Accommodate child themes: Update WP `stylesheet_root` separately ([#850](https://github.com/roots/trellis/pull/850))
 * Deploys: `--skip-themes` when updating WP `template_root` ([#849](https://github.com/roots/trellis/pull/849))

--- a/README.md
+++ b/README.md
@@ -27,11 +27,14 @@ Trellis will configure a server with the following and more:
 * Fail2ban
 * ferm
 
+## Documentation
+
+Full documentation is available at [https://roots.io/trellis/docs/](https://roots.io/trellis/docs/).
+
 ## Requirements
 
 Make sure all dependencies have been installed before moving on:
 
-* [Ansible](http://docs.ansible.com/ansible/intro_installation.html#latest-releases-via-pip) >= 2.2
 * [Virtualbox](https://www.virtualbox.org/wiki/Downloads) >= 4.3.10
 * [Vagrant](https://www.vagrantup.com/downloads.html) >= 1.8.5
 
@@ -56,10 +59,6 @@ See a complete working example in the [roots-example-project.com repo](https://g
 
 Windows user? [Read the Windows docs](https://roots.io/trellis/docs/windows/) for slightly different installation instructions. VirtualBox is known to have poor performance in Windows — use VMware or [see some possible solutions](https://discourse.roots.io/t/virtualbox-performance-in-windows/3932).
 
-## Documentation
-
-Trellis documentation is available at [https://roots.io/trellis/docs/](https://roots.io/trellis/docs/).
-
 ## Local development setup
 
 1. Configure your WordPress sites in `group_vars/development/wordpress_sites.yml` and in `group_vars/development/vault.yml`
@@ -68,6 +67,8 @@ Trellis documentation is available at [https://roots.io/trellis/docs/](https://r
 [Read the local development docs](https://roots.io/trellis/docs/local-development-setup/) for more information.
 
 ## Remote server setup (staging/production)
+
+For remote servers, installing Ansible locally is an additional requirement. See the [docs](https://roots.io/trellis/docs/remote-server-setup/#requirements) for more information.
 
 A base Ubuntu 16.04 server is required for setting up remote servers. OS X users must have [passlib](http://pythonhosted.org/passlib/install.html#installation-instructions) installed.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -91,11 +91,11 @@ Vagrant.configure('2') do |config|
     end
   end
 
-  provisioner = Vagrant::Util::Platform.windows? ? :ansible_local : :ansible
-  provisioning_path = Vagrant::Util::Platform.windows? ? ANSIBLE_PATH_ON_VM : ANSIBLE_PATH
+  provisioner = local_provisioning? ? :ansible_local : :ansible
+  provisioning_path = local_provisioning? ? ANSIBLE_PATH_ON_VM : ANSIBLE_PATH
 
   config.vm.provision provisioner do |ansible|
-    if Vagrant::Util::Platform.windows?
+    if local_provisioning?
       ansible.install_mode = 'pip'
       ansible.provisioning_path = provisioning_path
       ansible.version = vconfig.fetch('vagrant_ansible_version')

--- a/lib/trellis/vagrant.rb
+++ b/lib/trellis/vagrant.rb
@@ -62,6 +62,10 @@ def load_wordpress_sites
   wordpress_sites
 end
 
+def local_provisioning?
+  @local_provisioning ||= Vagrant::Util::Platform.windows? || !which('ansible-playbook') || ENV['FORCE_ANSIBLE_LOCAL']
+end
+
 def local_site_path(site)
   File.expand_path(site['local_path'], ANSIBLE_PATH)
 end
@@ -89,4 +93,17 @@ end
 
 def remote_site_path(site_name, site)
   "/srv/www/#{site_name}/#{site['current_path'] || 'current'}"
+end
+
+def which(cmd)
+  exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
+
+  paths = ENV['PATH'].split(File::PATH_SEPARATOR).flat_map do |path|
+    exts.map { |ext| File.join(path, "#{cmd}#{ext}") }
+  end
+
+  paths.any? do |path|
+    next unless File.executable?(path) && !File.directory?(path)
+    system("#{path} --help", %i(out err) => File::NULL)
+  end
 end


### PR DESCRIPTION
Previously only Windows would use Vagrant's `ansible_local` provisioner. But it's a much easier experience to get started in development since it skips the Ansible requirement.

This automatically uses the `ansible_local` provisioner if `ansible-playbook` does not exist on the host machine.

The env var `FORCE_ANSIBLE_LOCAL` can be set to force it as well.

Docs: https://github.com/roots/docs/pull/90