### PR TITLE
Dynamically increase ansible_group_priority for selected env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Dynamically increase `ansible_group_priority` for selected env ([#909](https://github.com/roots/trellis/pull/909))
 * Bump Ansible `version_tested_max` to 2.4.1.0 ([#911](https://github.com/roots/trellis/pull/911))
 * Update wp-cli to 1.4.0 ([#906](https://github.com/roots/trellis/pull/906))
 * [BREAKING] Normalize `apt` tasks ([#881](https://github.com/roots/trellis/pull/881))

--- a/lib/trellis/plugins/callback/vars.py
+++ b/lib/trellis/plugins/callback/vars.py
@@ -89,6 +89,11 @@ class CallbackModule(CallbackBase):
             return True
 
     def v2_playbook_on_play_start(self, play):
+        env = play.get_variable_manager().get_vars(play=play).get('env', '')
+        env_group = next((group for key,group in play.get_variable_manager()._inventory.groups.iteritems() if key == env), False)
+        if env_group:
+            env_group.set_priority(20)
+
         for host in play.get_variable_manager()._inventory.list_hosts(play.hosts[0]):
             hostvars = play.get_variable_manager().get_vars(play=play, host=host)
             self.raw_vars(play, host, hostvars)


### PR DESCRIPTION
This PR assigns higher priority to a user's indicated `env` group (if any).
Fixes https://discourse.roots.io/t/10756/2 originally reported at https://discourse.roots.io/t/6090

When the same hostname is used in both the [`[production]`](https://github.com/roots/trellis/blob/48dd66c6a952d744ecf6e502b7d693ea79397357/hosts/production#L4-L5) and [`[staging]`](https://github.com/roots/trellis/blob/48dd66c6a952d744ecf6e502b7d693ea79397357/hosts/staging#L4-L5) groups, Ansible will always use the staging group vars, even if a user specifies `-e env=production`. This is because without a differing `ansible_group_priority`, Ansible loads sibling groups in alphabetical order and variables from the last group loaded win out.

Ansible 2.4 added the `ansible_group_priority` option to assign differing priority to sibling groups (feature in ansible/ansible#22580 and docs in ansible/ansible#28777).

I think the `ansible_group_priority` needs to be defined in the hosts/inventory file in order to affect which group_vars are given priority. However, the hosts file doesn't support jinja interpolation, so we can't use the regular hosts file(s) to dynamically set `ansible_group_priority` based on a user's indicated `env`. That is why this PR uses one of the Trellis plugins to set the priority via `v2_playbook_on_play_start`.

Users who wish to manually set `ansible_group_priority` for an `env` group in their hosts file(s) will need to use a value greater than the `20` used in this PR. 