### PR TITLE
Git: Ignore `vagrant.local.yml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vault_pass
 .vagrant
+vagrant.local.yml
 vendor/roles
 *.py[co]
 *.retry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Git: Ignore `vagrant.local.yml`([#953](https://github.com/roots/trellis/pull/953))
 * Update to PHP 7.2 ([#929](https://github.com/roots/trellis/pull/929))
 * Fix `failed_when` in `template_root` check with wp-cli 1.5.0 ([#948](https://github.com/roots/trellis/pull/948))
 * Bump Ansible `version_tested_max` to 2.4.3.0 ([#945](https://github.com/roots/trellis/pull/945))


### PR DESCRIPTION
`vagrant.local.yml` is meant to be untracked as per https://github.com/roots/trellis/pull/828/commits/f6be4ac52183c5c491ac0720117d61573d6bd4e3