### PR TITLE
Remove outdated to_unicode import from plugin utils

### DIFF
--- a/lib/trellis/utils/output.py
+++ b/lib/trellis/utils/output.py
@@ -8,12 +8,7 @@ import re
 import textwrap
 
 from ansible import __version__
-
-# to_unicode will no longer be needed once Trellis requires Ansible >= 2.2
-try:
-    from ansible.module_utils._text import to_text
-except ImportError:
-    from ansible.utils.unicode import to_unicode as to_text
+from ansible.module_utils._text import to_text
 
 def system(vagrant_version=None):
     # Get most recent Trellis CHANGELOG entry


### PR DESCRIPTION
:broom: #683

The `to_unicode` method as fallback is no longer needed.
Ansible 2.2 deprecated `to_unicode` in favor of `to_text`. The `to_text`
method has been available since 2.2 and Trellis now requires 2.4+.