### PR TITLE
Only include *.conf files in sites-enabled/

### DIFF
--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -169,6 +169,6 @@ http {
   {% endblock %}
 
   {% block sites_enabled -%}
-  include sites-enabled/*;
+  include sites-enabled/*.conf;
   {% endblock %}
 }


### PR DESCRIPTION
If for any reason you need to backup a host (i.e `mv website.com.conf website.com.conf.bak`) then this allow you to name it anything that doesn't end in `.conf`.