### PR TITLE
Update WP template_root for multisite subsites when applicable

### DIFF
--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -16,7 +16,7 @@
       {% if not project.multisite.enabled | default(false) %}
         wp option get template_root --skip-plugins
       {% else %}
-        wp site list --field=url | xargs -I {} bash -c 'export url="{}"; echo -n "$url " && wp option get template_root --skip-plugins --url=$url'
+        wp site list --field=url | xargs -I {} bash -c 'export url="{}"; echo -n "$url " && wp option get template_root --skip-plugins --url=$url || echo'
       {% endif %}
     args:
       chdir: "{{ deploy_helper.current_path }}"
@@ -32,9 +32,9 @@
       {% if project.multisite.enabled | default(false) %} --url={{ item[0].split(' ')[0] }}{% endif %}
     args:
       chdir: "{{ deploy_helper.current_path }}"
-    when: update_wp_theme_paths | default(true) | bool and deploy_helper.releases_path in item[0]
+    when: update_wp_theme_paths | default(true) | bool
     with_nested:
-      - "{{ wp_template_root.stdout_lines }}"
+      - "{{ wp_template_root.stdout_lines | select('search', deploy_helper.releases_path) | list }}"
       - ['template_root', 'stylesheet_root']
 
   when: wp_installed | success

--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -14,9 +14,9 @@
   - name: Get WP theme template and stylesheet roots
     shell: >
       {% if not project.multisite.enabled | default(false) %}
-        wp option get {{ item }} --skip-plugins
+        wp option get {{ item }} --skip-plugins --skip-themes
       {% else %}
-        wp site list --field=url | xargs -I {} bash -c 'export url="{}"; echo -n "$url " && wp option get {{ item }} --skip-plugins --url=$url || echo'
+        wp site list --field=url | xargs -I {} bash -c 'export url="{}"; echo -n "$url " && wp option get {{ item }} --skip-plugins --skip-themes --url=$url || echo'
       {% endif %}
     args:
       chdir: "{{ deploy_helper.current_path }}"

--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -12,21 +12,30 @@
     when: project.update_db_on_deploy | default(update_db_on_deploy)
 
   - name: Get WP theme template root
-    command: wp option get template_root --skip-plugins
+    shell: >
+      {% if not project.multisite.enabled | default(false) %}
+        wp option get template_root --skip-plugins
+      {% else %}
+        wp site list --field=url | xargs -I {} bash -c 'export url="{}"; echo -n "$url " && wp option get template_root --skip-plugins --url=$url'
+      {% endif %}
     args:
       chdir: "{{ deploy_helper.current_path }}"
     register: wp_template_root
     changed_when: false
     failed_when: wp_template_root.stderr != ""
+    when: update_wp_theme_paths | default(true) | bool
 
   - name: Update WP theme paths
-    command: wp option set {{ item }} {{ deploy_helper.new_release_path }}/web/wp/wp-content/themes
+    command: >
+      wp option set {{ item[1] }}
+      {{ item[0] | regex_replace('.*' + deploy_helper.releases_path + '/[0-9]*(.*)', deploy_helper.new_release_path + '\1') }}
+      {% if project.multisite.enabled | default(false) %} --url={{ item[0].split(' ')[0] }}{% endif %}
     args:
       chdir: "{{ deploy_helper.current_path }}"
-    when: deploy_helper.releases_path in wp_template_root.stdout
-    with_items:
-      - stylesheet_root
-      - template_root
+    when: update_wp_theme_paths | default(true) | bool and deploy_helper.releases_path in item[0]
+    with_nested:
+      - "{{ wp_template_root.stdout_lines }}"
+      - ['template_root', 'stylesheet_root']
 
   when: wp_installed | success
 

--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -11,12 +11,12 @@
       chdir: "{{ deploy_helper.current_path }}"
     when: project.update_db_on_deploy | default(update_db_on_deploy)
 
-  - name: Get WP theme template root
+  - name: Get WP theme template and stylesheet roots
     shell: >
       {% if not project.multisite.enabled | default(false) %}
-        wp option get template_root --skip-plugins
+        wp option get {{ item }} --skip-plugins
       {% else %}
-        wp site list --field=url | xargs -I {} bash -c 'export url="{}"; echo -n "$url " && wp option get template_root --skip-plugins --url=$url || echo'
+        wp site list --field=url | xargs -I {} bash -c 'export url="{}"; echo -n "$url " && wp option get {{ item }} --skip-plugins --url=$url || echo'
       {% endif %}
     args:
       chdir: "{{ deploy_helper.current_path }}"
@@ -24,18 +24,21 @@
     changed_when: false
     failed_when: wp_template_root.stderr != ""
     when: update_wp_theme_paths | default(true) | bool
+    with_items:
+      - template_root
+      - stylesheet_root
 
   - name: Update WP theme paths
     command: >
-      wp option set {{ item[1] }}
-      {{ item[0] | regex_replace('.*' + deploy_helper.releases_path + '/[0-9]*(.*)', deploy_helper.new_release_path + '\1') }}
-      {% if project.multisite.enabled | default(false) %} --url={{ item[0].split(' ')[0] }}{% endif %}
+      wp option set {{ item[0].option }}
+      {{ item[1] | regex_replace('.*' + deploy_helper.releases_path + '/[0-9]*(.*)', deploy_helper.new_release_path + '\1') }}
+      {% if project.multisite.enabled | default(false) %} --url={{ item[1].split(' ')[0] }}{% endif %}
     args:
       chdir: "{{ deploy_helper.current_path }}"
     when: update_wp_theme_paths | default(true) | bool
-    with_nested:
-      - "{{ wp_template_root.stdout_lines | select('search', deploy_helper.releases_path) | list }}"
-      - ['template_root', 'stylesheet_root']
+    with_subelements:
+      - "[{% for result in wp_template_root.results %}{'option': '{{ result.item }}', 'stdout_lines': {{ result.stdout_lines | select('search', deploy_helper.releases_path) | list }}},{% endfor %}]"
+      - stdout_lines
 
   when: wp_installed | success
 


### PR DESCRIPTION
Followup to #840 and its history. Fixes https://discourse.roots.io/t/multisite-subsite-using-twentyfifteen-theme/9871/5

This PR enables Trellis deploys to update `template_root` and `stylesheet_root` WP options also for multisite subsites, not just the primary site.

Multisite operators that wish to disable all this (e.g., in order to avoid the processing time) may add `update_wp_theme_paths: false` somewhere in group_vars, or disable it on the fly:
```
ansible-playbook deploy.yml -e env=production -e site=example.com -e update_wp_theme_paths=false
```

Re: `xargs` etc, see also https://danielbachhuber.com/tip/run-wp-cli-command-wordpress-multisite/

Re: `bool` filter, it is necessary for proper interpretation of cli `-e update_wp_theme_paths=false` (otherwise the var remains a string "false" interpreted as boolean true).

No longer assumes that `template_root` and `stylesheet_root` are within a `.../web/wp/wp-content/themes` subdirectory of the `releases_directory` (although I don't know where else they'd be). 