### PR TITLE
Support for IPv6 in Letsencrypt challenges

### DIFF
--- a/roles/letsencrypt/templates/nginx-challenge-site.conf.j2
+++ b/roles/letsencrypt/templates/nginx-challenge-site.conf.j2
@@ -1,4 +1,5 @@
 server {
+  listen [::]:80;
   listen 80;
   server_name {{ missing_hosts | join(' ') }};
   include acme-challenge-location.conf;


### PR DESCRIPTION
When trying to validate the hostnames prior to the certificate generation process, it will fail if the IPv6 address is set for those hostnames and the server uses the protocol. This should fix this behavior.