### PR TITLE
Update to WP-CLI 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Update wp-cli to 1.4.1 ([#918](https://github.com/roots/trellis/pull/918))
 * Disallow duplicate site keys within a host's `wordpress_sites` ([#910](https://github.com/roots/trellis/pull/910))
 * Fix `raw_vars` functionality for Ansible 2.4.1 ([#915](https://github.com/roots/trellis/pull/915))
 * Enable Virtualbox ioapic option ([#913](https://github.com/roots/trellis/pull/913))

--- a/roles/wp-cli/defaults/main.yml
+++ b/roles/wp-cli/defaults/main.yml
@@ -1,4 +1,4 @@
-wp_cli_version: 1.4.0
+wp_cli_version: 1.4.1
 wp_cli_bin_path: /usr/bin/wp
 wp_cli_phar_url: "https://github.com/wp-cli/wp-cli/releases/download/v{{ wp_cli_version }}/wp-cli-{{ wp_cli_version }}.phar"
 wp_cli_completion_url: "https://raw.githubusercontent.com/wp-cli/wp-cli/v{{ wp_cli_version }}/utils/wp-completion.bash"


### PR DESCRIPTION
Fixes SQL injection bug in `wp search-replace`, among other things.

See:

+ https://make.wordpress.org/cli/2017/11/13/version-1-4-1-released/
+ https://blog.ircmaxell.com/2017/10/disclosure-wordpress-wpdb-sql-injection-technical.html 