### PR TITLE
Extract Trellis::Config

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,7 @@ ensure_plugins(vconfig.fetch('vagrant_plugins')) if vconfig.fetch('vagrant_insta
 
 trellis_config = Trellis::Config.new(root_path: ANSIBLE_PATH)
 
-Vagrant.require_version '>= 1.8.5'
+Vagrant.require_version '>= 1.9.6'
 
 Vagrant.configure('2') do |config|
   config.vm.box = vconfig.fetch('vagrant_box')

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,7 @@ ensure_plugins(vconfig.fetch('vagrant_plugins')) if vconfig.fetch('vagrant_insta
 
 trellis_config = Trellis::Config.new(root_path: ANSIBLE_PATH)
 
-Vagrant.require_version '>= 1.9.6'
+Vagrant.require_version '>= 1.8.5'
 
 Vagrant.configure('2') do |config|
   config.vm.box = vconfig.fetch('vagrant_box')

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,7 @@ Vagrant.configure('2') do |config|
   # Required for NFS to work
   config.vm.network :private_network, ip: vconfig.fetch('vagrant_ip'), hostsupdater: 'skip'
 
-  main_hostname, *hostnames = trellis_config.canonicals
+  main_hostname, *hostnames = trellis_config.site_hosts_canonical
   config.vm.hostname = main_hostname
 
   if Vagrant.has_plugin?('vagrant-hostmanager') && !trellis_config.multisite_subdomains?

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,7 +38,7 @@ Vagrant.configure('2') do |config|
   config.vm.hostname = main_hostname
 
   if Vagrant.has_plugin?('vagrant-hostmanager') && !trellis_config.multisite_subdomains?
-    redirects = trellis_config.redirects
+    redirects = trellis_config.site_hosts_redirects
 
     config.hostmanager.enabled = true
     config.hostmanager.manage_host = true

--- a/lib/trellis/config.rb
+++ b/lib/trellis/config.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'vagrant'
+require 'yaml'
+
+module Trellis
+  class Config
+    def initialize(root_path:)
+      @root_path = root_path
+    end
+
+    def multisite_subdomains?
+      @using_multisite_subdomains ||= begin
+        wordpress_sites.any? do |(_name, site)|
+          site.dig('multisite', 'enabled') && site.dig('multisite', 'subdomains')
+        end
+      end
+    end
+
+    def canonicals
+      @canonicals ||= site_hosts.map { |host| host['canonical'] }
+    end
+
+    def redirects
+      @redirects ||= site_hosts.flat_map { |host| host['redirects'] }.compact
+    end
+
+    def site_hosts
+      @site_hosts ||= begin
+        wordpress_sites.flat_map { |(_name, site)| site['site_hosts'] }.tap do |hosts|
+          fail_with message: template_content if malformed?(site_hosts: hosts)
+        end
+      end
+    end
+
+    def wordpress_sites
+      @wordpress_sites ||= begin
+        content['wordpress_sites'].tap do |sites|
+          fail_with message: "No sites found in #{path}." if sites.to_h.empty?
+        end
+      end
+    end
+
+    def content
+      @content ||= begin
+        fail_with message: "#{path} was not found. Please check `root_path`." unless exist?
+        YAML.load_file(path)
+      end
+    end
+
+    private
+
+    def malformed?(site_hosts:)
+      site_hosts.any? do |host|
+        !host.is_a?(Hash) || !host.key?('canonical')
+      end
+    end
+
+    def exist?
+      File.exist?(path)
+    end
+
+    def path
+      File.join(@root_path, 'group_vars', 'development', 'wordpress_sites.yml')
+    end
+
+    def template_content
+      File.read(File.join(@root_path, 'roles', 'common', 'templates', 'site_hosts.j2')).sub!('{{ env }}', 'development').gsub!(/com$/, 'dev')
+    end
+
+    def fail_with(message:)
+      raise Vagrant::Errors::VagrantError.new, message
+    end
+  end
+end

--- a/lib/trellis/config.rb
+++ b/lib/trellis/config.rb
@@ -17,8 +17,8 @@ module Trellis
       end
     end
 
-    def canonicals
-      @canonicals ||= site_hosts.map { |host| host['canonical'] }
+    def site_hosts_canonical
+      @site_hosts_canonical ||= site_hosts.map { |host| host['canonical'] }
     end
 
     def site_hosts_redirects

--- a/lib/trellis/config.rb
+++ b/lib/trellis/config.rb
@@ -21,8 +21,8 @@ module Trellis
       @canonicals ||= site_hosts.map { |host| host['canonical'] }
     end
 
-    def redirects
-      @redirects ||= site_hosts.flat_map { |host| host['redirects'] }.compact
+    def site_hosts_redirects
+      @site_hosts_redirects ||= site_hosts.flat_map { |host| host['redirects'] }.compact
     end
 
     def site_hosts

--- a/lib/trellis/config.rb
+++ b/lib/trellis/config.rb
@@ -12,7 +12,7 @@ module Trellis
     def multisite_subdomains?
       @using_multisite_subdomains ||= begin
         wordpress_sites.any? do |(_name, site)|
-          site.dig('multisite', 'enabled') && site.dig('multisite', 'subdomains')
+          site['multisite']&.fetch('enabled', false) && site['multisite']&.fetch('subdomains', false)
         end
       end
     end

--- a/lib/trellis/vagrant.rb
+++ b/lib/trellis/vagrant.rb
@@ -37,43 +37,12 @@ def fail_with_message(msg)
   fail Vagrant::Errors::VagrantError.new, msg
 end
 
-def hosts(sites)
-  site_hosts = sites.flat_map { |(_name, site)| site['site_hosts'] }
-
-  site_hosts.each do |host|
-    if !host.is_a?(Hash) || !host.has_key?('canonical')
-      fail_with_message File.read(File.join(ANSIBLE_PATH, 'roles/common/templates/site_hosts.j2')).sub!('{{ env }}', 'development').gsub!(/com$/, 'dev')
-    end
-  end
-
-  site_hosts
-end
-
-def load_wordpress_sites
-  config_file = File.join(ANSIBLE_PATH, 'group_vars', 'development', 'wordpress_sites.yml')
-
-  if File.exists?(config_file)
-    wordpress_sites = YAML.load_file(config_file)['wordpress_sites']
-    fail_with_message "No sites found in #{config_file}." if wordpress_sites.to_h.empty?
-  else
-    fail_with_message "#{config_file} was not found. Please set `ANSIBLE_PATH` in your Vagrantfile."
-  end
-
-  wordpress_sites
-end
-
 def local_provisioning?
   @local_provisioning ||= Vagrant::Util::Platform.windows? || !which('ansible-playbook') || ENV['FORCE_ANSIBLE_LOCAL']
 end
 
 def local_site_path(site)
   File.expand_path(site['local_path'], ANSIBLE_PATH)
-end
-
-def multisite_subdomains?(wordpress_sites)
-  wordpress_sites.any? do |(_name, site)|
-    site['multisite'].fetch('enabled', false) && site['multisite'].fetch('subdomains', false)
-  end
 end
 
 def nfs_path(path)


### PR DESCRIPTION
Helps vagrant plugins to read site info from `group_vars/development/wordpress_sites.yml`.

closes #886 