### PR TITLE
Redirect directly to https canonical domain

### DIFF
--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -196,7 +196,7 @@ server {
 server {
   listen [::]:80;
   listen 80;
-  server_name {{ site_hosts | union(multisite_subdomains_wildcards) | join(' ') }};
+  server_name {{ site_hosts_canonical | union(multisite_subdomains_wildcards) | join(' ') }};
 
   {{ self.acme_challenge() -}}
 
@@ -216,8 +216,12 @@ server {
 {% endif %}
 {% for host in item.value.site_hosts if host.redirects | default([]) %}
 server {
-  listen {{ ssl_enabled | ternary('[::]:443 ssl http2', '[::]:80') }};
-  listen {{ ssl_enabled | ternary('443 ssl http2', '80') }};
+  {% if ssl_enabled -%}
+  listen [::]:443 ssl http2;
+  listen 443 ssl http2;
+  {% endif -%}
+  listen [::]:80;
+  listen 80;
   server_name {{ host.redirects | join(' ') }};
 
   {{ self.https() -}}
@@ -226,7 +230,9 @@ server {
 
   {{ self.includes_d() -}}
 
-  return 301 $scheme://{{ host.canonical }}$request_uri;
+  location / {
+    return 301 {{ ssl_enabled | ternary('https', 'http') }}://{{ host.canonical }}$request_uri;
+  }
 }
 {% endfor %}
 {% endblock %}


### PR DESCRIPTION
Fixes https://discourse.roots.io/t/secure-non-secure-www-non-www-redirects/10420/2

`http://www.xyz.com -> http://xyz.com -> https://xyz.com`
becomes simply `http://www.xyz.com -> https://xyz.com`.

Also moves `return 301` directive back into `location` block so that it will run only if acme challenge `location` is not matched. Otherwise Let's Encrypt validation in this `server` block fails due to redirect.