### PR TITLE
New ssl provider: cloudflare-origin-ca

### DIFF
--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -7,6 +7,7 @@ ntp_manage_config: true
 www_root: /srv/www
 ip_whitelist:
   - "{{ (env == 'development') | ternary(ansible_default_ipv4.gateway, ipify_public_ip | default('')) }}"
+cloudflare_origin_ca_api_key: "{{ vault_cloudflare_origin_ca_api_key }}" # Define this variable in group_vars/all/vault.yml
 
 # Values of raw_vars will be wrapped in `{% raw %}` to avoid templating problems if values include `{%` and `{{`.
 # Will recurse dicts/lists. `*` is wildcard for one or more dict keys, list indices, or strings. Example:
@@ -18,3 +19,4 @@ raw_vars:
   - vault_users.*.password
   - vault_users.*.salt
   - vault_wordpress_sites
+  - vault_cloudflare_origin_ca_api_key

--- a/group_vars/all/vault.yml
+++ b/group_vars/all/vault.yml
@@ -1,2 +1,3 @@
 # Documentation: https://roots.io/trellis/docs/vault/
 vault_mail_password: smtp_password
+vault_cloudflare_origin_ca_api_key: example_api_key

--- a/roles/wordpress-setup/tasks/cloudflare-origin-ca.yml
+++ b/roles/wordpress-setup/tasks/cloudflare-origin-ca.yml
@@ -1,0 +1,37 @@
+---
+- name: Add Cloudflare key
+  apt_key:
+    url: 'https://pkg.cloudflare.com/pubkey.gpg'
+
+- name: Add Cloudflare PPA
+  apt_repository:
+    repo: 'deb http://pkg.cloudflare.com/ xenial main'
+    update_cache: yes
+
+- name: Install CFCA
+  apt:
+    name: cfca
+    state: present
+    force: yes
+
+- name: Create directoriy and set permission
+  file:
+    path: "{{ nginx_ssl_path }}/cloudflare-origin-ca"
+    mode: 0700
+    state: directory
+
+- name: Generate Cloudflare Origin CA
+  shell: "cfca getcert \
+    -hostnames {{ site_hosts | union(multisite_subdomains_wildcards) | join(',') }} \
+    -key-out {{ item.key | quote }}.key \
+    -certificate-out {{ item.key | quote }}.pem"
+  args:
+    executable: "/bin/bash"
+    chdir: "{{ nginx_ssl_path }}/cloudflare-origin-ca"
+    creates: "{{ item.key }}.*"
+  environment:
+    CF_API_KEY: "{{ cloudflare_origin_ca_api_key }}"
+  no_log: true
+  with_dict: "{{ wordpress_sites }}"
+  when: ssl_enabled and item.value.ssl.provider | default('manual') == 'cloudflare-origin-ca'
+  notify: reload nginx

--- a/roles/wordpress-setup/tasks/main.yml
+++ b/roles/wordpress-setup/tasks/main.yml
@@ -3,6 +3,9 @@
   tags: wordpress-setup-database
 - include: self-signed-certificate.yml
   tags: wordpress-setup-self-signed-certificate
+- include: cloudflare-origin-ca.yml
+  when: '"cloudflare-origin-ca" in wordpress_sites|json_query("*.ssl.provider")'
+  tags: wordpress-setup-cloudflare-origin-ca
 
 - name: Create web root
   file:

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -83,6 +83,10 @@ server {
   ssl_certificate         {{ nginx_path }}/ssl/letsencrypt/{{ item.key }}-{{ letsencrypt_cert_ids[item.key] }}-bundled.cert;
   ssl_certificate_key     {{ nginx_path }}/ssl/letsencrypt/{{ item.key }}.key;
 
+  {% elif item.value.ssl.provider | default('manual') == 'cloudflare-origin-ca' -%}
+  ssl_certificate         {{ nginx_path }}/ssl/cloudflare-origin-ca/{{ item.key }}.pem;
+  ssl_certificate_key     {{ nginx_path }}/ssl/cloudflare-origin-ca/{{ item.key }}.key;
+
   {% elif item.value.ssl.provider | default('manual') == 'self-signed' -%}
   ssl_certificate         {{ nginx_path }}/ssl/{{ item.key }}.cert;
   ssl_trusted_certificate {{ nginx_path }}/ssl/{{ item.key }}.cert;


### PR DESCRIPTION
Usage:
```yaml
vault_cloudflare_origin_ca_api_key: 'my_api_key'

wordpress_sites:
  example.com:
    site_hosts:
      - canonical: example.com
        redirects:
          - hi.example.com
          - bye.example.com
    ssl:
      enabled: true
      provider: cloudflare-origin-ca
```

This will generate and upload (to Cloudflare) a cert for `example.com,hi.example.com,bye.example.com`

This is [Origin CA](https://blog.cloudflare.com/cloudflare-ca-encryption-origin/) not [Universal SSL](https://blog.cloudflare.com/introducing-universal-ssl/)

close #868 