### PR TITLE
Re-enable IPv4 connections in Nginx no-default.conf

### DIFF
--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -57,6 +57,7 @@
     dest: "{{ nginx_path }}/sites-available/{{ item.src | basename | regex_replace('.j2$', '') }}"
   with_items: "{{ nginx_sites_confs }}"
   when: item.enabled | default(true)
+  notify: reload nginx
   tags: nginx-sites
 
 - name: Enable or disable Nginx sites

--- a/roles/nginx/templates/no-default.conf.j2
+++ b/roles/nginx/templates/no-default.conf.j2
@@ -8,6 +8,7 @@
 # returning 444 "no response".
 
 server {
-  listen [::]:80 default_server;
+  listen [::]:80 default_server deferred;
+  listen 80 default_server deferred;
   return 444;
 }


### PR DESCRIPTION
### Multiple listen directives
It appears Ubuntu doesn't support dual-stack sockets (single socket serving both IPv4 and IPv6), even with `ipv6only=off` parameter for `listen`. Separate listen directives are necessary for `no-default.conf` to serve IPv4 and IPv6 connections to unknown hosts. Discussion at [h5bp/server-configs-nginx#179](https://github.com/h5bp/server-configs-nginx/pull/179#issuecomment-328713502) (comment).

### deferred parameter
This PR also adds the `deferred` parameter to enable deferred `accept()` (the `TCP_DEFER_ACCEPT` socket option) to streamline usage of server processes. Here is the [best description](https://unix.stackexchange.com/a/94120) I found.

Note that `deferred` is one of the "additional parameters ... [that can be applied] only once for a given `address:port` pair" ([Nginx docs](http://nginx.org/en/docs/http/ngx_http_core_module.html#listen)). For this reason it should be applied only in the `no-default.conf`. If `deferred` were also applied for [WordPress vhosts](https://github.com/roots/trellis/blob/ec9324ccbc1910115d382d0559784824084d683f/roles/wordpress-setup/templates/wordpress-site.conf.j2#L7-L8), Nginx would fail to reload: `nginx: [emerg] duplicate listen options for` socket ([example discussion](https://serverfault.com/a/277667/221368)). 

### Testing IPv6
Of course, to test IPv6, one's local machine and server must both enable IPv6. For Trellis to make IPv6 SSH connections (e.g., to run a playbook), adjust the [ListenAdresses](https://github.com/roots/trellis/blob/ec9324ccbc1910115d382d0559784824084d683f/roles/sshd/defaults/main.yml#L9-L10) and [AddressFamily](https://github.com/roots/trellis/blob/ec9324ccbc1910115d382d0559784824084d683f/roles/sshd/defaults/main.yml#L16):

```diff
 sshd_listen_addresses:
   - 0.0.0.0
+  - '::'

-sshd_address_family: inet
+sshd_address_family: any
```

⚠️ **Trellis is not ready for IPv6 in production**. There are no `ip6tables` settings.