### PR TITLE
Enable select deploy configs to optionally vary by site

### DIFF
--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -6,7 +6,7 @@
       chdir: "{{ deploy_helper.current_path }}"
     register: site_transient_theme_roots
     changed_when: site_transient_theme_roots.stdout != ''
-    when: update_wp_theme_paths | default(true) | bool
+    when: project.update_wp_theme_paths | default(update_wp_theme_paths | default(true)) | bool
 
   - name: Update WP theme paths
     command: >
@@ -15,7 +15,7 @@
       {% if project.multisite.enabled | default(false) %} --url={{ item[1].split(' ')[0] }}{% endif %}
     args:
       chdir: "{{ deploy_helper.current_path }}"
-    when: update_wp_theme_paths | default(true) | bool
+    when: project.update_wp_theme_paths | default(update_wp_theme_paths | default(true)) | bool
     with_subelements:
       - "[{% for result in wp_template_root.results %}{'option': '{{ result.item }}', 'stdout_lines': {{ result.stdout_lines | default ([]) | select('search', deploy_helper.releases_path) | list }}},{% endfor %}]"
       - stdout_lines

--- a/roles/deploy/hooks/finalize-before.yml
+++ b/roles/deploy/hooks/finalize-before.yml
@@ -26,7 +26,7 @@
   failed_when: wp_template_root.stderr  | default('') != ''
   when:
     - wp_installed.rc == 0
-    - update_wp_theme_paths | default(true) | bool
+    - project.update_wp_theme_paths | default(update_wp_theme_paths | default(true)) | bool
   with_items:
     - template_root
     - stylesheet_root

--- a/roles/deploy/tasks/build.yml
+++ b/roles/deploy/tasks/build.yml
@@ -10,13 +10,13 @@
     src: "{{ item.src }}"
     dest: "{{ deploy_helper.new_release_path }}/{{ item.dest }}"
     mode: "{{ item.mode | default('0644') }}"
-  with_items: "{{ project_templates }}"
+  with_items: "{{ project.project_templates | default(project_templates) }}"
 
 - name: Check if project folders exist
   stat:
     path: "{{ deploy_helper.current_path }}/{{ item }}"
   register: project_folder_paths
-  with_items: "{{ project_copy_folders }}"
+  with_items: "{{ project.project_copy_folders | default(project_copy_folders) }}"
 
 - name: Copy project folders
   command: cp -rp {{ deploy_helper.current_path }}/{{ item.item }} {{ deploy_helper.new_release_path }}

--- a/roles/deploy/tasks/share.yml
+++ b/roles/deploy/tasks/share.yml
@@ -10,7 +10,7 @@
     path: "{{ deploy_helper.shared_path }}/{{ item.src }}"
     state: directory
     mode: "{{ item.mode | default('0755') }}"
-  with_items: "{{ project_shared_children }}"
+  with_items: "{{ project.project_shared_children | default(project_shared_children) }}"
   when: item.type | default('directory') | lower == 'directory'
 
 - name: Ensure shared sources are present -- files' parent directories
@@ -18,7 +18,7 @@
     path: "{{ deploy_helper.shared_path }}/{{ item.src | dirname }}"
     state: directory
     mode: '0755'
-  with_items: "{{ project_shared_children }}"
+  with_items: "{{ project.project_shared_children | default(project_shared_children) }}"
   when: item.type | default('directory') | lower == 'file'
 
 - name: Ensure shared sources are present -- files
@@ -26,27 +26,27 @@
     path: "{{ deploy_helper.shared_path }}/{{ item.src }}"
     state: touch
     mode: "{{ item.mode | default('0644') }}"
-  with_items: "{{ project_shared_children }}"
+  with_items: "{{ project.project_shared_children | default(project_shared_children) }}"
   when: item.type | default('directory') | lower == 'file'
 
 - name: Ensure parent directories for shared paths are present
   file:
     path: "{{ deploy_helper.new_release_path }}/{{ item.path | dirname }}"
     state: directory
-  with_items: "{{ project_shared_children }}"
+  with_items: "{{ project.project_shared_children | default(project_shared_children) }}"
 
 - name: Ensure shared paths are absent
   file:
     path: "{{ deploy_helper.new_release_path }}/{{ item.path }}"
     state: absent
-  with_items: "{{ project_shared_children }}"
+  with_items: "{{ project.project_shared_children | default(project_shared_children) }}"
 
 - name: Create shared symlinks
   file:
     path: "{{ deploy_helper.new_release_path }}/{{ item.path }}"
     src: "{{ deploy_helper.shared_path }}/{{ item.src }}"
     state: link
-  with_items: "{{ project_shared_children }}"
+  with_items: "{{ project.project_shared_children | default(project_shared_children) }}"
 
 - include_tasks: "{{ include_path }}"
   with_items: "{{ deploy_share_after | default([]) }}"

--- a/roles/deploy/tasks/update.yml
+++ b/roles/deploy/tasks/update.yml
@@ -37,7 +37,7 @@
     repo: "{{ project_git_repo }}"
     dest: "{{ project_source_path }}"
     version: "{{ project_version }}"
-    accept_hostkey: "{{ repo_accept_hostkey | default(true) }}"
+    accept_hostkey: "{{ project.repo_accept_hostkey | default(repo_accept_hostkey | default(true)) }}"
   ignore_errors: true
   no_log: true
   register: git_clone


### PR DESCRIPTION
This PR makes it possible to add some deploy configs to each site in `wordpress_sites`. 

**The config that started all this.** I noticed that #854 added the `update_wp_theme_paths` toggle but could have made it optionally vary by site, vs. being global only. For example, it could be more like the `update_db_on_deploy` option used in the "[Update WP database](https://github.com/roots/trellis/blob/112a88717c9ac82e87531a55242156d47f279501/roles/deploy/hooks/finalize-after.yml#L32)" task.

This per-site configurability would be nice if a project/server were to have one tiny site that needs to `update_wp_theme_paths` and also a gigantic multisite network that does not need to `update_wp_theme_paths` and that would waste a lot of time trying to do so. It would be convenient if it were possible to add `update_wp_theme_paths: false` to the multisite network in `wordpress_sites`.

**Other configs that hopped on board.** I looked through roles that deal with individual sites (`wordpress-setup`, `wordpress-install`, and `deploy`), looking for global options that might also be nice to vary by site. This PR also adjusts the other configs that I thought were good candidates:

* `project_templates` (e.g., per-site packagist auth files?)
* `project_copy_folders` (e.g., ?)
* `project_shared_children` (e.g., specific language files)
* `repo_accept_hostkey`

-----

**Could take it all the way with deploy hooks.** This PR does not implement such a change for the deploy hook variables. However, it seems rather likely that users could want different deploy hook definitions per site (vs. just using a `{{ site }}` variable in the paths added to hooks). If implemented, each hook would need a change like this:

```diff
 - include_tasks: "{{ include_path }}"
-   with_items: "{{ deploy_finalize_after | default([]) }}"
+   with_items: "{{ project.deploy_finalize_after | default(deploy_finalize_after | default([])) }}"
   loop_control:
     loop_var: include_path
   tags: deploy-finalize-after
```