### PR TITLE
Add support for SMTP without authentication

### DIFF
--- a/roles/ssmtp/templates/ssmtp.conf.j2
+++ b/roles/ssmtp/templates/ssmtp.conf.j2
@@ -7,5 +7,9 @@ UseTLS={{ ssmtp_tls }}
 UseSTARTTLS={{ ssmtp_start_tls }}
 hostname={{ mail_hostname }}
 mailhub={{ mail_smtp_server }}
+{% if mail_user is defined %}
 AuthUser={{ mail_user }}
+{% endif %}
+{% if mail_password is defined %}
 AuthPass={{ mail_password }}
+{% endif %}


### PR DESCRIPTION
I admit this is an edge case. I have a client that provided their own internal smtp-server that had no authentication (it was IP-blocked). By not providing user and password I got it to work.