### PR TITLE
Fix raw_vars functionality for Ansible 2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Fix `raw_vars` functionality for Ansible 2.4.1 ([#915](https://github.com/roots/trellis/pull/915))
 * Enable Virtualbox ioapic option ([#913](https://github.com/roots/trellis/pull/913))
 * Dynamically increase `ansible_group_priority` for selected env ([#909](https://github.com/roots/trellis/pull/909))
 * Bump Ansible `version_tested_max` to 2.4.1.0 ([#911](https://github.com/roots/trellis/pull/911))

--- a/lib/trellis/plugins/callback/vars.py
+++ b/lib/trellis/plugins/callback/vars.py
@@ -10,6 +10,7 @@ from ansible.errors import AnsibleError
 from ansible.parsing.dataloader import DataLoader
 from ansible.parsing.yaml.objects import AnsibleMapping, AnsibleSequence, AnsibleUnicode
 from ansible.playbook.play_context import PlayContext
+from ansible.playbook.task import Task
 from ansible.plugins.callback import CallbackBase
 from ansible.template import Templar
 
@@ -95,7 +96,8 @@ class CallbackModule(CallbackBase):
             env_group.set_priority(20)
 
         for host in play.get_variable_manager()._inventory.list_hosts(play.hosts[0]):
-            hostvars = play.get_variable_manager().get_vars(play=play, host=host)
+            # it should be ok to remove dummy Task() once minimum required Ansible >= 2.4.2
+            hostvars = play.get_variable_manager().get_vars(play=play, host=host, task=Task())
             self.raw_vars(play, host, hostvars)
             host.vars['ssh_args_default'] = PlayContext(play=play, options=self._options)._ssh_args.default
             host.vars['cli_options'] = self.cli_options()


### PR DESCRIPTION
This PR fixes broken `raw_vars` functionality for Ansible 2.4.1.

**Background.** In contrast to prior versions, Ansible 2.4.1 [populates `basedirs` only if a `task` is passed](https://github.com/ansible/ansible/commit/7f2c611dfceaef877de7dded084362d28bf5f8c7#diff-473ef6db3f086739e3c053f001d731b5R236) to the `VariableManager`'s `get_vars()`. Without a known `basedir`, no `group_vars` files are loaded, such that `get_vars()` no longer returns any group vars, only host vars and play vars. The `basedirs` definitions and group vars retrieval should go back to normal in Ansible 2.4.2 (fix in ansible/ansible#32269).

**Implications for Trellis.** The Trellis `raw_vars` feature retrieves and wraps var values in `{% raw %}` using the `v2_playbook_on_play_start` callback, not during any particular task. Thus Trellis did not pass any `task` to `get_vars()`. With Ansible 2.4.1, this means the `raw_vars` feature couldn't find nor process any group vars, risking jinja templating errors (e.g., for password vars with random characters).

**Implementation.** This PR passes a dummy `Task()` to `get_vars()` just so `basedirs` will be populated and group vars retrieved. The is no other effect of passing in the `task`: `task._role` is `None`, `task.environment` is `None`, and `task.get_vars()` returns `{}`.

**Future.** It should be ok to remove the dummy `task` once the Trellis minimum requirement for Ansible is 2.4.2+. I decided not to bother making the dummy task conditional on Ansible version 2.4.1 given that it had no problematic effects in 2.4.0 nor in 2.4.2.0-0.2.beta2.