### PR TITLE
Bump Ansible version_tested_max to 2.4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Bump Ansible `version_tested_max` to 2.4.2.0 ([#932](https://github.com/roots/trellis/pull/932))
 * Add MariaDB 10.2 PPA ([#926](https://github.com/roots/trellis/pull/926))
 * Switch from `.dev` to `.test` ([#923](https://github.com/roots/trellis/pull/923))
 

--- a/lib/trellis/plugins/vars/version.py
+++ b/lib/trellis/plugins/vars/version.py
@@ -14,7 +14,7 @@ except ImportError:
     display = Display()
 
 version_requirement = '2.4.0.0'
-version_tested_max = '2.4.1.0'
+version_tested_max = '2.4.2.0'
 
 if not ge(LooseVersion(__version__), LooseVersion(version_requirement)):
     raise AnsibleError(('Trellis no longer supports Ansible {}.\n'

--- a/lib/trellis/utils/output.py
+++ b/lib/trellis/utils/output.py
@@ -62,10 +62,9 @@ def display(obj, result):
     display = obj._display.display
     wrap_width = 77
     first = obj.first_host and obj.first_item
-    failed = result.get('failed', False) or result.get('unreachable', False)
 
     # Only display msg if debug module or if failed (some modules have undesired 'msg' on 'ok')
-    if 'msg' in result and (failed or obj.action == 'debug'):
+    if 'msg' in result and (obj.task_failed or obj.action == 'debug'):
         msg = result.pop('msg', '')
 
         # Disable Ansible's verbose setting for debug module to avoid the CallbackBase._dump_results()
@@ -73,7 +72,7 @@ def display(obj, result):
             del result['_ansible_verbose_always']
 
     # Display additional info when failed
-    if failed:
+    if obj.task_failed:
         items = (item for item in ['reason', 'module_stderr', 'module_stdout', 'stderr'] if item in result and to_text(result[item]) != '')
         for item in items:
             msg = result[item] if msg == '' else '\n'.join([msg, result.pop(item, '')])
@@ -106,7 +105,7 @@ def display(obj, result):
     else:
         if not first:
             display(hr, 'bright gray')
-        display(msg, 'red' if failed else 'bright purple')
+        display(msg, 'red' if obj.task_failed else 'bright purple')
 
 def display_host(obj, result):
     if 'results' not in result._result:

--- a/vagrant.default.yml
+++ b/vagrant.default.yml
@@ -4,7 +4,7 @@ vagrant_cpus: 1
 vagrant_memory: 1024 # in MB
 vagrant_box: 'bento/ubuntu-16.04'
 vagrant_box_version: '<= 201710.25.0'
-vagrant_ansible_version: '2.4.1.0'
+vagrant_ansible_version: '2.4.2.0'
 vagrant_skip_galaxy: false
 
 vagrant_install_plugins: true


### PR DESCRIPTION
In my tests, Trellis works with Ansible 2.4.2.0 as expected.

The only exception is that the Trellis `output.py` callback plugin was not formatting failure output as expected (e.g., not interpreting `\n` line breaks). The plugin had been triggering such formatting when the `failed: True` status appeared in the `result` formerly sent to callbacks. 

Such statuses were removed in ansible/ansible#27175, the rationale being that "statuses are already reflected on the event type." For example, the `v2_runner_on_failed` event obviously implies `failed` status. The Trellis output plugin was already loading and passing along a `task_failed` attribute that can serve just as well. 

Before fix
```
TASK [connection : Warn about change in host keys] **************************************************************************
System info:
  Ansible 2.4.2.0; Darwin
  Trellis at "Add MariaDB 10.2 PPA"
---------------------------------------------------
fatal: [example.com]: FAILED! => {"changed": false, "msg": "WARNING: REMOTE HOST IDENTIFICATION HAS
CHANGED!\n\nIf this change in host keys is expected (e.g., if you rebuilt the server\nor if the
Trellis sshd role made changes recently), then run the following\ncommand to clear the old host key
from your known_hosts.\n\n  ssh-keygen -R example.com\n\nThen try your Trellis playbook or SSH 
connection again.\n\nIf the change is unexpected, cautiously consider why the host 
identification\nmay have changed and whether you may be victim to a man-in-the-middle attack.
```

After fix
```
TASK [connection : Warn about change in host keys] **************************************************************************
System info:
  Ansible 2.4.2.0; Darwin
  Trellis at "Bump Ansible `version_tested_max` to 2.4.2.0"
---------------------------------------------------
WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!

If this change in host keys is expected (e.g., if you rebuilt the server
or if the Trellis sshd role made changes recently), then run the following
command to clear the old host key from your known_hosts.

  ssh-keygen -R example.com

Then try your Trellis playbook or SSH connection again.

If the change is unexpected, cautiously consider why the host identification
may have changed and whether you may be victim to a man-in-the-middle attack.
```