### PR TITLE
Nginx: Compile dynamic modules

### DIFF
--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -16,3 +16,19 @@ nginx_cache_path: /var/cache/nginx
 nginx_cache_key_storage_size: 10m
 nginx_cache_size: 250m
 nginx_cache_inactive: 1h
+
+# Dynamic modules
+# Reserved for future Trellis. Don't change!
+nginx_dynamic_modules_default: {}
+
+# Exmaple:
+# nginx_dynamic_modules_custom:
+#   ngx_brotli:
+#     repo: "https://github.com/google/ngx_brotli.git"
+#     version: bfd2885b2da4d763fed18f49216bb935223cd34b
+#     objs:
+#       - ngx_http_brotli_filter_module.so
+#       - ngx_http_brotli_static_module.so
+nginx_dynamic_modules_custom: {}
+
+nginx_dynamic_modules: "{{ nginx_dynamic_modules_default | combine(nginx_dynamic_modules_custom) }}"

--- a/roles/nginx/tasks/dynamic-modules.yml
+++ b/roles/nginx/tasks/dynamic-modules.yml
@@ -1,0 +1,39 @@
+---
+- name: Find Nginx version
+  shell: nginx -v 2>&1 | awk -F/ '{print $2}'
+  register: nginx_version_raw
+
+- name: Find Nginx configure options
+  shell: "nginx -V 2>&1 | awk -F: '$1==\"configure arguments\"{print $2;exit;}'"
+  register: nginx_configure_options_raw
+
+- name: Set Fact -- Nginx dynamic modules
+  set_fact:
+    nginx_source_path: "/opt/{{ nginx_package }}-{{ nginx_version_raw.stdout }}"
+    nginx_configure_options: "{{ nginx_configure_options_raw.stdout.split(' --')|reject('search','add-dynamic-module=')|list|join(' --') }}"
+
+- name: Install Nginx build dependencies
+  apt:
+    name: "{{ nginx_package }}"
+    state: build-dep
+    force: yes
+
+- name: Grab Nginx source
+  shell: "apt-get source {{ nginx_package }}"
+  args:
+    chdir: /opt
+
+- name: Configure dynamic modules
+  shell: "./configure {{ nginx_configure_options }} --add-dynamic-module=../{{ nginx_dynamic_modules.keys()|join(' --add-dynamic-module=../') }}"
+  args:
+    chdir: "{{ nginx_source_path }}"
+
+- name: Compile dynamic modules
+  shell: make modules
+  args:
+    chdir: "{{ nginx_source_path }}"
+
+- name:  Create 60-dynamic-modules.conf
+  template:
+    src: dynamic-modules.conf.j2
+    dest: "{{ nginx_path }}/modules-available/60-dynamic-modules.conf"

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -1,14 +1,34 @@
 ---
 - name: Add Nginx PPA
-  apt_repository:
-    repo: "{{ nginx_ppa }}"
-    update_cache: yes
+  shell: "add-apt-repository --enable-source {{ nginx_ppa }}"
 
 - name: Install Nginx
   apt:
     name: "{{ nginx_package }}"
     state: present
     force: yes
+    update_cache: yes
+  register: nginx
+
+- name: Grab dynamic module sources
+  git:
+    repo: "{{ item.value.repo }}"
+    dest: "/opt/{{ item.key }}"
+    version: "{{ item.value.version | default(omit) }}"
+    force: yes
+  with_dict: "{{ nginx_dynamic_modules }}"
+  register: nginx_dynamic_module_sources
+
+- include: dynamic-modules.yml
+  when: nginx_dynamic_modules and (nginx_dynamic_module_sources.changed or nginx.changed)
+
+- name: Enable or disable dynamic modules
+  file:
+    path: "{{ nginx_path }}/modules-enabled/60-dynamic-modules.conf"
+    src: "{{ nginx_path }}/modules-available/60-dynamic-modules.conf"
+    state: "{{ nginx_dynamic_modules | ternary('link', 'absent') }}"
+    force: yes
+  notify: reload nginx
 
 - name: Create SSL directory
   file:

--- a/roles/nginx/templates/dynamic-modules.conf.j2
+++ b/roles/nginx/templates/dynamic-modules.conf.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+
+{% for obj in ( nginx_dynamic_modules | json_query('*.objs') | sum(start = []) ) %}
+load_module {{ nginx_source_path }}/objs/{{ obj }};
+{% endfor %}


### PR DESCRIPTION
Note:
- it doesn't compile or install Nginx
- it assumes dynamic module sources are git repos
- it recompiles if Nginx version or dynamic module repos changed
- it skips when `nginx_dynamic_modules` is empty

Usage (see #867): 
```yaml
# group_vars/all/main.yml
nginx_dynamic_modules:
  ngx_brotli:
    repo: https://github.com/google/ngx_brotli.git
    objs:
      - ngx_http_brotli_filter_module.so
      - ngx_http_brotli_static_module.so
```

Related: #863
