### PR TITLE
Fix failed_when in template_root check with wp-cli 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Fix `failed_when` in `template_root` check with wp-cli 1.5.0 ([#948](https://github.com/roots/trellis/pull/948))
 * Bump Ansible `version_tested_max` to 2.4.3.0 ([#945](https://github.com/roots/trellis/pull/945))
 * Update wp-cli to 1.5.0 ([#944](https://github.com/roots/trellis/pull/944))
 * Update `vagrant_box_version` to `>= 201801.02.0` ([#939](https://github.com/roots/trellis/pull/939))

--- a/roles/deploy/hooks/finalize-before.yml
+++ b/roles/deploy/hooks/finalize-before.yml
@@ -23,7 +23,7 @@
     chdir: "{{ deploy_helper.current_path }}"
   register: wp_template_root
   changed_when: false
-  failed_when: wp_template_root.stderr  | default('') != ''
+  failed_when: not wp_template_root.stderr | default('') | match("(|.*Could not get '" + item + "' option\. Does it exist\?)")
   when:
     - wp_installed.rc == 0
     - project.update_wp_theme_paths | default(update_wp_theme_paths | default(true)) | bool


### PR DESCRIPTION
Previous wp-cli versions returned rc=1 and stderr='' for `wp option get template_root` when the option didn't exist. Version 1.5.0 (#944) uses a new stderr message.

This PR changes to only failing if stderr is not empty and does not match this new and expected message.

Alternatively, it would probably be fine to simply use `failed_when: false`

This PR prevents errors like the following:
```
TASK [deploy : Get WP theme template and stylesheet roots] *****************************************
System info:
  Ansible 2.4.3.0; Darwin
  Trellis at "Bump Ansible `version_tested_max` to 2.4.3.0"
---------------------------------------------------
non-zero return code
Error: Could not get 'template_root' option. Does it exist?
failed: [138.68.203.29] (item=template_root) => {"changed": false, "cmd": " wp option get 
template_root --skip-plugins --skip-themes\n ", "delta": "0:00:00.343446", "end": "2018-02-08 
23:36:30.191017", "failed_when_result": true, "item": "template_root", "rc": 1, "start": "2018-02-08 
23:36:29.847571", "stderr_lines": ["Error: Could not get 'template_root' option. Does it exist?"], 
"stdout": "", "stdout_lines": []}
---------------------------------------------------
non-zero return code
Error: Could not get 'stylesheet_root' option. Does it exist?
failed: [138.68.203.29] (item=stylesheet_root) => {"changed": false, "cmd": " wp option get 
stylesheet_root --skip-plugins --skip-themes\n ", "delta": "0:00:00.372746", "end": "2018-02-08 
23:36:30.911272", "failed_when_result": true, "item": "stylesheet_root", "rc": 1, "start": "2018-02-08 
23:36:30.538526", "stderr_lines": ["Error: Could not get 'stylesheet_root' option. Does it exist?"], 
"stdout": "", "stdout_lines": []}
```