### PR TITLE
Deploys: Update WP theme paths for multisite subsites

### DIFF
--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -1,5 +1,13 @@
 ---
 - block:
+  - name: Remove WordPress transient containing old release path
+    shell: "{{ project.multisite.enabled | default(false) | ternary('wp network meta delete 1', 'wp option delete') }} _site_transient_theme_roots ||:"
+    args:
+      chdir: "{{ deploy_helper.current_path }}"
+    register: site_transient_theme_roots
+    changed_when: site_transient_theme_roots.stdout != ''
+    when: update_wp_theme_paths | default(true) | bool
+
   - name: Update WP theme paths
     command: >
       wp option set {{ item[0].option }}

--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -1,33 +1,5 @@
 ---
 - block:
-  - name: Warn about updating network database.
-    debug:
-      msg: "Updating the network database could take a long time with a large number of sites."
-    when: project.update_db_on_deploy | default(update_db_on_deploy) and project.multisite.enabled | default(false)
-
-  - name: Update WP database
-    command: wp core update-db {{ project.multisite.enabled | default(false) | ternary('--network', '') }}
-    args:
-      chdir: "{{ deploy_helper.current_path }}"
-    when: project.update_db_on_deploy | default(update_db_on_deploy)
-
-  - name: Get WP theme template and stylesheet roots
-    shell: >
-      {% if not project.multisite.enabled | default(false) %}
-        wp option get {{ item }} --skip-plugins --skip-themes
-      {% else %}
-        wp site list --field=url | xargs -I {} bash -c 'export url="{}"; echo -n "$url " && wp option get {{ item }} --skip-plugins --skip-themes --url=$url || echo'
-      {% endif %}
-    args:
-      chdir: "{{ deploy_helper.current_path }}"
-    register: wp_template_root
-    changed_when: false
-    failed_when: wp_template_root.stderr != ""
-    when: update_wp_theme_paths | default(true) | bool
-    with_items:
-      - template_root
-      - stylesheet_root
-
   - name: Update WP theme paths
     command: >
       wp option set {{ item[0].option }}
@@ -39,6 +11,17 @@
     with_subelements:
       - "[{% for result in wp_template_root.results %}{'option': '{{ result.item }}', 'stdout_lines': {{ result.stdout_lines | select('search', deploy_helper.releases_path) | list }}},{% endfor %}]"
       - stdout_lines
+
+  - name: Warn about updating network database.
+    debug:
+      msg: "Updating the network database could take a long time with a large number of sites."
+    when: project.update_db_on_deploy | default(update_db_on_deploy) and project.multisite.enabled | default(false)
+
+  - name: Update WP database
+    command: wp core update-db {{ project.multisite.enabled | default(false) | ternary('--network', '') }}
+    args:
+      chdir: "{{ deploy_helper.current_path }}"
+    when: project.update_db_on_deploy | default(update_db_on_deploy)
 
   when: wp_installed | success
 

--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -12,24 +12,33 @@
     when: project.update_db_on_deploy | default(update_db_on_deploy)
 
   - name: Get WP theme template and stylesheet roots
-    command: wp option get {{ item }} --skip-plugins --skip-themes
+    shell: >
+      {% if not project.multisite.enabled | default(false) %}
+        wp option get {{ item }} --skip-plugins --skip-themes
+      {% else %}
+        wp site list --field=url | xargs -I {} bash -c 'export url="{}"; echo -n "$url " && wp option get {{ item }} --skip-plugins --skip-themes --url=$url || echo'
+      {% endif %}
     args:
       chdir: "{{ deploy_helper.current_path }}"
     register: wp_template_root
     changed_when: false
     failed_when: wp_template_root.stderr != ""
+    when: update_wp_theme_paths | default(true) | bool
     with_items:
       - template_root
       - stylesheet_root
 
   - name: Update WP theme paths
     command: >
-      wp option set {{ item.item }}
-      {{ item.stdout | regex_replace(deploy_helper.releases_path + '/[^/]+(.*)', deploy_helper.new_release_path + '\1') }}
+      wp option set {{ item[0].option }}
+      {{ item[1] | regex_replace('.*' + deploy_helper.releases_path + '/[^/]*(.*)', deploy_helper.new_release_path + '\1') }}
+      {% if project.multisite.enabled | default(false) %} --url={{ item[1].split(' ')[0] }}{% endif %}
     args:
       chdir: "{{ deploy_helper.current_path }}"
