### PR TITLE
Load modules-enabled config files

### DIFF
--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -3,6 +3,10 @@
 # nginx Configuration File
 # http://wiki.nginx.org/Configuration
 
+{% block modules_enabled -%}
+include modules-enabled/*.conf;
+{% endblock %}
+
 {% block user %}
 # Run as a less privileged user for security reasons.
 user {{ nginx_user }};


### PR DESCRIPTION
The nginx package was updated earlier this year to include
`modules-available` and `modules-enabled` directories in `/etc/nginx`.

This adds loading of conf files from modules-enabled to the top of
the trellis nginx.conf (in a new `modules_enabled` block).