### PR TITLE
Default h5bp expires and cache busting to false

### DIFF
--- a/roles/wordpress-setup/defaults/main.yml
+++ b/roles/wordpress-setup/defaults/main.yml
@@ -30,9 +30,9 @@ h5bp_cache_file_descriptors_enabled: "{{ h5bp.cache_file_descriptors | default(n
 h5bp_extra_security_enabled: "{{ h5bp.extra_security | default(true) }}"
 h5bp_no_transform_enabled: "{{ h5bp.no_transform | default(false) }}"
 h5bp_x_ua_compatible_enabled: "{{ h5bp.x_ua_compatible | default(true) }}"
-h5bp_cache_busting_enabled: "{{ h5bp.cache_busting | default(not_dev) }}"
+h5bp_cache_busting_enabled: "{{ h5bp.cache_busting | default(false) }}"
 h5bp_cross_domain_fonts_enabled: "{{ h5bp.cross_domain_fonts | default(true) }}"
-h5bp_expires_enabled: "{{ h5bp.expires | default(not_dev) }}"
+h5bp_expires_enabled: "{{ h5bp.expires | default(false) }}"
 h5bp_protect_system_files_enabled: "{{ h5bp.protect_system_files | default(true) }}"
 
 # PHP FPM


### PR DESCRIPTION
Expires needs to be disabled by default and cache busting should be optional as well.