### PR TITLE
Deploys: Make wp core update-db optional

### DIFF
--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -45,6 +45,9 @@ project_environment:
 # - default is 'current'
 project_current_path: "{{ project.current_path | default('current') }}"
 
+# Whether to run `wp core update-db` at end of each deploy
+update_db_on_deploy: true
+
 # Helpers
 project: "{{ wordpress_sites[site] }}"
 project_root: "{{ www_root }}/{{ site }}"

--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -1,21 +1,15 @@
 ---
 - block:
-  - name: Update WP database
-    command: wp core update-db
-    args:
-      chdir: "{{ deploy_helper.current_path }}"
-    when: not project.multisite.enabled | default(false)
-
   - name: Warn about updating network database.
     debug:
       msg: "Updating the network database could take a long time with a large number of sites."
-    when: project.multisite.enabled | default(false)
+    when: project.update_db_on_deploy | default(update_db_on_deploy) and project.multisite.enabled | default(false)
 
-  - name: Update WP network database
-    command: wp core update-db --network
+  - name: Update WP database
+    command: wp core update-db {{ project.multisite.enabled | default(false) | ternary('--network', '') }}
     args:
       chdir: "{{ deploy_helper.current_path }}"
-    when: project.multisite.enabled | default(false)
+    when: project.update_db_on_deploy | default(update_db_on_deploy)
 
   - name: Get WP theme template root
     command: wp option get template_root


### PR DESCRIPTION
On deploys, users with large network databases may want to disable the `wp core update-db` option to avoid the long processing time.

This PR adds the `update_db_on_deploy` option variable (default `true`) to control whether the `update-db` runs. This var may be defined per site in `wordpress_site` or just generally in `group_vars`.

This PR also consolidates the two "Update WP database" tasks, where the only difference was the presence of the `--network` flag for multisite.