### PR TITLE
Nginx Site Template: Make ssl-stapling.conf optional

### DIFF
--- a/group_vars/all/helpers.yml
+++ b/group_vars/all/helpers.yml
@@ -15,4 +15,5 @@ site_hosts_redirects: "{{ item.value.site_hosts | selectattr('redirects', 'defin
 site_hosts: "{{ site_hosts_canonical | union(site_hosts_redirects) }}"
 multisite_subdomains_wildcards: "{{ item.value.multisite.subdomains | default(false) | ternary( site_hosts_canonical | map('regex_replace', '^(www\\.)?(.*)$', '*.\\2') | list, [] ) }}"
 ssl_enabled: "{{ item.value.ssl is defined and item.value.ssl.enabled | default(false) }}"
+ssl_stapling_enabled: "{{ item.value.ssl is defined and item.value.ssl.stapling_enabled | default(true) }}"
 cron_enabled: "{{ site_env.disable_wp_cron and (not item.value.multisite.enabled | default(false) or (item.value.multisite.enabled | default(false) and item.value.multisite.cron | default(true))) }}"

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -68,7 +68,9 @@ server {
   {% if ssl_enabled -%}
   # SSL configuration
   include h5bp/directive-only/ssl.conf;
+  {% if ssl_stapling_enabled -%}
   include h5bp/directive-only/ssl-stapling.conf;
+  {% endif -%}
 
   ssl_dhparam /etc/nginx/ssl/dhparams.pem;
   ssl_buffer_size 1400; # 1400 bytes to fit in one MTU


### PR DESCRIPTION
Because SSL stapling can't be used with [Trellis Cloudflare Origin CA](https://www.typist.tech/projects/trellis-cloudflare-origin-ca)

> It sounds like you're trying to staple OCSP responses with Origin CA. Right now OCSP is not supported with Origin CA, so you should remove the ssl_staping directive for the host that you're using the Origin CA cert on.
> --- Cloudflare Support