### PR TITLE
Replace bare Dataloader() with pre-loaded play._loader

### DIFF
--- a/lib/trellis/plugins/callback/vars.py
+++ b/lib/trellis/plugins/callback/vars.py
@@ -7,7 +7,6 @@ import sys
 from __main__ import cli
 from ansible.module_utils.six import iteritems
 from ansible.errors import AnsibleError
-from ansible.parsing.dataloader import DataLoader
 from ansible.parsing.yaml.objects import AnsibleMapping, AnsibleSequence, AnsibleUnicode
 from ansible.playbook.play_context import PlayContext
 from ansible.playbook.task import Task
@@ -22,7 +21,6 @@ class CallbackModule(CallbackBase):
     CALLBACK_NAME = 'vars'
 
     def __init__(self):
-        self.loader = DataLoader()
         self._options = cli.options if cli else None
 
     def raw_triage(self, key_string, item, patterns):
@@ -43,7 +41,7 @@ class CallbackModule(CallbackBase):
         if 'raw_vars' not in hostvars:
             return
 
-        raw_vars = Templar(variables=hostvars, loader=self.loader).template(hostvars['raw_vars'])
+        raw_vars = Templar(variables=hostvars, loader=play._loader).template(hostvars['raw_vars'])
         if not isinstance(raw_vars, list):
             raise AnsibleError('The `raw_vars` variable must be defined as a list.')
 


### PR DESCRIPTION
:broom:

The `play._loader` already exists. It is pre-loaded with `play._loader._vault.secrets`, `play._loader.FILE_CACHE`, etc. There's little point in creating a fresh `Dataloader()` and having to process or load it up.

### The life of a `loader`

No need to read this.

The `ansible-playbook` cli command [`PlaybookCLI()`](https://github.com/ansible/ansible/blob/v2.4.1.0-1/lib/ansible/cli/playbook.py#L104) runs its base class's [`_play_prereqs()`](https://github.com/ansible/ansible/blob/v2.4.1.0-1/lib/ansible/cli/__init__.py#L774-L788) which initializes a new `loader` and processes it, running `setup_vault_secrets()` etc.

The `PlaybookCLI` then [passes](https://github.com/ansible/ansible/blob/v2.4.1.0-1/lib/ansible/cli/playbook.py#L127) this pre-loaded `loader` instance to the `PlaybookExecutor` which forwards on the `loader` via [`Playbook.load()`](https://github.com/ansible/ansible/blob/v2.4.1.0-1/lib/ansible/executor/playbook_executor.py#L82) which uses the `loader` to initialize a new [`Playbook()`](https://github.com/ansible/ansible/blob/devel/lib/ansible/playbook/__init__.py#L48-L53).

The `Playbook()` uses the `loader` to [initialize](https://github.com/ansible/ansible/blob/devel/lib/ansible/playbook/__init__.py#L106) our given `Play()`. Finally, Trellis can access the `play._loader` via the [`v2_playbook_on_play_start`](https://github.com/ansible/ansible/blob/v2.4.1.0-1/lib/ansible/plugins/callback/__init__.py#L373) callback method.

This `loader` is all loaded up with `vault_secrets` and `_FILE_CACHE`, in contrast to a bare new [`Dataloader()`](https://github.com/ansible/ansible/blob/v2.4.1.0-1/lib/ansible/parsing/dataloader.py) we've been using and would otherwise need to load up manually.  The pre-loaded `_loader._vault.secrets` obviates procedures such as [this](https://github.com/roots/trellis/blob/2322be0899694bebe70bc5c9779e59ea15b30e98/lib/trellis/plugins/callback/vars.py#L92-L97).