### PR TITLE
Remove db_import option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### HEAD
+* Remove potentially dangerous `db_import` option ([#825](https://github.com/roots/trellis/pull/825))
+
 ### 1.0.0-rc.1: April 7th, 2017
 * Add vault_wordpress_sites validation ([#823](https://github.com/roots/trellis/pull/823))
 * Use dynamic HostKeyAlgorithms SSH option for unknown hosts ([#798](https://github.com/roots/trellis/pull/798))

--- a/roles/wordpress-setup/tasks/database.yml
+++ b/roles/wordpress-setup/tasks/database.yml
@@ -22,22 +22,3 @@
     login_password: "{{ mysql_root_password }}"
   with_dict: "{{ wordpress_sites }}"
   when: site_uses_local_db and item.value.db_create | default(True)
-
-- name: Copy database dump
-  copy:
-    src: "{{ item.value.db_import }}"
-    dest: /tmp
-  with_dict: "{{ wordpress_sites }}"
-  when: item.value.db_import | default(False)
-
-- name: Import database
-  mysql_db:
-    name: "{{ site_env.db_name }}"
-    state: import
-    target: "/tmp/{{ item.value.db_import | basename }}"
-    login_host: "{{ site_env.db_host }}"
-    login_user: "{{ site_env.db_user }}"
-    login_password: "{{ site_env.db_password }}"
-  with_dict: "{{ wordpress_sites }}"
-  when: item.value.db_import | default(False)
-  notify: reload nginx


### PR DESCRIPTION
This option is used to import a local SQL dump file into the database.

It was seldom used and could be dangerous. This option would cause the DB to be imported *every* provision which could overwrite data.

As an alternative for most DB operations, we always recommend using WP CLI.

Example: `wp db import dbname.sql`