### PR TITLE
Remove unnecessary ID from Let's Encrypt bundled cert filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Removes ID from Lets Encrypt bundled certificate and make filename stable ([#834](https://github.com/roots/trellis/pull/834))
 * Make Fail2ban settings extensible ([#1177](https://github.com/roots/trellis/pull/1177))
 * Improve ip_whitelist in development ([#1183](https://github.com/roots/trellis/pull/1183))
 * Support Ansible 2.9 ([#1169](https://github.com/roots/trellis/pull/1169))

--- a/roles/letsencrypt/tasks/certificates.yml
+++ b/roles/letsencrypt/tasks/certificates.yml
@@ -25,7 +25,7 @@
   changed_when: false
   when: site_uses_letsencrypt
   with_dict: "{{ wordpress_sites }}"
-  tags: [wordpress, wordpress-setup, nginx-includes, nginx-sites]
+  tags: [wordpress, wordpress-setup, wordpress-setup-nginx, nginx-includes]
 
 - name: Generate CSRs
   shell: "openssl req -new -sha256 -key '{{ letsencrypt_keys_dir }}/{{ item.key }}.key' -subj '/' -reqexts SAN -config <(cat /etc/ssl/openssl.cnf <(printf '[SAN]\nsubjectAltName=DNS:{{ site_hosts | join(',DNS:') }}')) > {{ acme_tiny_data_directory }}/csrs/{{ item.key }}-{{ letsencrypt_cert_ids[item.key] }}.csr"
@@ -40,6 +40,7 @@
     src: renew-certs.py
     dest: "{{ acme_tiny_data_directory }}/renew-certs.py"
     mode: 0700
+  tags: [wordpress, wordpress-setup, wordpress-setup-nginx, nginx-includes]
 
 - name: Generate the certificates
   command: ./renew-certs.py
@@ -48,3 +49,4 @@
   register: generate_certs
   changed_when: generate_certs.stdout is defined and 'Created' in generate_certs.stdout
   notify: reload nginx
+  tags: [wordpress, wordpress-setup, wordpress-setup-nginx, nginx-includes]

--- a/roles/letsencrypt/templates/renew-certs.py
+++ b/roles/letsencrypt/templates/renew-certs.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
 import os
 import sys
 import time
@@ -10,38 +12,51 @@ failed = False
 letsencrypt_cert_ids = {{ letsencrypt_cert_ids }}
 
 for site in {{ sites_using_letsencrypt }}:
-    bundled_cert_path = os.path.join('{{ letsencrypt_certs_dir }}', site + '-' + letsencrypt_cert_ids[site] + '-bundled.cert')
+    csr_path = os.path.join('{{ acme_tiny_data_directory }}', 'csrs', '{}-{}.csr'.format(site, letsencrypt_cert_ids[site]))
+    bundled_cert_path = os.path.join('{{ letsencrypt_certs_dir }}', '{}-bundled.cert'.format(site))
+    bundled_hashed_cert_path = os.path.join('{{ letsencrypt_certs_dir }}', '{}-{}-bundled.cert'.format(site, letsencrypt_cert_ids[site]))
 
-    if os.access(bundled_cert_path, os.F_OK):
-        stat = os.stat(bundled_cert_path)
-        print('Certificate file ' + bundled_cert_path + ' already exists')
-
-        if time.time() - stat.st_mtime < {{ letsencrypt_min_renewal_age }} * 86400:
-            print('  The certificate is younger than {{ letsencrypt_min_renewal_age }} days. Not creating a new certificate.\n')
-            continue
-
-    print('Generating certificate for ' + site)
-
-    cmd = (
-        '/usr/bin/env python {{ acme_tiny_software_directory }}/acme_tiny.py '
-        '--quiet '
-        '--ca {{ letsencrypt_ca }} '
-        '--account-key {{ letsencrypt_account_key }} '
-        '--csr {{ acme_tiny_data_directory }}/csrs/{0}-{1}.csr '
-        '--acme-dir {{ acme_tiny_challenges_directory }}'
-    ).format(site, letsencrypt_cert_ids[site])
-
-    try:
-        cert = check_output(cmd, stderr=STDOUT, shell=True)
-    except CalledProcessError as e:
+    # Generate or update root cert if needed
+    if not os.access(csr_path, os.F_OK):
         failed = True
-        print('Error while generating certificate for ' + site)
-        print(e.output)
-    else:
-        with open(bundled_cert_path, 'w') as cert_file:
-            cert_file.write(cert)
+        print('The required CSR file {} does not exist. This could happen if you changed site_hosts and have '
+              'not yet rerun the letsencrypt role. Create the CSR file by re-provisioning (running the Trellis '
+              'server.yml playbook) with `--tags letsencrypt`'.format(csr_path), file=sys.stderr)
+        continue
 
-        print('Created certificate for ' + site)
+    elif os.access(bundled_hashed_cert_path, os.F_OK) and time.time() - os.stat(bundled_hashed_cert_path).st_mtime < {{ letsencrypt_min_renewal_age }} * 86400:
+        print('Certificate file {} already exists and is younger than {{ letsencrypt_min_renewal_age }} days. '
+              'Not creating a new certificate.'.format(bundled_hashed_cert_path))
+
+    else:
+        cmd = ('/usr/bin/env python {{ acme_tiny_software_directory }}/acme_tiny.py '
+            '--quiet '
+            '--ca {{ letsencrypt_ca }} '
+            '--account-key {{ letsencrypt_account_key }} '
+            '--csr {} '
+            '--acme-dir {{ acme_tiny_challenges_directory }}'
+        ).format(csr_path)
+
+        try:
+            new_bundled_cert = check_output(cmd, stderr=STDOUT, shell=True)
+        except CalledProcessError as e:
+            failed = True
+            print('Error while generating certificate for {}\n{}'.format(site, e.output), file=sys.stderr)
+            continue
+        else:
+            with open(bundled_hashed_cert_path, 'w') as bundled_hashed_cert_file:
+                bundled_hashed_cert_file.write(new_bundled_cert)
+            with open(bundled_cert_path, 'w') as bundled_cert_file:
+                bundled_cert_file.write(new_bundled_cert)
+
+    if not os.access(bundled_cert_path, os.F_OK):
+        with open(bundled_hashed_cert_path, 'rb') as bundled_hashed_cert_file:
+            bundled_hashed_cert = bundled_hashed_cert_file.read()
+
+            with open(bundled_cert_path, 'w') as bundled_cert_file:
+                bundled_cert_file.write(bundled_hashed_cert)
+                print('Created bundled certificate {}'.format(bundled_cert_path))
+
 
 if failed:
     sys.exit(1)

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -92,7 +92,7 @@ server {
   ssl_certificate_key     {{ nginx_path }}/ssl/{{ item.value.ssl.key | basename }};
 
   {% elif item.value.ssl.provider | default('manual') == 'letsencrypt' -%}
-  ssl_certificate         {{ nginx_path }}/ssl/letsencrypt/{{ item.key }}-{{ letsencrypt_cert_ids[item.key] }}-bundled.cert;
+  ssl_certificate         {{ nginx_path }}/ssl/letsencrypt/{{ item.key }}-bundled.cert;
   ssl_certificate_key     {{ nginx_path }}/ssl/letsencrypt/{{ item.key }}.key;
 
   {% elif item.value.ssl.provider | default('manual') == 'self-signed' -%}


### PR DESCRIPTION
#826 says it would be nice for other programs to have a stable path to the Let's Encrypt bundled cert (vs. a filename with an ID that changes). 

**ID ensures regenerated CSR and cert_file.** The CSR uses the ID/hash [here](https://github.com/roots/trellis/blob/560b523222c4b30a08b127d49713b88eaff7ba95/roles/letsencrypt/tasks/certificates.yml#L31) to ensure it is regenerated in response to changes in relevant conditions, and an ID in the `cert_file` name appeared necessary for the correct [stat and age](https://github.com/roots/trellis/blob/560b523222c4b30a08b127d49713b88eaff7ba95/roles/letsencrypt/templates/renew-certs.py#L17-L20) calculation for the file. 

**ID unnecessary in bundled cert filename.** However, an ID in the bundled cert filename is not necessary, as far as I can tell. I think I just included it in #630 for filename consistency with the CSR and `cert_file`. So, this PR removes the ID from the bundled cert filename, for convenience of other programs that use its path. I'm not aware of any external need for the bundled cert filename to be unique with each cert renewal. Indeed, certbot considers it optional to "uniquify" cert paths: certbot/certbot#3009

**Backward compatibility** This PR also rsyncs existing ID-in-filename bundled certs to their non-ID counterparts. This ensures the non-ID bundled certs exist when users happen to run only the `wordpress` tag and not the `letsencrypt` tag. In such a scenario, the `wordpress-site.conf` files would be regenerated with non-ID filenames but such files would not exist without an rsync that runs under the same Ansible tag. (The two tasks for compatibility are the bulk of this PR, unfortunately. Removing the ID was just 2 lines of code otherwise).

**Tags note.** This PR also adds the `wordpress-setup-nginx` tag to the "Generate Lets Encrypt certificate IDs" task, this task being required for the later tasks in this PR to have access to the IDs, if a user happened to trigger these tasks via the `wordpress-setup-nginx` tag.

This PR also adds the `nginx-includes` tag to the two rsync tasks because they need to run if a user runs the `nginx-includes` tag, which would regenerate the `wordpress-site.conf` with the non-ID bundled cert filename via the "Create WordPress configuration for Nginx" task.

**Playing it safe.** This PR also augmented the `renew-certs.py` with a check for the existence of the bundled cert, in the spirit of pursuing "desired state." If the bundled cert doesn't exist, running the rest of the script is the only way it will be created. I concede that it would be a rare case for the `cert_file` to exist and the `bundled_cert_file` to not exist, but strange things happen, and this addition doesn't seem to have too big of a price for playing it safe.