### PR TITLE
Update ansible galaxy roles

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,10 +1,10 @@
 - name: composer
   src: geerlingguy.composer
-  version: 1.5.0
+  version: 1.6.1
 
 - name: ntp
   src: geerlingguy.ntp
-  version: 1.3.0
+  version: 1.5.2
 
 - name: logrotate
   src: nickhammond.logrotate
@@ -12,11 +12,8 @@
 
 - name: swapfile
   src: kamaln7.swapfile
-  version: 0.4
-
-- src: geerlingguy.daemonize
-  version: 1.1.1
+  version: 4850d8a
 
 - name: mailhog
   src: geerlingguy.mailhog
-  version: 2.1.0
+  version: 2.1.3


### PR DESCRIPTION
`geerlingguy.daemonize` is removed because:
- trellis doesn't use it directly
- `geerlingguy.mailhog` marked it as a dependency

https://github.com/geerlingguy/ansible-role-mailhog/blob/f7c4603eee04803b9cda7c0ba911c2a49ed2d75f/meta/main.yml#L3