### PR TITLE
Remove cron_file if WP system cron disabled

### DIFF
--- a/roles/wordpress-setup/tasks/main.yml
+++ b/roles/wordpress-setup/tasks/main.yml
@@ -49,8 +49,8 @@
     user: "{{ web_user }}"
     job: "cd {{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }} && wp cron event run --due-now > /dev/null 2>&1"
     cron_file: "wordpress-{{ item.key | replace('.', '_') }}"
+    state: "{{ (cron_enabled and not item.value.multisite.enabled) | ternary('present', 'absent') }}"
   with_dict: "{{ wordpress_sites }}"
-  when: cron_enabled and not item.value.multisite.enabled
 
 - name: Setup WP Multisite system cron
   cron:
@@ -59,5 +59,5 @@
     user: "{{ web_user }}"
     job: "cd {{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }} && wp site list --field=url | xargs -n1 -I \\% wp --url=\\% cron event run --due-now > /dev/null 2>&1"
     cron_file: "wordpress-multisite-{{ item.key | replace('.', '_') }}"
+    state: "{{ (cron_enabled and item.value.multisite.enabled) | ternary('present', 'absent') }}"
   with_dict: "{{ wordpress_sites }}"
-  when: cron_enabled and item.value.multisite.enabled


### PR DESCRIPTION
If a `cron_file` has already been created but then a user sets `multisite.cron: false`, these `cron` tasks should not skip. Rather, they should run with the parameter `state: absent` in order to remove the `cron_file`.

Example scenario: User discovers that the default of cron enabled for multisite is a problem due to a large number of sites. This PR empowers the user to disable the cron via a `multisite.cron: false` addition to `wordpress_sites`, rather than having to SSH and manually disable the cron.

Related discussion in #802