### PR TITLE
Update `vagrant_box_version` to `>= 201801.02.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### HEAD
-* Update `vagrant_box_version` to `<= 201801.02.0` ([#938](https://github.com/roots/trellis/pull/938))
+* Update `vagrant_box_version` to `>= 201801.02.0` ([#939](https://github.com/roots/trellis/pull/939))
 * Bump Ansible `version_tested_max` to 2.4.2.0 ([#932](https://github.com/roots/trellis/pull/932))
 * Add MariaDB 10.2 PPA ([#926](https://github.com/roots/trellis/pull/926))
 * Switch from `.dev` to `.test` ([#923](https://github.com/roots/trellis/pull/923))

--- a/vagrant.default.yml
+++ b/vagrant.default.yml
@@ -3,7 +3,7 @@ vagrant_ip: '192.168.50.5'
 vagrant_cpus: 1
 vagrant_memory: 1024 # in MB
 vagrant_box: 'bento/ubuntu-16.04'
-vagrant_box_version: '<= 201801.02.0'
+vagrant_box_version: '>= 201801.02.0'
 vagrant_ansible_version: '2.4.2.0'
 vagrant_skip_galaxy: false
 


### PR DESCRIPTION
Follow up on #938

Issues with box version *should* be very rare.
During the past 6 months of using Trellis, I never encountered any issues with box version. Besides, when provisioning production servers, we can't control which server image the hosting company provides. Trellis should work as long as it's ubuntu 16.04.