### PR TITLE
Ansible 2.4 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 ### HEAD
+* Default h5bp expires and cache busting to false ([#894](https://github.com/roots/trellis/pull/894))
+* Deploys: Update WP theme paths for multisite subsites ([#854](https://github.com/roots/trellis/pull/854))
+* Vagrant: Support DHCP ([#892](https://github.com/roots/trellis/pull/892))
+* Extract Trellis::Config ([#890](https://github.com/roots/trellis/pull/890))
+* Redirect directly to https canonical domain ([#889](https://github.com/roots/trellis/pull/889))
+* WordPress Setup: Add Nginx `ssl_client_certificate` ([#869](https://github.com/roots/trellis/pull/869))
+* Update h5bp/server-configs-nginx ([#876](https://github.com/roots/trellis/pull/876))
+* Update ansible galaxy roles ([#872](https://github.com/roots/trellis/pull/872))
+* Update wp-cli to 1.3.0 ([#871](https://github.com/roots/trellis/pull/871))
 * Add ansible_local support for non-Windows ([#824](https://github.com/roots/trellis/pull/824))
 * Load `modules-enabled` config files in Nginx ([#859](https://github.com/roots/trellis/pull/859))
 * Only include \*.conf files in Nginx `sites-enabled/` ([#862](https://github.com/roots/trellis/pull/862))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Ansible 2.4 compatibility ([#895](https://github.com/roots/trellis/pull/895))
 * Default h5bp expires and cache busting to false ([#894](https://github.com/roots/trellis/pull/894))
 * Deploys: Update WP theme paths for multisite subsites ([#854](https://github.com/roots/trellis/pull/854))
 * Vagrant: Support DHCP ([#892](https://github.com/roots/trellis/pull/892))

--- a/deploy.yml
+++ b/deploy.yml
@@ -1,5 +1,5 @@
 ---
-- include: variable-check.yml
+- import_playbook: variable-check.yml
   vars:
     playbook: deploy.yml
 

--- a/lib/trellis/plugins/callback/vars.py
+++ b/lib/trellis/plugins/callback/vars.py
@@ -5,10 +5,11 @@ import re
 import sys
 
 from __main__ import cli
-from ansible.compat.six import iteritems
+from ansible.module_utils.six import iteritems
 from ansible.errors import AnsibleError
 from ansible.parsing.dataloader import DataLoader
 from ansible.parsing.yaml.objects import AnsibleMapping, AnsibleSequence, AnsibleUnicode
+from ansible.playbook.play_context import PlayContext
 from ansible.plugins.callback import CallbackBase
 from ansible.template import Templar
 
@@ -58,7 +59,6 @@ class CallbackModule(CallbackBase):
 
         strings = {
             '--connection': 'connection',
-            '--inventory-file': 'inventory',
             '--private-key': 'private_key_file',
             '--ssh-common-args': 'ssh_common_args',
             '--ssh-extra-args': 'ssh_extra_args',
@@ -69,6 +69,9 @@ class CallbackModule(CallbackBase):
         for option,value in strings.iteritems():
             if getattr(self._options, value, False):
                 options.append("{0}='{1}'".format(option, str(getattr(self._options, value))))
+
+        for inventory in getattr(self._options, 'inventory'):
+            options.append("--inventory='{}'".format(str(inventory)))
 
         if getattr(self._options, 'ask_vault_pass', False):
             options.append('--ask-vault-pass')
@@ -87,8 +90,9 @@ class CallbackModule(CallbackBase):
 
     def v2_playbook_on_play_start(self, play):
         for host in play.get_variable_manager()._inventory.list_hosts(play.hosts[0]):
-            hostvars = play.get_variable_manager().get_vars(loader=self.loader, play=play, host=host)
+            hostvars = play.get_variable_manager().get_vars(play=play, host=host)
             self.raw_vars(play, host, hostvars)
+            host.vars['ssh_args_default'] = PlayContext(play=play, options=self._options)._ssh_args.default
             host.vars['cli_options'] = self.cli_options()
             host.vars['cli_ask_pass'] = getattr(self._options, 'ask_pass', False)
             host.vars['cli_ask_become_pass'] = getattr(self._options, 'become_ask_pass', False)

--- a/lib/trellis/plugins/filter/filters.py
+++ b/lib/trellis/plugins/filter/filters.py
@@ -5,7 +5,7 @@ __metaclass__ = type
 import types
 
 from ansible import errors
-from ansible.compat.six import string_types
+from ansible.module_utils.six import string_types
 
 def to_env(dict_value):
     envs = ["{0}='{1}'".format(key.upper(), str(value).replace("'","\\'")) for key, value in sorted(dict_value.items())]

--- a/lib/trellis/plugins/vars/version.py
+++ b/lib/trellis/plugins/vars/version.py
@@ -5,16 +5,31 @@ __metaclass__ = type
 from ansible import __version__
 from ansible.errors import AnsibleError
 from distutils.version import LooseVersion
-from operator import ge
+from operator import ge, gt
 
-version_requirement = '2.2.0.0'
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
+
+version_requirement = '2.4.0.0'
+version_tested_max = '2.4.0.0'
+
 if not ge(LooseVersion(__version__), LooseVersion(version_requirement)):
     raise AnsibleError(('Trellis no longer supports Ansible {}.\n'
         'Please upgrade to Ansible {} or higher.').format(__version__, version_requirement))
+elif gt(LooseVersion(__version__), LooseVersion(version_tested_max)):
+    display.warning(u'You Ansible version is {} but this version of Trellis has only been tested for '
+            u'compatability with Ansible {} -> {}. It is advisable to check for Trellis updates or '
+            u'downgrade your Ansible version.'.format(__version__, version_requirement, version_tested_max))
+
+# Import BaseVarsPlugin after Ansible version check.
+# Otherwise import error for Ansible versions older than 2.4 would prevent display of version check message.
+from ansible.plugins.vars import BaseVarsPlugin
 
 
-class VarsModule(object):
-    ''' Creates and modifies host variables '''
+class VarsModule(BaseVarsPlugin):
 
-    def __init__(self, inventory):
-        pass
+    def get_vars(self, loader, path, entities, cache=True):
+        return {}

--- a/lib/trellis/utils/output.py
+++ b/lib/trellis/utils/output.py
@@ -67,7 +67,7 @@ def display(obj, result):
     display = obj._display.display
     wrap_width = 77
     first = obj.first_host and obj.first_item
-    failed = 'failed' in result or 'unreachable' in result
+    failed = result.get('failed', False) or result.get('unreachable', False)
 
     # Only display msg if debug module or if failed (some modules have undesired 'msg' on 'ok')
     if 'msg' in result and (failed or obj.action == 'debug'):

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: disable temporary challenge sites
-  include: disable_challenge_sites.yml
+  import_tasks: disable_challenge_sites.yml
 
 - name: restart memcached
   service:
@@ -12,4 +12,4 @@
     name: php7.1-fpm
     state: reloaded
 
-- include: reload_nginx.yml
+- import_tasks: reload_nginx.yml

--- a/roles/connection/tasks/main.yml
+++ b/roles/connection/tasks/main.yml
@@ -12,14 +12,15 @@
   register: preferred_host_key_algorithms
   when:
     - dynamic_host_key_algorithms | default(true)
-    - ansible_ssh_extra_args == ''
+    - ansible_ssh_extra_args | default('') == ''
     - not (ansible_host_known or ssh_config_host_known)
 
 - name: Check whether Ansible can connect as {{ dynamic_user | default(true) | ternary('root', web_user) }}
   local_action: |
-    command ansible {{ inventory_hostname }} -m raw -a whoami -u {{ dynamic_user | default(true) | ternary('root', web_user) }}
-    {{ ('--ssh-extra-args' not in cli_options) | ternary('--ssh-extra-args="' + ansible_ssh_extra_args + '"', '') }}
-    {{ cli_options | default('') }} -vvvv
+    command ansible {{ inventory_hostname }} -m raw -a whoami
+    -u {{ dynamic_user | default(true) | ternary('root', web_user) }} {{ cli_options | default('') }} -vvvv
+  environment:
+    ANSIBLE_SSH_ARGS: "{{ ssh_args_default }} {{ ansible_ssh_extra_args | default('') }}"
   failed_when: false
   changed_when: false
   check_mode: no

--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -17,7 +17,7 @@
       chdir: "{{ deploy_helper.current_path }}"
     when: update_wp_theme_paths | default(true) | bool
     with_subelements:
-      - "[{% for result in wp_template_root.results %}{'option': '{{ result.item }}', 'stdout_lines': {{ result.stdout_lines | select('search', deploy_helper.releases_path) | list }}},{% endfor %}]"
+      - "[{% for result in wp_template_root.results %}{'option': '{{ result.item }}', 'stdout_lines': {{ result.stdout_lines | default ([]) | select('search', deploy_helper.releases_path) | list }}},{% endfor %}]"
       - stdout_lines
 
   - name: Warn about updating network database.
@@ -31,7 +31,7 @@
       chdir: "{{ deploy_helper.current_path }}"
     when: project.update_db_on_deploy | default(update_db_on_deploy)
 
-  when: wp_installed | success
+  when: wp_installed.rc == 0
 
 - name: Reload php-fpm
   shell: sudo service php7.1-fpm reload

--- a/roles/deploy/hooks/finalize-before.yml
+++ b/roles/deploy/hooks/finalize-before.yml
@@ -23,9 +23,9 @@
     chdir: "{{ deploy_helper.current_path }}"
   register: wp_template_root
   changed_when: false
-  failed_when: wp_template_root.stderr != ""
+  failed_when: wp_template_root.stderr  | default('') != ''
   when:
-    - wp_installed | success
+    - wp_installed.rc == 0
     - update_wp_theme_paths | default(true) | bool
   with_items:
     - template_root

--- a/roles/deploy/tasks/build.yml
+++ b/roles/deploy/tasks/build.yml
@@ -1,5 +1,5 @@
 ---
-- include: "{{ include_path }}"
+- include_tasks: "{{ include_path }}"
   with_items: "{{ deploy_build_before | default([]) }}"
   loop_control:
     loop_var: include_path
@@ -23,7 +23,7 @@
   with_items: "{{ project_folder_paths.results }}"
   when: item.stat.exists
 
-- include: "{{ include_path }}"
+- include_tasks: "{{ include_path }}"
   with_items: "{{ deploy_build_after | default([]) }}"
   loop_control:
     loop_var: include_path

--- a/roles/deploy/tasks/finalize.yml
+++ b/roles/deploy/tasks/finalize.yml
@@ -1,5 +1,5 @@
 ---
-- include: "{{ include_path }}"
+- include_tasks: "{{ include_path }}"
   with_items: "{{ deploy_finalize_before | default([]) }}"
   loop_control:
     loop_var: include_path
@@ -12,7 +12,7 @@
     release: "{{ deploy_helper.new_release }}"
     state: finalize
 
-- include: "{{ include_path }}"
+- include_tasks: "{{ include_path }}"
   with_items: "{{ deploy_finalize_after | default([]) }}"
   loop_control:
     loop_var: include_path

--- a/roles/deploy/tasks/initialize.yml
+++ b/roles/deploy/tasks/initialize.yml
@@ -1,5 +1,5 @@
 ---
-- include: "{{ include_path }}"
+- include_tasks: "{{ include_path }}"
   with_items: "{{ deploy_initialize_before | default([]) }}"
   loop_control:
     loop_var: include_path
@@ -11,7 +11,7 @@
     path: "{{ project_root }}"
     state: present
 
-- include: "{{ include_path }}"
+- include_tasks: "{{ include_path }}"
   with_items: "{{ deploy_initialize_after | default([]) }}"
   loop_control:
     loop_var: include_path

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -1,18 +1,18 @@
 ---
-- include: "{{ include_path }}"
+- include_tasks: "{{ include_path }}"
   with_items: "{{ deploy_before | default([]) }}"
   loop_control:
     loop_var: include_path
   tags: deploy-before
 
-- include: initialize.yml
-- include: update.yml
-- include: prepare.yml
-- include: build.yml
-- include: share.yml
-- include: finalize.yml
+- import_tasks: initialize.yml
+- import_tasks: update.yml
+- import_tasks: prepare.yml
+- import_tasks: build.yml
+- import_tasks: share.yml
+- import_tasks: finalize.yml
 
-- include: "{{ include_path }}"
+- include_tasks: "{{ include_path }}"
   with_items: "{{ deploy_after | default([]) }}"
   loop_control:
     loop_var: include_path

--- a/roles/deploy/tasks/prepare.yml
+++ b/roles/deploy/tasks/prepare.yml
@@ -1,5 +1,5 @@
 ---
-- include: "{{ include_path }}"
+- include_tasks: "{{ include_path }}"
   with_items: "{{ deploy_prepare_before | default([]) }}"
   loop_control:
     loop_var: include_path
@@ -38,7 +38,7 @@
     chdir: "{{ project_source_path }}"
   when: project.repo_subtree_path is defined
 
-- include: "{{ include_path }}"
+- include_tasks: "{{ include_path }}"
   with_items: "{{ deploy_prepare_after | default([]) }}"
   loop_control:
     loop_var: include_path

--- a/roles/deploy/tasks/share.yml
+++ b/roles/deploy/tasks/share.yml
@@ -1,5 +1,5 @@
 ---
-- include: "{{ include_path }}"
+- include_tasks: "{{ include_path }}"
   with_items: "{{ deploy_share_before | default([]) }}"
   loop_control:
     loop_var: include_path
@@ -48,7 +48,7 @@
     state: link
   with_items: "{{ project_shared_children }}"
 
-- include: "{{ include_path }}"
+- include_tasks: "{{ include_path }}"
   with_items: "{{ deploy_share_after | default([]) }}"
   loop_control:
     loop_var: include_path

--- a/roles/deploy/tasks/update.yml
+++ b/roles/deploy/tasks/update.yml
@@ -1,5 +1,5 @@
 ---
-- include: "{{ include_path }}"
+- include_tasks: "{{ include_path }}"
   with_items: "{{ deploy_update_before | default([]) }}"
   loop_control:
     loop_var: include_path
@@ -51,7 +51,7 @@
       > https://roots.io/trellis/docs/ssh-keys/#cloning-remote-repo-using-ssh-agent-forwarding
   when: git_clone | failed
 
-- include: "{{ include_path }}"
+- include_tasks: "{{ include_path }}"
   with_items: "{{ deploy_update_after | default([]) }}"
   loop_control:
     loop_var: include_path

--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
-- include: setup.yml
-- include: nginx.yml
-- include: certificates.yml
+- import_tasks: setup.yml
+- import_tasks: nginx.yml
+- import_tasks: certificates.yml
 
 - name: Install cronjob for key generation
   cron:

--- a/roles/letsencrypt/tasks/nginx.yml
+++ b/roles/letsencrypt/tasks/nginx.yml
@@ -35,7 +35,7 @@
   with_dict: "{{ wordpress_sites }}"
   notify: disable temporary challenge sites
 
-- include: "{{ playbook_dir }}/roles/common/tasks/reload_nginx.yml"
+- import_tasks: "{{ playbook_dir }}/roles/common/tasks/reload_nginx.yml"
   when: challenge_site_confs | changed or challenge_sites_enabled | changed
 
 - name: Create test Acme Challenge file

--- a/roles/rollback/tasks/main.yml
+++ b/roles/rollback/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
-- include: user-release.yml
+- import_tasks: user-release.yml
   when: release is defined
 
-- include: prior-release.yml
+- import_tasks: prior-release.yml
   when: release is not defined
 
 - name: Check whether target release was from a successful deploy

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -66,6 +66,6 @@
   when: (ansible_user != admin_user and not sshd_permit_root_login) or (cli_ask_pass and not sshd_password_authentication)
   tags: [connection-tests, sshd]
 
-- include: connection-warnings.yml
-  when: admin_user_status | failed
+- import_tasks: connection-warnings.yml
+  when: not admin_user_status | skipped and admin_user_status.rc != 0
   tags: [connection-tests, sshd]

--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- include: directories.yml
+- import_tasks: directories.yml
   tags: wordpress-install-directories
 
 - name: Create .env file

--- a/roles/wordpress-setup/tasks/main.yml
+++ b/roles/wordpress-setup/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
-- include: database.yml
+- import_tasks: database.yml
   tags: wordpress-setup-database
-- include: self-signed-certificate.yml
+- import_tasks: self-signed-certificate.yml
   tags: wordpress-setup-self-signed-certificate
-- include: nginx-client-cert.yml
+- import_tasks: nginx-client-cert.yml
   tags: wordpress-setup-nginx-client-cert
 
 - name: Create web root
@@ -36,10 +36,10 @@
   when: disable_default_pool | default(true)
   notify: reload php-fpm
 
-- include: nginx-includes.yml
+- import_tasks: nginx-includes.yml
   tags: [nginx-includes, wordpress-setup-nginx]
 
-- include: nginx.yml
+- import_tasks: nginx.yml
   tags: wordpress-setup-nginx
 
 - name: Setup WP system cron

--- a/roles/wordpress-setup/tasks/nginx.yml
+++ b/roles/wordpress-setup/tasks/nginx.yml
@@ -17,7 +17,7 @@
   when: ssl_enabled and item.value.ssl.key is defined
   notify: reload nginx
 
-- include: "{{ playbook_dir }}/roles/common/tasks/disable_challenge_sites.yml"
+- import_tasks: "{{ playbook_dir }}/roles/common/tasks/disable_challenge_sites.yml"
 
 - name: Create Nginx conf for challenges location
   template:

--- a/rollback.yml
+++ b/rollback.yml
@@ -1,5 +1,5 @@
 ---
-- include: variable-check.yml
+- import_playbook: variable-check.yml
   vars:
     playbook: rollback.yml
 

--- a/server.yml
+++ b/server.yml
@@ -1,5 +1,5 @@
 ---
-- include: variable-check.yml
+- import_playbook: variable-check.yml
   vars:
     playbook: server.yml
 

--- a/vagrant.default.yml
+++ b/vagrant.default.yml
@@ -4,7 +4,7 @@ vagrant_cpus: 1
 vagrant_memory: 1024 # in MB
 vagrant_box: 'bento/ubuntu-16.04'
 vagrant_box_version: '<= 2.3.8'
-vagrant_ansible_version: '2.3.0'
+vagrant_ansible_version: '2.4.0'
 vagrant_skip_galaxy: false
 
 vagrant_install_plugins: true


### PR DESCRIPTION
- update `include` to `import_tasks`, `include_tasks` or `import_playbook` ([docs](https://docs.ansible.com/ansible/devel/playbooks_reuse.html) and [docs](https://docs.ansible.com/ansible/devel/playbooks_reuse_includes.html)).
  This avoids deprecation warning. However, `server.yml` will still show deprecation warning till the composer galaxy role changes these [two `includes`](https://github.com/geerlingguy/ansible-role-composer/blob/1e9c94423584b6eb0e5b4f4cba5d730beb24d822/tasks/main.yml#L54-L58).
- bump Ansible requirement to 2.4 to accommodate `import_*` and `include_*`
- add warning for Ansible versions greater than tested with Trellis
  It happens that people update Ansible but not Trellis, then run into problems, not realizing they need to update their Trellis for compatibility, posting on discourse, etc.
  ```
  [WARNING]: You Ansible version is 2.5.0.0 but this version of Trellis has only been tested for
  compatability with Ansible 2.4.0.0 -> 2.4.2.0. It is advisable to check for Trellis updates or
  downgrade your Ansible version.
  ```
- adjust `when` conditions: `failed` and `success` [no longer account for `rc`](https://github.com/ansible/ansible/commit/2a041d10d26d5746132061da4b874f33cb73ffb0#diff-bc6bf5732a9c00dcb3cb182f4ce3b7c8R29)
- move dynamic HostKeyAlgorithms from `--ssh-extra-args` to `environment` keyword
  `--ssh-extra-args` seemed to no longer have any effect ([maybe related](https://github.com/ansible/ansible/commit/f921369445900dcc756821e40c9257d5359087af#diff-efa3a13dd7cbec87c75b359049e1c7d3L295)?)
- accommodate potential for multiple inventories (`inventory` list in `cli.options`)
  > It is now possible to specify mulitple inventory sources in the command line (-i /etc/hosts1 -i /opt/hosts2) _[--Ansible CHANGELOG](https://github.com/ansible/ansible/blob/devel/CHANGELOG.md)_
- remove `loader` kwarg from VariableManager.get_vars()