### PR TITLE
Clarify DB creation task name

### DIFF
--- a/roles/wordpress-setup/tasks/database.yml
+++ b/roles/wordpress-setup/tasks/database.yml
@@ -1,6 +1,6 @@
 ---
 - block:
-  - name: Create database of sites
+  - name: Create databases for sites
     mysql_db:
       name: "{{ site_env.db_name }}"
       state: present


### PR DESCRIPTION
I've always found the description of the database creation task confusing (it's not creating a database _of_ sites). This PR changes it.