### PR TITLE
Add MariaDB 10.2 PPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Add MariaDB 10.2 PPA ([#926](https://github.com/roots/trellis/pull/926))
 * Switch from `.dev` to `.test` ([#923](https://github.com/roots/trellis/pull/923))
 
 ### 1.0.0-rc.2: November 13th, 2017

--- a/roles/mariadb/defaults/main.yml
+++ b/roles/mariadb/defaults/main.yml
@@ -1,3 +1,7 @@
+mariadb_keyserver: keyserver.ubuntu.com
+mariadb_keyserver_id: "0xF1656F24C74CD1D8"
+mariadb_ppa: "deb [arch=amd64,i386,ppc64el] http://ftp.osuosl.org/pub/mariadb/repo/10.2/ubuntu xenial main"
+
 mariadb_client_package: mariadb-client
 mariadb_server_package: mariadb-server
 

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -1,4 +1,15 @@
 ---
+- block:
+  - name: Add MariaDB APT key
+    apt_key:
+      keyserver: "{{ mariadb_keyserver }}"
+      id: "{{ mariadb_keyserver_id }}"
+
+  - name: Add MariaDB PPA
+    apt_repository:
+      repo: "{{ mariadb_ppa }}"
+      update_cache: yes
+
 - name: Install MySQL client
   apt:
     name: "{{ mariadb_client_package }}"


### PR DESCRIPTION
Tested.

10.2 is the current stable version, and I have chosen the main MariaDB mirror.

Closes #924 

Sidenote: We should also update the Nginx PPA to use Ondrej's instead of the official Nginx. At least according to his PPA page. https://launchpad.net/~ondrej/+archive/ubuntu/php

> If you are using nginx, you are advise to add ppa:ondrej/nginx-mainline or ppa:ondrej/nginx