### PR TITLE
Switch from .dev to .test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### HEAD
+* Switch from `.dev` to `.test` ([#923](https://github.com/roots/trellis/pull/923))
+
 ### 1.0.0-rc.2: November 13th, 2017
 * Update wp-cli to 1.4.1 ([#918](https://github.com/roots/trellis/pull/918))
 * Disallow duplicate site keys within a host's `wordpress_sites` ([#910](https://github.com/roots/trellis/pull/910))

--- a/group_vars/development/wordpress_sites.yml
+++ b/group_vars/development/wordpress_sites.yml
@@ -5,11 +5,11 @@
 wordpress_sites:
   example.com:
     site_hosts:
-      - canonical: example.dev
+      - canonical: example.test
         redirects:
-          - www.example.dev
+          - www.example.test
     local_path: ../site # path targeting local Bedrock site directory (relative to Ansible root)
-    admin_email: admin@example.dev
+    admin_email: admin@example.test
     multisite:
       enabled: false
     ssl:


### PR DESCRIPTION
see #580 and https://ma.ttias.be/chrome-force-dev-domains-https-via-preloaded-hsts/