### PR TITLE
WordPress Setup: Add Nginx ssl_client_certificate

### DIFF
--- a/roles/wordpress-setup/tasks/main.yml
+++ b/roles/wordpress-setup/tasks/main.yml
@@ -3,6 +3,8 @@
   tags: wordpress-setup-database
 - include: self-signed-certificate.yml
   tags: wordpress-setup-self-signed-certificate
+- include: nginx-client-cert.yml
+  tags: wordpress-setup-nginx-client-cert
 
 - name: Create web root
   file:

--- a/roles/wordpress-setup/tasks/nginx-client-cert.yml
+++ b/roles/wordpress-setup/tasks/nginx-client-cert.yml
@@ -1,0 +1,8 @@
+---
+- name: Download client cert
+  get_url:
+    url: "{{ item.value.ssl.client_cert_url }}"
+    dest: "{{ nginx_ssl_path }}/client-{{ (item.value.ssl.client_cert_url | hash('md5'))[:7] }}.crt"
+    mode: 0640
+  with_dict: "{{ wordpress_sites }}"
+  when: ssl_enabled and item.value.ssl.client_cert_url is defined

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -80,6 +80,11 @@ server {
 
   add_header Strict-Transport-Security "max-age={{ [hsts_max_age, hsts_include_subdomains, hsts_preload] | reject('none') | join('; ') }}";
 
+  {% if item.value.ssl.client_cert_url is defined -%}
+  ssl_verify_client       on;
+  ssl_client_certificate  {{ nginx_ssl_path }}/client-{{ (item.value.ssl.client_cert_url | hash('md5'))[:7] }}.crt;
+  {% endif -%}
+
   {% if item.value.ssl.provider | default('manual') == 'manual' and item.value.ssl.cert is defined and item.value.ssl.key is defined -%}
   ssl_certificate         {{ nginx_path }}/ssl/{{ item.value.ssl.cert | basename }};
   ssl_certificate_key     {{ nginx_path }}/ssl/{{ item.value.ssl.key | basename }};


### PR DESCRIPTION
Usage:
```yaml
wordpress_sites:
  example.com:
    site_hosts:
      - canonical: example.com
    ssl:
      enabled: true
      provider: self-signed
      client_cert_url: 'https://support.cloudflare.com/hc/en-us/article_attachments/201243967/origin-pull-ca.pem'
```

See: 
- https://support.cloudflare.com/hc/en-us/articles/204494148-Setting-up-NGINX-to-use-TLS-Authenticated-Origin-Pulls
- https://blog.cloudflare.com/protecting-the-origin-with-tls-authenticated-origin-pulls/