### PR TITLE
Update wp-cli to 1.3.0

### DIFF
--- a/roles/wp-cli/defaults/main.yml
+++ b/roles/wp-cli/defaults/main.yml
@@ -1,4 +1,4 @@
-wp_cli_version: 1.2.1
+wp_cli_version: 1.3.0
 wp_cli_bin_path: /usr/bin/wp
 wp_cli_phar_url: "https://github.com/wp-cli/wp-cli/releases/download/v{{ wp_cli_version }}/wp-cli-{{ wp_cli_version }}.phar"
 wp_cli_completion_url: "https://raw.githubusercontent.com/wp-cli/wp-cli/v{{ wp_cli_version }}/utils/wp-completion.bash"


### PR DESCRIPTION
Version 1.3.0 released on 08 Aug 2017
https://make.wordpress.org/cli/2017/08/08/version-1-3-0-released/