### PR TITLE
Allow Trellis VMs to be created in Windows Subsystem for Linux

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,7 +69,7 @@ Vagrant.configure('2') do |config|
 
   bin_path = File.join(ANSIBLE_PATH_ON_VM, 'bin')
 
-  if Vagrant::Util::Platform.windows? and !Vagrant.has_plugin? 'vagrant-winnfsd'
+  if Vagrant::Util::Platform.wsl? || (Vagrant::Util::Platform.windows? and !Vagrant.has_plugin? 'vagrant-winnfsd')
     trellis_config.wordpress_sites.each_pair do |name, site|
       config.vm.synced_folder local_site_path(site), remote_site_path(name, site), owner: 'vagrant', group: 'www-data', mount_options: ['dmode=776', 'fmode=775']
     end


### PR DESCRIPTION
WSL does not support NFS, but Trellis's checks to determine whether or not to
use NFS for Vagrant shares assume that NFS is supported if the operating system
is not reported to be Windows. Unfortunately this means that it attempts to
use NFS in WSL and consequently fails..

This change simply adds an additional check: If Vagrant believes that it is
being run from WSL, it syncs folders without NFS (just as though it was
running in Windows without `vagrant-winnfsd`). Other than that, it should
have no effect on any other functionality.

Note: This applies to Vagrant when it is run as a Linux executable through
WSL, *not* when the Windows `vagrant.exe` is run from WSL.