### PR TITLE
Update acme-tiny commit hash

### DIFF
--- a/roles/letsencrypt/defaults/main.yml
+++ b/roles/letsencrypt/defaults/main.yml
@@ -4,7 +4,7 @@ missing_hosts: "{{ site_hosts | difference((current_hosts.results | selectattr('
 letsencrypt_cert_ids: "{ {% for item in (generate_cert_ids | default({'results':[{'skipped':True}]})).results if not item | skipped %}'{{ item.item.key }}':'{{ item.stdout }}', {% endfor %} }"
 
 acme_tiny_repo: 'https://github.com/diafygi/acme-tiny.git'
-acme_tiny_commit: '5a7b4e79bc9bd5b51739c0d8aaf644f62cc440e6'
+acme_tiny_commit: '4ed13950c0a9cf61f1ca81ff1874cde1cf48ab32'
 
 acme_tiny_software_directory: /usr/local/letsencrypt
 acme_tiny_data_directory: /var/lib/letsencrypt


### PR DESCRIPTION
In response to #920. According to [this commit](https://github.com/diafygi/acme-tiny/commit/c4940d229a296b7643e86d2e9ab31a6e0099ba71) by @diafygi, this should also prevent this problem going forward by automatically grabbing the correct agreement URL, and according to [this post](https://community.letsencrypt.org/t/subscriber-agreement-update-november-15-2017/45607) over at LetsEncrypt, it is not necessary to re-sign the agreement every time it changes, so this problem should be resolved for good now?