### PR TITLE
Update WP theme paths only when template_root in releases_path

### DIFF
--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -23,7 +23,7 @@
     command: wp option set {{ item }} {{ deploy_helper.new_release_path }}/web/wp/wp-content/themes
     args:
       chdir: "{{ deploy_helper.current_path }}"
-    when: wp_template_root.stdout != '' and wp_template_root.stdout != '/themes'
+    when: deploy_helper.releases_path in wp_template_root.stdout
     with_items:
       - stylesheet_root
       - template_root


### PR DESCRIPTION
The update to WP theme paths is needed only if the WP `template_root` falls in the `releases` subdirectory. The problem to solve — originally addressed by #275 then 632bbe8 — is that on deploy, the `template_root` will sometimes retain the old releases path value, such as `/srv/www/example.com/releases/20170614235048/web/wp/wp-content/themes`, when in fact it needs to be assigned the new release path, such as  `/srv/www/example.com/releases/20170614235217` (the newer date).

This PR uses a safer condition in evaluating whether to update the theme paths. It performs the update only if the `releases_path` (`/srv/www/example.com/releases`) appears in the retrieved `template_root` value. This revised condition avoids overwriting less common `template_root` values such as [subdirectories of plugins](https://codex.wordpress.org/Function_Reference/register_theme_directory#Register_a_plugin.27s_subdirectory_as_a_theme_folder). Such paths were not accounted for prior to this PR and would have been reset inappropriately, unintentionally deactivating such themes.