-    when: deploy_helper.releases_path in item.stdout
-    with_items: "{{ wp_template_root.results }}"
+    when: update_wp_theme_paths | default(true) | bool
+    with_subelements:
+      - "[{% for result in wp_template_root.results %}{'option': '{{ result.item }}', 'stdout_lines': {{ result.stdout_lines | select('search', deploy_helper.releases_path) | list }}},{% endfor %}]"
+      - stdout_lines
 
   when: wp_installed | success
 

--- a/roles/deploy/hooks/finalize-before.yml
+++ b/roles/deploy/hooks/finalize-before.yml
@@ -11,3 +11,22 @@
   register: wp_installed
   changed_when: false
   failed_when: wp_installed.stderr != ""
+
+- name: Get WP theme template and stylesheet roots
+  shell: >
+    {% if not project.multisite.enabled | default(false) %}
+      wp option get {{ item }} --skip-plugins --skip-themes
+    {% else %}
+      wp site list --field=url | xargs -I {} bash -c 'export url="{}"; echo -n "$url " && wp option get {{ item }} --skip-plugins --skip-themes --url=$url || echo'
+    {% endif %}
+  args:
+    chdir: "{{ deploy_helper.current_path }}"
+  register: wp_template_root
+  changed_when: false
+  failed_when: wp_template_root.stderr != ""
+  when:
+    - wp_installed | success
+    - update_wp_theme_paths | default(true) | bool
+  with_items:
+    - template_root
+    - stylesheet_root


### PR DESCRIPTION
This PR is the final piece of the former #848 and addresses https://discourse.roots.io/t/multisite-subsite-using-twentyfifteen-theme/9871/5. This PR enables Trellis deploys to update `template_root` and `stylesheet_root` WP options also for multisite subsites, not just the primary site.

**To disable:** Multisite operators who wish to avoid the processing time may define `update_wp_theme_paths: false` in a group_vars file or on the fly:

```
ansible-playbook deploy.yml -e env=production -e site=example.com -e update_wp_theme_paths=false
```

### Implementation notes
**`xargs` for multisite.** See also https://danielbachhuber.com/tip/run-wp-cli-command-wordpress-multisite/

**`bool` filter** is necessary for proper interpretation of cli `-e update_wp_theme_paths=false` (otherwise the var remains a string "false" interpreted as boolean true).

