### PR TITLE
Fix Vagrantfile merge of ANSIBLE_VARS into ansible.extra_vars

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -115,7 +115,7 @@ Vagrant.configure('2') do |config|
 
     if vars = ENV['ANSIBLE_VARS']
       extra_vars = Hash[vars.split(',').map { |pair| pair.split('=') }]
-      ansible.extra_vars.merge(extra_vars)
+      ansible.extra_vars.merge!(extra_vars)
     end
   end
 


### PR DESCRIPTION
#549 introduced `ansible.extra_vars.merge(extra_vars)`.
This **returns** a new merged hash and the new hash was not captured in a new variable.

This PR fixes the merge to be the intended `merge!(extra_vars)` which actually **adds** the `extra_vars`.