### PR TITLE
Bump Ansible version_tested_max to 2.4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Bump Ansible `version_tested_max` to 2.4.3.0 ([#945](https://github.com/roots/trellis/pull/945))
 * Update wp-cli to 1.5.0 ([#944](https://github.com/roots/trellis/pull/944))
 * Update `vagrant_box_version` to `>= 201801.02.0` ([#939](https://github.com/roots/trellis/pull/939))
 * Bump Ansible `version_tested_max` to 2.4.2.0 ([#932](https://github.com/roots/trellis/pull/932))

--- a/lib/trellis/plugins/vars/version.py
+++ b/lib/trellis/plugins/vars/version.py
@@ -14,7 +14,7 @@ except ImportError:
     display = Display()
 
 version_requirement = '2.4.0.0'
-version_tested_max = '2.4.2.0'
+version_tested_max = '2.4.3.0'
 
 if not ge(LooseVersion(__version__), LooseVersion(version_requirement)):
     raise AnsibleError(('Trellis no longer supports Ansible {}.\n'

--- a/lib/trellis/utils/output.py
+++ b/lib/trellis/utils/output.py
@@ -45,8 +45,14 @@ def reset_task_info(obj, task=None):
 
 # Display dict key only, instead of full json dump
 def replace_item_with_key(obj, result):
-    if not obj._display.verbosity and 'label' not in result._task._ds.get('loop_control', {}):
-        item = '_ansible_item_label' if '_ansible_item_label' in result._result else 'item'
+    item = '_ansible_item_label' if '_ansible_item_label' in result._result else 'item'
+    should_replace = (
+        not obj._display.verbosity
+        and 'label' not in result._task._ds.get('loop_control', {})
+        and item in result._result
+    )
+
+    if should_replace:
         if 'key' in result._result[item]:
             result._result[item] = result._result[item]['key']
         elif type(result._result[item]) is dict:

--- a/vagrant.default.yml
+++ b/vagrant.default.yml
@@ -4,7 +4,7 @@ vagrant_cpus: 1
 vagrant_memory: 1024 # in MB
 vagrant_box: 'bento/ubuntu-16.04'
 vagrant_box_version: '>= 201801.02.0'
-vagrant_ansible_version: '2.4.2.0'
+vagrant_ansible_version: '2.4.3.0'
 vagrant_skip_galaxy: false
 
 vagrant_install_plugins: true


### PR DESCRIPTION
I found no adjustments needed to accommodate Ansible 2.4.3.0.

However, @runofthemill kindly pointed out a problem on `vagrant up` for various Ansible versions:

```
TASK [wordpress-install : Setup packagist.com authentication] ******************
 [WARNING]: Failure using method (v2_runner_item_on_skipped) in callback plugin
(<ansible.plugins.callback.output.CallbackModule object at 0x7f9cd2039150>):
'item'
```

This PR adds a fix for this cosmetic problem, enabling the `replace_item_with_key()` custom output method to handle tasks that use `with_dict` and `no_log`. 

To avoid a long line, the fix uses a multiline conditional which can have funny [formatting in python](https://www.python.org/dev/peps/pep-0008/#indentation). I took the formatting approach [here](https://www.naftaliharris.com/blog/python-multiline-if-statements/). However, the condition wouldn't be too terribly long on a single line, if preferred.