### PR TITLE
Update wp-cli to 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Update WP-CLI to 1.2.1 ([#838](https://github.com/roots/trellis/pull/838))
 * Auto-install Vagrant plugins ([#829](https://github.com/roots/trellis/pull/829))
 * Add Vagrant config ([#828](https://github.com/roots/trellis/pull/828))
 * Ansible 2.3 compatibility ([#813](https://github.com/roots/trellis/pull/813))

--- a/roles/wp-cli/defaults/main.yml
+++ b/roles/wp-cli/defaults/main.yml
@@ -1,4 +1,4 @@
-wp_cli_version: 1.1.0
+wp_cli_version: 1.2.1
 wp_cli_bin_path: /usr/bin/wp
 wp_cli_phar_url: "https://github.com/wp-cli/wp-cli/releases/download/v{{ wp_cli_version }}/wp-cli-{{ wp_cli_version }}.phar"
 wp_cli_completion_url: "https://raw.githubusercontent.com/wp-cli/wp-cli/v{{ wp_cli_version }}/utils/wp-completion.bash"


### PR DESCRIPTION
[version 1.2.0](https://make.wordpress.org/cli/2017/05/31/version-1-2-0-released/) was released May 31, 2017
[version 1.2.1](https://make.wordpress.org/cli/2017/06/06/version-1-2-1-released/) was released June 6, 2017 with some fixes