### PR TITLE
Accommodate child themes: Update WP stylesheet_root separately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Accommodate child themes: Update WP `stylesheet_root` separately ([#850](https://github.com/roots/trellis/pull/850))
 * Deploys: `--skip-themes` when updating WP `template_root` ([#849](https://github.com/roots/trellis/pull/849))
 * Option to install WP-CLI packages ([#837](https://github.com/roots/trellis/pull/837))
 * Update WP-CLI to 1.2.1 ([#838](https://github.com/roots/trellis/pull/838))

--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -11,22 +11,25 @@
       chdir: "{{ deploy_helper.current_path }}"
     when: project.update_db_on_deploy | default(update_db_on_deploy)
 
-  - name: Get WP theme template root
-    command: wp option get template_root --skip-plugins --skip-themes
+  - name: Get WP theme template and stylesheet roots
+    command: wp option get {{ item }} --skip-plugins --skip-themes
     args:
       chdir: "{{ deploy_helper.current_path }}"
     register: wp_template_root
     changed_when: false
     failed_when: wp_template_root.stderr != ""
+    with_items:
+      - template_root
+      - stylesheet_root
 
   - name: Update WP theme paths
-    command: wp option set {{ item }} {{ deploy_helper.new_release_path }}/web/wp/wp-content/themes
+    command: >
+      wp option set {{ item.item }}
+      {{ item.stdout | regex_replace(deploy_helper.releases_path + '/[^/]+(.*)', deploy_helper.new_release_path + '\1') }}
     args:
       chdir: "{{ deploy_helper.current_path }}"
-    when: deploy_helper.releases_path in wp_template_root.stdout
-    with_items:
-      - stylesheet_root
-      - template_root
+    when: deploy_helper.releases_path in item.stdout
+    with_items: "{{ wp_template_root.results }}"
 
   when: wp_installed | success
 


### PR DESCRIPTION
This PR is a piece of the former #848 and addresses https://discourse.roots.io/t/template-root-not-updated-by-env/9724

When a child theme is in Bedrock `web/app/themes` and its parent theme is in different directory (e.g., `web/wp/wp-content/themes`), `stylesheet_root` must be `/themes` while `template_root` should be updated with the latest deploy releases_path. Prior to this commit, `stylesheet_root` was always updated with `template_root`, causing problems for some child themes.

----

Regarding the `regex_replace`: Till now Trellis has assumed that if a `template_root`includes the releases path (e.g., /srv/www/example.com/releases) then we can replace the entire `template_root` using the new release path + `/web/wp/wp-content/themes`. Maybe that's a safe assumption, but at my level of familiarity, the only thing I feel safe saying is that "I know the release path portion can be replaced with the new release path, but I don't know about the rest of the path." 

That's why you'll notice that I made the following replacement (pseudo code):
```diff
- wp option set {{ <option> }} {{ deploy_helper.new_release_path }}/web/wp/wp-content/themes
+ wp option set {{ <option> }} <old_full_path> | regex_replace(releases_path + '/[^/]+(.*)', new_release_path + '\1')
```

The only weakness I can think of for this change is that it is less readable. Maybe someone who knows more will say that the original assumption was safe, implying that this change is unnecessary.