**[`select`](http://jinja.pocoo.org/docs/latest/templates/#select) statement** in [`with_subelements`](http://docs.ansible.com/ansible/latest/playbooks_loops.html#looping-over-subelements) limits the items executed instead of via the `when` condition. This prevents `skipped` output, which could otherwise be very lengthy if an installation has many subsites. Consider a multisite installation with only two sites. When one site is `changed` and one is `skipped`, this PR's output contains only this:
```
TASK [deploy : Update WP theme paths] *************************************************************
changed: [test] => (item=({'option': 'template_root'}, u'http://test2.example.test/ /srv/www/exampl
e.com/releases/20170730231750/web/wp/wp-content/themes'))

changed: [test] => (item=({'option': 'stylesheet_root'}, u'http://test2.example.test/ /srv/www/exam
ple.com/releases/20170730231750/web/wp/wp-content/themes'))
```

Compare output from using a `when` condition instead of the `select` statement in `with_subelements`: 
```
TASK [deploy : Update WP theme paths] *************************************************************
skipping: [test] => (item=({'_ansible_parsed': True, 'stderr_lines': [], '_ansible_item_result': Tr
ue, u'end': u'2017-07-30 23:18:16.665821', '_ansible_no_log': False, u'stdout': u'http://example.te
st/wp/ \nhttp://test2.example.test/ /srv/www/example.com/releases/20170730190452/web/wp/wp-content/
themes', u'cmd': u' wp site list --field=url | xargs -I {} bash -c \'export url="{}"; echo -n "$url
 " && wp option get template_root --skip-plugins --skip-themes --url=$url || echo\'\n ', u'rc': 0, 
'item': u'template_root', u'delta': u'0:00:01.619913', u'stderr': u'', u'changed': False, u'invocat
ion': {u'module_args': {u'warn': True, u'executable': None, u'chdir': u'/srv/www/example.com/curren
t', u'_raw_params': u' wp site list --field=url | xargs -I {} bash -c \'export url="{}"; echo -n "$
url " && wp option get template_root --skip-plugins --skip-themes --url=$url || echo\'\n ', u'remov
es': None, u'creates': None, u'_uses_shell': True}}, 'failed_when_result': False, u'start': u'2017-
07-30 23:18:15.045908', 'failed': False}, u'http://example.test/wp/ '))

changed: [test] => (item=({'_ansible_parsed': True, 'stderr_lines': [], '_ansible_item_result': Tru
e, u'end': u'2017-07-30 23:18:16.665821', '_ansible_no_log': False, u'stdout': u'http://example.tes
t/wp/ \nhttp://test2.example.test/ /srv/www/example.com/releases/20170730190452/web/wp/wp-content/t
hemes', u'cmd': u' wp site list --field=url | xargs -I {} bash -c \'export url="{}"; echo -n "$url 
" && wp option get template_root --skip-plugins --skip-themes --url=$url || echo\'\n ', u'rc': 0, '
item': u'template_root', u'delta': u'0:00:01.619913', u'stderr': u'', u'changed': False, u'invocati
on': {u'module_args': {u'warn': True, u'executable': None, u'chdir': u'/srv/www/example.com/current
', u'_raw_params': u' wp site list --field=url | xargs -I {} bash -c \'export url="{}"; echo -n "$u
rl " && wp option get template_root --skip-plugins --skip-themes --url=$url || echo\'\n ', u'remove
s': None, u'creates': None, u'_uses_shell': True}}, 'failed_when_result': False, u'start': u'2017-0
7-30 23:18:15.045908', 'failed': False}, u'http://test2.example.test/ /srv/www/example.com/releases
/20170730190452/web/wp/wp-content/themes'))

skipping: [test] => (item=({'_ansible_parsed': True, 'stderr_lines': [], '_ansible_item_result': Tr
ue, u'end': u'2017-07-30 23:18:19.421725', '_ansible_no_log': False, u'stdout': u'http://example.te
st/wp/ \nhttp://test2.example.test/ /srv/www/example.com/releases/20170730190452/web/wp/wp-content/
themes', u'cmd': u' wp site list --field=url | xargs -I {} bash -c \'export url="{}"; echo -n "$url 
" && wp option get stylesheet_root --skip-plugins --skip-themes --url=$url || echo\'\n ', u'rc': 0
, 'item': u'stylesheet_root', u'delta': u'0:00:01.708665', u'stderr': u'', u'changed': False, u'inv
ocation': {u'module_args': {u'warn': True, u'executable': None, u'chdir': '/srv/www/example.com/cu
rrent', u'_raw_params': u' wp site list --field=url | xargs -I {} bash -c \'export url="{}"; echo -
n "$url " && wp option get stylesheet_root --skip-plugins --skip-themes --url=$url || echo\'\n ', u
'removes': None, u'creates': None, u'_uses_shell': True}}, 'failed_when_result': False, u'start': u
'2017-07-30 23:18:17.713060', 'failed': False}, u'http://example.test/wp/ '))

changed: [test] => (item=({'_ansible_parsed': True, 'stderr_lines': [], '_ansible_item_result': Tru
e, u'end': u'2017-07-30 23:18:19.421725', '_ansible_no_log': False, u'stdout': u'http://example.tes
t/wp/ \nhttp://test2.example.test/ /srv/www/example.com/releases/20170730190452/web/wp/wp-content/t
hemes', u'cmd': u' wp site list --field=url | xargs -I {} bash -c \'export url="{}"; echo -n "$url 
" && wp option get stylesheet_root --skip-plugins --skip-themes --url=$url || echo\'\n ', u'rc': 0,
 'item': u'stylesheet_root', u'delta': u'0:00:01.708665', u'stderr': u'', u'changed': False, u'invo
cation': {u'module_args': {u'warn': True, u'executable': None, u'chdir': u'/srv/www/example.com/cur
rent', u'_raw_params': u' wp site list --field=url | xargs -I {} bash -c \'export url="{}"; echo -n
 "$url " && wp option get stylesheet_root --skip-plugins --skip-themes --url=$url || echo\'\n ', u
'removes': None, u'creates': None, u'_uses_shell': True}}, 'failed_when_result': False, u'start': u
'2017-07-30 23:18:17.713060', 'failed': False}, u'http://test2.example.test/ /srv/www/example.com/re
leases/20170730190452/web/wp/wp-content/themes'))
```
The above is for two sites only. Imagine output above for a multisite installation with 50+ subsites.