### PR TITLE
Add option vagrant_prefer_nfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Add option vagrant_prefer_nfs ([#904](https://github.com/roots/trellis/pull/904))
 * [BREAKING] Normalize `apt` tasks ([#881](https://github.com/roots/trellis/pull/881))
 * Ansible 2.4 compatibility ([#895](https://github.com/roots/trellis/pull/895))
 * Default h5bp expires and cache busting to false ([#894](https://github.com/roots/trellis/pull/894))

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,7 +69,7 @@ Vagrant.configure('2') do |config|
 
   bin_path = File.join(ANSIBLE_PATH_ON_VM, 'bin')
 
-  if Vagrant::Util::Platform.windows? and !Vagrant.has_plugin? 'vagrant-winnfsd'
+  if (Vagrant::Util::Platform.windows? && !Vagrant.has_plugin?('vagrant-winnfsd')) || !vconfig.fetch('vagrant_prefer_nfs')
     trellis_config.wordpress_sites.each_pair do |name, site|
       config.vm.synced_folder local_site_path(site), remote_site_path(name, site), owner: 'vagrant', group: 'www-data', mount_options: ['dmode=776', 'fmode=775']
     end

--- a/vagrant.default.yml
+++ b/vagrant.default.yml
@@ -5,6 +5,7 @@ vagrant_memory: 1024 # in MB
 vagrant_box: 'bento/ubuntu-16.04'
 vagrant_box_version: '<= 2.3.8'
 vagrant_ansible_version: '2.4.0'
+vagrant_prefer_nfs: true
 vagrant_skip_galaxy: false
 
 vagrant_install_plugins: true


### PR DESCRIPTION
On Macs that using APFS, `vagrant up` gives:
```
==> default: Mounting NFS shared folders...
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!
mount -o vers=3,udp 192.168.50.1:/Users/XXX/Code/site /vagrant-nfs-example.com
Stdout from the command:
Stderr from the command:
mount.nfs: access denied by server while mounting 192.168.50.1:/Users/XXX/Code/site
```
See:
 - https://github.com/hashicorp/vagrant/issues/8788
 - https://github.com/geerlingguy/drupal-vm/issues/1547

This pull request adds `vagrant_prefer_nfs` option so that non-windows users could have a choice to use default `synced_folder` type.

Only tested with vagrant 1.9.8 + macOS 10.13 + APFS.

For APFS user:
1. Set `vagrant_prefer_nfs: false`
2. `FORCE_ANSIBLE_LOCAL=true vagrant up`

Note: This won't work on vagrant 2.0, see: https://discourse.roots.io/t/the-requested-ansible-version-2-4-0-was-not-found-on-the-guest/10513

Discuss:
 - Should we implicitly set `ansible_local` when `vagrant_prefer_nfs: false`(like what we are doing for windows users)?
 - Bring back #439?
