### PR TITLE
Nginx: Skip caching WP API

### DIFF
--- a/roles/wordpress-setup/defaults/main.yml
+++ b/roles/wordpress-setup/defaults/main.yml
@@ -14,7 +14,7 @@ hsts_preload: "{{ item.value.ssl.hsts_preload | default(nginx_hsts_preload) | te
 
 # Fastcgi cache params
 nginx_cache_duration: 30s
-nginx_skip_cache_uri: /wp-admin/|/xmlrpc.php|wp-.*.php|/feed/|index.php|sitemap(_index)?.xml
+nginx_skip_cache_uri: /wp-admin/|/wp-json/|/xmlrpc.php|wp-.*.php|/feed/|index.php|sitemap(_index)?.xml
 nginx_skip_cache_cookie: comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in
 
 # Nginx includes


### PR DESCRIPTION
## Submit a feature request or bug report

- [x] I've read the [guidelines for Contributing to Roots Projects](https://github.com/roots/guidelines/blob/master/CONTRIBUTING.md)
- [ ] This is a feature request
- [ ] This is a bug report
- [x] This request isn't a duplicate of an [existing issue](https://github.com/roots/trellis/issues)
- [x] I've read the [docs](https://roots.io/trellis/docs) and followed them (if applicable)
- [x] This is not a personal support request that should be posted on the [Roots Discourse](https://discourse.roots.io/c/trellis) forums

Replace any `X` with your information.

---

**What is the current behavior?**

Nginx caches WP API responses and serving them to everyone without checking authorizations.


**What is the expected or desired behavior?**

Nginx should skip caching WP API responses
