### PR TITLE
Deploys: --skip-themes when updating WP template_root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Deploys: `--skip-themes` when updating WP `template_root` ([#849](https://github.com/roots/trellis/pull/849))
 * Option to install WP-CLI packages ([#837](https://github.com/roots/trellis/pull/837))
 * Update WP-CLI to 1.2.1 ([#838](https://github.com/roots/trellis/pull/838))
 * Auto-install Vagrant plugins ([#829](https://github.com/roots/trellis/pull/829))

--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -12,7 +12,7 @@
     when: project.update_db_on_deploy | default(update_db_on_deploy)
 
   - name: Get WP theme template root
-    command: wp option get template_root --skip-plugins
+    command: wp option get template_root --skip-plugins --skip-themes
     args:
       chdir: "{{ deploy_helper.current_path }}"
     register: wp_template_root


### PR DESCRIPTION
This PR is a piece of the former #848 and addresses https://discourse.roots.io/t/deploy-failing-at-task-deploy-get-wp-theme-template-root/10017

Some WP themes may throw errors if loaded in this context, e.g., some PHP classes may not be available with `--skip-plugins`. It is not necessary to load themes when updating WP options for `template_root` and `stylesheet_root`, so it is safer to `--skip-themes`.

Trellis already uses `--skip-themes` in conjunction with `--skip-plugins` in the [`WordPress Installed?`](https://github.com/roots/trellis/blob/2ae7cf189ff6305aa22226bfa1825881862d879e/roles/deploy/hooks/finalize-before.yml#L7-L8) task.