### PR TITLE
Remove unnecessary output about running WP-CLI and Composer

### DIFF
--- a/lib/trellis/vagrant.rb
+++ b/lib/trellis/vagrant.rb
@@ -78,7 +78,8 @@ end
 
 def post_up_message
   msg = 'Your Trellis Vagrant box is ready to use!'
-  msg << "\n* Composer and WP-CLI commands need to be run on the virtual machine."
+  msg << "\n* Composer and WP-CLI commands need to be run on the virtual machine"
+  msg << "\n  for any post-provision modifications."
   msg << "\n* You can SSH into the machine with `vagrant ssh`."
   msg << "\n* Then navigate to your WordPress sites at `/srv/www`"
   msg << "\n  or to your Trellis files at `#{ANSIBLE_PATH_ON_VM}`."


### PR DESCRIPTION
I removed this line (post vagrant up) as it originally confused me because both of these commands run automatically.
`==> default: * Composer and WP-CLI commands need to be run on the virtual machine.`