### PR TITLE
Add fastcgi_read_timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Add `fastcgi_read_timeout` to Nginx config ([#860](https://github.com/roots/trellis/pull/860))
 * Accommodate child themes: Update WP `stylesheet_root` separately ([#850](https://github.com/roots/trellis/pull/850))
 * Deploys: `--skip-themes` when updating WP `template_root` ([#849](https://github.com/roots/trellis/pull/849))
 * Option to install WP-CLI packages ([#837](https://github.com/roots/trellis/pull/837))

--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -7,7 +7,7 @@ nginx_logs_root: /var/log/nginx
 nginx_user: www-data
 nginx_fastcgi_buffers: 8 8k
 nginx_fastcgi_buffer_size: 8k
-nginx_fastcgi_read_timeout: 60s
+nginx_fastcgi_read_timeout: 120s
 nginx_sites_confs:
   - src: no-default.conf.j2
 

--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -7,6 +7,7 @@ nginx_logs_root: /var/log/nginx
 nginx_user: www-data
 nginx_fastcgi_buffers: 8 8k
 nginx_fastcgi_buffer_size: 8k
+nginx_fastcgi_read_timeout: 60s
 nginx_sites_confs:
   - src: no-default.conf.j2
 

--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -55,6 +55,7 @@ http {
   # Setup the fastcgi cache.
   fastcgi_buffers {{ nginx_fastcgi_buffers }};
   fastcgi_buffer_size {{ nginx_fastcgi_buffer_size }};
+  fastcgi_read_timeout {{ nginx_fastcgi_read_timeout }};
   fastcgi_cache_path {{ nginx_cache_path }} levels=1:2 keys_zone=wordpress:{{ nginx_cache_key_storage_size }} max_size={{ nginx_cache_size }} inactive={{ nginx_cache_inactive }};
   fastcgi_cache_use_stale updating error timeout invalid_header http_500;
   fastcgi_cache_lock on;


### PR DESCRIPTION
ran into a problem when importing a media library with ~300 items and wordpress kept timing out despite upping 

* php_max_execution_time
* php_max_input_time
* php_max_input_vars
* php_memory_limit
* fastcgi_buffers
* fastcgi_buffer_size

ended up needing to add `fastcgi_read_timeout`. ~~this PR includes the [default nginx value](http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_read_timeout) of `60s`~~ matched the value to `php_max_execution_time` after a chat with the team