### PR TITLE
Update `vagrant_box_version` to `<= 201801.02.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Update `vagrant_box_version` to `<= 201801.02.0` ([#938](https://github.com/roots/trellis/pull/938))
 * Bump Ansible `version_tested_max` to 2.4.2.0 ([#932](https://github.com/roots/trellis/pull/932))
 * Add MariaDB 10.2 PPA ([#926](https://github.com/roots/trellis/pull/926))
 * Switch from `.dev` to `.test` ([#923](https://github.com/roots/trellis/pull/923))

--- a/vagrant.default.yml
+++ b/vagrant.default.yml
@@ -3,7 +3,7 @@ vagrant_ip: '192.168.50.5'
 vagrant_cpus: 1
 vagrant_memory: 1024 # in MB
 vagrant_box: 'bento/ubuntu-16.04'
-vagrant_box_version: '<= 201710.25.0'
+vagrant_box_version: '<= 201801.02.0'
 vagrant_ansible_version: '2.4.2.0'
 vagrant_skip_galaxy: false
 


### PR DESCRIPTION
See: https://app.vagrantup.com/bento/boxes/ubuntu-16.04

---

Question:
The box is `ubuntu-16.04`. Should we use lower-bound version constraint instead of upper-bound?
I.e.: Will this be better? 

```
vagrant_box_version: '>= 201801.02.0'
```