### PR TITLE
Update Vagrant requirement to v2.0.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Full documentation is available at [https://roots.io/trellis/docs/](https://root
 Make sure all dependencies have been installed before moving on:
 
 * [Virtualbox](https://www.virtualbox.org/wiki/Downloads) >= 4.3.10
-* [Vagrant](https://www.vagrantup.com/downloads.html) >= 1.8.5
+* [Vagrant](https://www.vagrantup.com/downloads.html) >= 2.0.1
 
 ## Installation
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,7 @@ ensure_plugins(vconfig.fetch('vagrant_plugins')) if vconfig.fetch('vagrant_insta
 
 trellis_config = Trellis::Config.new(root_path: ANSIBLE_PATH)
 
-Vagrant.require_version '>= 1.8.5'
+Vagrant.require_version '>= 2.0.1'
 
 Vagrant.configure('2') do |config|
   config.vm.box = vconfig.fetch('vagrant_box')


### PR DESCRIPTION
This is necessary to support the changes introduced in commit 0015b95, specifically the use of the `Vagrant::Util::Platform.wsl?` test in the Vagrantfile.

Addressed on Discourse [here](https://discourse.roots.io/t/undefined-method-wsl/11351/4).