### PR TITLE
Disallow duplicate site keys within a host's wordpress_sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Disallow duplicate site keys within a host's `wordpress_sites` ([#910](https://github.com/roots/trellis/pull/910))
 * Fix `raw_vars` functionality for Ansible 2.4.1 ([#915](https://github.com/roots/trellis/pull/915))
 * Enable Virtualbox ioapic option ([#913](https://github.com/roots/trellis/pull/913))
 * Dynamically increase `ansible_group_priority` for selected env ([#909](https://github.com/roots/trellis/pull/909))

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,5 +1,25 @@
 ntp_timezone: Etc/UTC
 
+env_groups: "{{ ['development', 'staging', 'production'] | intersect(group_names) }}"
+
+envs_with_wp_sites: "{{
+  lookup('filetree', playbook_dir + '/group_vars') |
+  selectattr('path', 'match', '(' + env_groups | join('|') + ')/wordpress_sites\\.yml$') |
+  map(attribute='path') | map('regex_replace', '([^/]*)/.*', '\\1') | list
+}}"
+
+site_keys_by_env_pair: "[
+  {% for env_pair in envs_with_wp_sites | combinations(2) | list %}
+    {
+      'env_pair': {{ env_pair }},
+      'site_keys': {{
+                     (vars[env_pair[0] + '_sites'].wordpress_sites | default({})).keys() | intersect(
+                     (vars[env_pair[1] + '_sites'].wordpress_sites | default({})).keys())
+                   }}
+    },
+  {% endfor %}
+]"
+
 apt_packages_default:
   python-software-properties: "{{ apt_package_state }}"
   python-pycurl: "{{ apt_package_state }}"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,4 +1,26 @@
 ---
+- block:
+  - name: Load wordpress_sites.yml vars into <env>_sites vars
+    include_vars:
+      file: group_vars/{{ item }}/wordpress_sites.yml
+      name: "{{ item }}_sites"
+    with_items: "{{ envs_with_wp_sites }}"
+    when: envs_with_wp_sites | count > 1
+
+  - name: Fail if there are duplicate site keys within host's wordpress_sites
+    fail:
+      msg: >
+        If you put multiple environments on `{{ inventory_hostname }}`, `wordpress_sites`
+        must use different site keys per environment. Adjust the following site keys that
+        are duplicated between the `{{ item.env_pair | join('` and `') }}` groups:
+          {{ item.site_keys | to_nice_yaml | indent(2) }}
+    when: item.site_keys | count
+    with_items: "{{ site_keys_by_env_pair }}"
+
+  when:
+    - env_groups | count > 1
+    - validate_site_keys | default(true) | bool
+
 - name: Validate wordpress_sites
   fail:
     msg: "{{ lookup('template', 'wordpress_sites.j2') }}"


### PR DESCRIPTION
**What?** This PR adds a validation to prevent duplicate site keys when a host is in multiple `env` groups simultaneously. Fixes https://discourse.roots.io/t/10756/2

**Why?** If a user loads a site's staging and production environment on a single host, site keys must differ between environments to prevent conflict that would otherwise occur in resources built from site keys (e.g., [Nginx conf filepaths](https://github.com/roots/trellis/blob/48dd66c6a952d744ecf6e502b7d693ea79397357/roles/wordpress-setup/tasks/nginx.yml#L31)). Loading both production and staging on a single server is discouraged, but at least this PR prevents one of the most certain accompanying problems.

**Rarely runs.** This validation skips in the usual case that a host is only in a single `env` group.

**To disable.** Hate it? Have a special case when you don't want the validation? Define `validate_site_keys: false`.

**Custom envs?** If people have custom environments and care to have them validated by this PR's procedure, they can redefine `env_groups` in `group_vars/all/main.yml`, including their custom `env` in the list.

**Shouldn't choke on weird customizations.** In case users have customizations such that the `wordpress_sites.yml` file is missing or the `wordpress_sites` dict is missing for an `env`, the validation in this PR won't choke with a yaml or jinja failure, but no validation will occur.

**Loads files manually.** Ansible only loads `wordpress_sites` vars from a single `env` group on a given playbook run. Thus we must manually load the vars files ourselves in order to access `wordpress_sites` from multiple environments simultaneously. Simultaneous access is necessary to check for duplicate site keys.

**Example error message.**
```
TASK [common : Fail if there are duplicate site keys within host's wordpress_sites] ****
---------------------------------------------------
If you put multiple environments on `138.68.203.29`, `wordpress_sites` must
use different site keys per environment. Adjust the following site keys that
are duplicated between the `production` and `staging` groups:
  - example.com
  - site2.io

failed: [138.68.203.29] (item=...)
```