### PR TITLE
Reload Nginx with updates to manual cert or key

### DIFF
--- a/roles/wordpress-setup/tasks/nginx.yml
+++ b/roles/wordpress-setup/tasks/nginx.yml
@@ -6,6 +6,7 @@
     mode: 0640
   with_dict: "{{ wordpress_sites }}"
   when: ssl_enabled and item.value.ssl.cert is defined
+  notify: reload nginx
 
 - name: Copy SSL key
   copy:
@@ -14,6 +15,7 @@
     mode: 0600
   with_dict: "{{ wordpress_sites }}"
   when: ssl_enabled and item.value.ssl.key is defined
+  notify: reload nginx
 
 - include: "{{ playbook_dir }}/roles/common/tasks/disable_challenge_sites.yml"
 


### PR DESCRIPTION
When a user updates the manual SSL cert, the [copy module](http://docs.ansible.com/ansible/copy_module.html) will copy the new cert (default `force: yes`) but the new cert won't take effect unless Nginx reloads.

This PR ensures Nginx reloads if the "manual" cert or key changes. 