### PR TITLE
Nginx: Include includes.d/http/*.conf

### DIFF
--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -199,6 +199,10 @@ http {
   # a specific directory, or on an individual server{} level.
   # gzip_static on;
   {% endblock %}
+  
+  {% block http_includes_d -%}
+  include includes.d/http/*.conf;
+  {% endblock -%}
 
   {% block sites_enabled -%}
   # Include files in the sites-enabled folder. server{} configuration files should be


### PR DESCRIPTION
Allow third party galaxy roles to inject configuration to http block