### PR TITLE
Expose the deploy_helper keep_releases option

### DIFF
--- a/roles/deploy/tasks/finalize.yml
+++ b/roles/deploy/tasks/finalize.yml
@@ -11,6 +11,7 @@
     path: "{{ project_root }}"
     release: "{{ deploy_helper.new_release }}"
     state: finalize
+    keep_releases: "{{ project.deploy_keep_releases | default(deploy_keep_releases | default(omit)) }}"
 
 - include_tasks: "{{ include_path }}"
   with_items: "{{ deploy_finalize_after | default([]) }}"


### PR DESCRIPTION
The default keep_releases = 5 may not fit all users. 
* Want fewer: A server that hosts a huge number of sites may try to save space by keeping fewer past releases. 
* Want more: A project deployed especially frequently may want a more numerous collection of old releases for potential rollback, in case errors go unnoticed for many deploys.
