### PR TITLE
Add PHP SOAP extension to defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Add PHP SOAP extension to defaults ([#844](https://github.com/roots/trellis/pull/844))
 * Option to install WP-CLI packages ([#837](https://github.com/roots/trellis/pull/837))
 * Update WP-CLI to 1.2.1 ([#838](https://github.com/roots/trellis/pull/838))
 * Auto-install Vagrant plugins ([#829](https://github.com/roots/trellis/pull/829))

--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -12,6 +12,7 @@ php_extensions_default:
   - php7.1-mcrypt
   - php7.1-mysql
   - php7.1-opcache
+  - php7.1-soap
   - php7.1-xml
   - php7.1-xmlrpc
   - php7.1-zip


### PR DESCRIPTION
i think this is worth adding to the default extensions

older mention from discourse: https://discourse.roots.io/t/woocomerce-and-php7-0-soap-and-php7-0-mbstring/6049