### PR TITLE
Bump Ansible version_tested_max to 2.4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Bump Ansible `version_tested_max` to 2.4.1.0 ([#911](https://github.com/roots/trellis/pull/911))
 * Update wp-cli to 1.4.0 ([#906](https://github.com/roots/trellis/pull/906))
 * [BREAKING] Normalize `apt` tasks ([#881](https://github.com/roots/trellis/pull/881))
 * Ansible 2.4 compatibility ([#895](https://github.com/roots/trellis/pull/895))

--- a/lib/trellis/plugins/vars/version.py
+++ b/lib/trellis/plugins/vars/version.py
@@ -14,7 +14,7 @@ except ImportError:
     display = Display()
 
 version_requirement = '2.4.0.0'
-version_tested_max = '2.4.0.0'
+version_tested_max = '2.4.1.0'
 
 if not ge(LooseVersion(__version__), LooseVersion(version_requirement)):
     raise AnsibleError(('Trellis no longer supports Ansible {}.\n'

--- a/vagrant.default.yml
+++ b/vagrant.default.yml
@@ -4,7 +4,7 @@ vagrant_cpus: 1
 vagrant_memory: 1024 # in MB
 vagrant_box: 'bento/ubuntu-16.04'
 vagrant_box_version: '<= 2.3.8'
-vagrant_ansible_version: '2.4.0'
+vagrant_ansible_version: '2.4.1.0'
 vagrant_skip_galaxy: false
 
 vagrant_install_plugins: true


### PR DESCRIPTION
Ansible 2.4.1.0 passes my superficial manual testing.

💚  As @oleg2106 pointed out, adding the fourth portion to the Ansible version in `vagrant.default.yml` fixes https://discourse.roots.io/t/the-requested-ansible-version-2-4-0-was-not-found-on-the-guest/10513 :arrow_left: 