### PR TITLE
Fix incorrect file path in vault error template

### DIFF
--- a/roles/common/templates/wordpress_sites.j2
+++ b/roles/common/templates/wordpress_sites.j2
@@ -5,6 +5,6 @@ Sites without a matching vault entry:
 * `{{ name }}`
 {% endfor %}
 
-Update `group_vars/{{ env }}/vault_wordpress_sites.yml` to continue.
+Update `group_vars/{{ env }}/vault.yml` to continue.
 
 Docs: https://roots.io/trellis/docs/wordpress-sites/#passwordssecrets


### PR DESCRIPTION
When a vault entry is missing for a site in `wordpress_sites.yml`, [this template](https://github.com/roots/trellis/blob/master/roles/common/templates/wordpress_sites.j2) is used to display an error message. However, the error message incorrectly instructs the user to update the nonexistent `group_vars/<environment>/vault_wordpress_sites.yml` file instead of `group_vars/<environment>/vault.yml`. This PR fixes this issue.