### PR TITLE
Ensure updated H5BP nginx includes sync into place

### DIFF
--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -33,7 +33,7 @@
     force: yes
 
 - name: Move h5bp configs
-  command: rsync -ac --info=NAME {{ nginx_path }}/h5bp-server-configs/h5bp/ {{ nginx_path }}/h5bp
+  command: rsync -ac --delete --info=NAME {{ nginx_path }}/h5bp-server-configs/h5bp/ {{ nginx_path }}/h5bp
   register: h5bp_nginx_sync
   changed_when: h5bp_nginx_sync.stdout != ''
   notify: reload nginx

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -33,9 +33,10 @@
     force: yes
 
 - name: Move h5bp configs
-  command: cp -R {{ nginx_path }}/h5bp-server-configs/h5bp {{ nginx_path }}/h5bp
-  args:
-    creates: "{{ nginx_path }}/h5bp/"
+  command: rsync -ac --info=NAME {{ nginx_path }}/h5bp-server-configs/h5bp/ {{ nginx_path }}/h5bp
+  register: h5bp_nginx_sync
+  changed_when: h5bp_nginx_sync.stdout != ''
+  notify: reload nginx
 
 - name: Create nginx.conf
   template:


### PR DESCRIPTION
When outdated h5bp nginx confs are already in place, the former `cp` will not copy updated confs into place due to `creates: "{{ nginx_path }}/h5bp/"` (prevents the `cp` because destination already exists).

This PR uses `rsync` to update the confs when necessary while remaining idempotent.

Consider an existing server that applies the recent H5BP Nginx update from #876. The git task would pull down the latest confs, but the new confs would not be copied into place. Without this PR's fix, users would likely see an error like the following after reprovisioning:

```
RUNNING HANDLER [common : reload nginx] *******************************************************************
nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
nginx: [emerg] open() "/usr/share/nginx/logs/static.log" failed (2: No such
file or directory)
nginx: configuration file /etc/nginx/nginx.conf test failed
fatal: [162.243.128.213]: FAILED!
```

This happens because prior to #876, Trellis did not include `expires.conf` but [now it does by default](https://github.com/roots/trellis/blob/e7447ac0649786c6e37df8fc816a3cd19598a7db/roles/wordpress-setup/defaults/main.yml#L35) on staging and production. The old version of `expires.conf` on the server would still have the `access_log logs/static.log;` removed in h5bp/server-configs-nginx@b8fdd45. This PR's rsync approach will update the `expires.conf`, avoiding the error above.