### PR TITLE
Revert "Vagrant: Use DHCP by default"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
 ### HEAD
-* Vagrant: Use DHCP by default ([#898](https://github.com/roots/trellis/pull/898))
 * [BREAKING] Normalize `apt` tasks ([#881](https://github.com/roots/trellis/pull/881))
 * Ansible 2.4 compatibility ([#895](https://github.com/roots/trellis/pull/895))
 * Default h5bp expires and cache busting to false ([#894](https://github.com/roots/trellis/pull/894))

--- a/vagrant.default.yml
+++ b/vagrant.default.yml
@@ -1,5 +1,5 @@
 ---
-vagrant_ip: dhcp
+vagrant_ip: '192.168.50.5'
 vagrant_cpus: 1
 vagrant_memory: 1024 # in MB
 vagrant_box: 'bento/ubuntu-16.04'


### PR DESCRIPTION
Reverts roots/trellis#898

Fixes https://github.com/roots/trellis/issues/902