### PR TITLE
Update to PHP 7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Update to PHP 7.2 ([#929](https://github.com/roots/trellis/pull/929))
 * Fix `failed_when` in `template_root` check with wp-cli 1.5.0 ([#948](https://github.com/roots/trellis/pull/948))
 * Bump Ansible `version_tested_max` to 2.4.3.0 ([#945](https://github.com/roots/trellis/pull/945))
 * Update wp-cli to 1.5.0 ([#944](https://github.com/roots/trellis/pull/944))

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Trellis will configure a server with the following and more:
 
 * Ubuntu 16.04 Xenial LTS
 * Nginx (with optional FastCGI micro-caching)
-* PHP 7.1
+* PHP 7.2
 * MariaDB (a drop-in MySQL replacement)
 * SSL support (scores an A+ on the [Qualys SSL Labs Test](https://www.ssllabs.com/ssltest/))
 * Let's Encrypt integration for free SSL certificates

--- a/dev.yml
+++ b/dev.yml
@@ -1,5 +1,5 @@
 ---
-- name: "WordPress Server: Install LEMP Stack with PHP 7.1 and MariaDB MySQL"
+- name: "WordPress Server: Install LEMP Stack with PHP 7.2 and MariaDB MySQL"
   hosts: web:&development
   become: yes
   remote_user: vagrant

--- a/group_vars/all/users.yml
+++ b/group_vars/all/users.yml
@@ -19,4 +19,4 @@ users:
 web_user: web
 web_group: www-data
 web_sudoers:
-  - "/usr/sbin/service php7.1-fpm *"
+  - "/usr/sbin/service php7.2-fpm *"

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -9,7 +9,7 @@
 
 - name: reload php-fpm
   service:
-    name: php7.1-fpm
+    name: php7.2-fpm
     state: reloaded
 
 - import_tasks: reload_nginx.yml

--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -34,6 +34,6 @@
   when: wp_installed.rc == 0
 
 - name: Reload php-fpm
-  shell: sudo service php7.1-fpm reload
+  shell: sudo service php7.2-fpm reload
   args:
     warn: false

--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -2,19 +2,18 @@ disable_default_pool: true
 memcached_sessions: false
 
 php_extensions_default:
-  php7.1-cli: "{{ apt_package_state }}"
-  php7.1-common: "{{ apt_package_state }}"
-  php7.1-curl: "{{ apt_package_state }}"
-  php7.1-dev: "{{ apt_package_state }}"
-  php7.1-fpm: "{{ apt_package_state }}"
-  php7.1-gd: "{{ apt_package_state }}"
-  php7.1-mbstring: "{{ apt_package_state }}"
-  php7.1-mcrypt: "{{ apt_package_state }}"
-  php7.1-mysql: "{{ apt_package_state }}"
-  php7.1-opcache: "{{ apt_package_state }}"
-  php7.1-xml: "{{ apt_package_state }}"
-  php7.1-xmlrpc: "{{ apt_package_state }}"
-  php7.1-zip: "{{ apt_package_state }}"
+  php7.2-cli: "{{ apt_package_state }}"
+  php7.2-common: "{{ apt_package_state }}"
+  php7.2-curl: "{{ apt_package_state }}"
+  php7.2-dev: "{{ apt_package_state }}"
+  php7.2-fpm: "{{ apt_package_state }}"
+  php7.2-gd: "{{ apt_package_state }}"
+  php7.2-mbstring: "{{ apt_package_state }}"
+  php7.2-mysql: "{{ apt_package_state }}"
+  php7.2-opcache: "{{ apt_package_state }}"
+  php7.2-xml: "{{ apt_package_state }}"
+  php7.2-xmlrpc: "{{ apt_package_state }}"
+  php7.2-zip: "{{ apt_package_state }}"
 
 php_extensions_custom: {}
 php_extensions: "{{ php_extensions_default | combine(php_extensions_custom) }}"

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -1,24 +1,24 @@
 ---
-- name: Add PHP 7.1 PPA
+- name: Add PHP 7.2 PPA
   apt_repository:
     repo: "ppa:ondrej/php"
     update_cache: yes
 
-- name: Install PHP 7.1
+- name: Install PHP 7.2
   apt:
     name: "{{ item.key }}"
     state: "{{ item.value }}"
     cache_valid_time: "{{ apt_cache_valid_time }}"
   with_dict: "{{ php_extensions }}"
 
-- name: Start php7.1-fpm service
+- name: Start php7.2-fpm service
   service:
-    name: php7.1-fpm
+    name: php7.2-fpm
     state: started
     enabled: true
 
 - name: PHP configuration file
   template:
     src: php.ini.j2
-    dest: /etc/php/7.1/fpm/php.ini
+    dest: /etc/php/7.2/fpm/php.ini
   notify: reload php-fpm

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -17,6 +17,20 @@
     state: started
     enabled: true
 
+- name: Check for existing php7.1-fpm service
+  stat:
+    path: /etc/init.d/php7.1-fpm
+  register: php71_status
+
+- name: Stop php7.1-fpm service if it exists
+  service:
+    name: php7.1-fpm
+    state: stopped
+    enabled: false
+  register: service_stopped
+  when: php71_status.stat.exists
+  notify: reload php-fpm
+
 - name: PHP configuration file
   template:
     src: php.ini.j2

--- a/roles/wordpress-setup/tasks/main.yml
+++ b/roles/wordpress-setup/tasks/main.yml
@@ -26,13 +26,13 @@
 - name: Create WordPress php-fpm configuration file
   template:
     src: php-fpm.conf.j2
-    dest: /etc/php/7.1/fpm/pool.d/wordpress.conf
+    dest: /etc/php/7.2/fpm/pool.d/wordpress.conf
   notify: reload php-fpm
 
 - name: Disable default PHP-FPM pool
-  command: mv /etc/php/7.1/fpm/pool.d/www.conf /etc/php/7.1/fpm/pool.d/www.disabled
+  command: mv /etc/php/7.2/fpm/pool.d/www.conf /etc/php/7.2/fpm/pool.d/www.disabled
   args:
-    creates: /etc/php/7.1/fpm/pool.d/www.disabled
+    creates: /etc/php/7.2/fpm/pool.d/www.disabled
   when: disable_default_pool | default(true)
   notify: reload php-fpm
 

--- a/roles/xdebug/tasks/main.yml
+++ b/roles/xdebug/tasks/main.yml
@@ -9,13 +9,13 @@
   - name: Template the Xdebug configuration file
     template:
       src: xdebug.ini.j2
-      dest: /etc/php/7.1/mods-available/xdebug.ini
+      dest: /etc/php/7.2/mods-available/xdebug.ini
     notify: reload php-fpm
 
   - name: Ensure 20-xdebug.ini is present
     file:
-      src: /etc/php/7.1/mods-available/xdebug.ini
-      dest: /etc/php/7.1/fpm/conf.d/20-xdebug.ini
+      src: /etc/php/7.2/mods-available/xdebug.ini
+      dest: /etc/php/7.2/fpm/conf.d/20-xdebug.ini
       state: link
     notify: reload php-fpm
 
@@ -23,12 +23,12 @@
 
 - name: Disable Xdebug
   file:
-    path: /etc/php/7.1/fpm/conf.d/20-xdebug.ini
+    path: /etc/php/7.2/fpm/conf.d/20-xdebug.ini
     state: absent
   when: not xdebug_remote_enable | bool
   notify: reload php-fpm
 
 - name: Disable Xdebug CLI
   file:
-    path: /etc/php/7.1/cli/conf.d/20-xdebug.ini
+    path: /etc/php/7.2/cli/conf.d/20-xdebug.ini
     state: absent

--- a/server.yml
+++ b/server.yml
@@ -19,7 +19,7 @@
       register: python_check
       changed_when: not python_check.stdout | search('/usr/bin/python')
 
-- name: WordPress Server - Install LEMP Stack with PHP 7.1 and MariaDB MySQL
+- name: WordPress Server - Install LEMP Stack with PHP 7.2 and MariaDB MySQL
   hosts: web:&{{ env }}
   become: yes
   roles:

--- a/xdebug-tunnel.yml
+++ b/xdebug-tunnel.yml
@@ -14,5 +14,5 @@
   handlers:
     - name: reload php-fpm
       service:
-        name: php7.1-fpm
+        name: php7.2-fpm
         state: reloaded


### PR DESCRIPTION
note: xdebug currently not avail, see https://github.com/oerdnj/deb.sury.org/issues/751

the `mcrypt` extension is also removed (see http://php.net/manual/en/migration71.deprecated.php)

Note: this PR will install all necessary PHP 7.2 packages and *stop* the existing 7.1 service if it exists. PHP 7.1 packages will still remain installed but unused. They can be manually uninstalled if need be. We aren't automatically cleaning up the 7.1 packages because people might have custom packages installed. This also allows for easier rollback if need be.