### PR TITLE
Update wp-cli to 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Update wp-cli to 1.5.0 ([#944](https://github.com/roots/trellis/pull/944))
 * Update `vagrant_box_version` to `>= 201801.02.0` ([#939](https://github.com/roots/trellis/pull/939))
 * Bump Ansible `version_tested_max` to 2.4.2.0 ([#932](https://github.com/roots/trellis/pull/932))
 * Add MariaDB 10.2 PPA ([#926](https://github.com/roots/trellis/pull/926))

--- a/roles/wp-cli/defaults/main.yml
+++ b/roles/wp-cli/defaults/main.yml
@@ -1,4 +1,4 @@
-wp_cli_version: 1.4.1
+wp_cli_version: 1.5.0
 wp_cli_bin_path: /usr/bin/wp
 wp_cli_phar_url: "https://github.com/wp-cli/wp-cli/releases/download/v{{ wp_cli_version }}/wp-cli-{{ wp_cli_version }}.phar"
 wp_cli_completion_url: "https://raw.githubusercontent.com/wp-cli/wp-cli/v{{ wp_cli_version }}/utils/wp-completion.bash"


### PR DESCRIPTION
See: https://make.wordpress.org/cli/2018/01/31/version-1-5-0-released/