### PR TITLE
Add `update_cache: true` to `apt` tasks

### DIFF
--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -8,6 +8,8 @@
   apt:
     name: "{{ nginx_package }}"
     state: present
+    update_cache: true
+    cache_valid_time: "{{ apt_cache_valid_time }}"
     force: yes
 
 - name: Create SSL directory

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -8,6 +8,8 @@
   apt:
     name: "{{ item }}"
     state: present
+    update_cache: true
+    cache_valid_time: "{{ apt_cache_valid_time }}"
     force: yes
   with_items: "{{ php_extensions }}"
 


### PR DESCRIPTION
Because `apt_repository` tasks skip `apt-get update` if repo is already added.

This patch changes nothing if `state: present` but necessary for `state: latest`

Question: Do we actually need `force: yes` in `apt` tasks?