### PR TITLE
Disable memcached UDP support by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* [BREAKING] Disable memcached UDP support by default ([#955](https://github.com/roots/trellis/pull/955))
 * Git: Ignore `vagrant.local.yml`([#953](https://github.com/roots/trellis/pull/953))
 * Update to PHP 7.2 ([#929](https://github.com/roots/trellis/pull/929))
 * Fix `failed_when` in `template_root` check with wp-cli 1.5.0 ([#948](https://github.com/roots/trellis/pull/948))

--- a/roles/memcached/defaults/main.yml
+++ b/roles/memcached/defaults/main.yml
@@ -4,6 +4,7 @@ memcached_fs_file_max: 756024
 memcached_listen_ip: 127.0.0.1
 memcached_max_conn: 1024
 memcached_port: 11211
+memcached_port_udp: 0
 
 memcached_packages_default:
   memcached: "{{ apt_package_state }}"

--- a/roles/memcached/templates/memcached.conf.j2
+++ b/roles/memcached/templates/memcached.conf.j2
@@ -10,6 +10,11 @@
 # information.
 -d
 
+# modifies the UDP port, defaulting to on.
+# UDP is useful for fetching or setting small items, not as useful for manipulating large items.
+# Setting this to 0 will disable it, if you're worried.
+-U {{ memcached_port_udp }}
+
 # Log memcached's output to /var/log/memcached
 logfile /var/log/memcached.log
 


### PR DESCRIPTION
memcached can be exploited via UDP. This disables it by default.

See https://blog.cloudflare.com/memcrashed-major-amplification-attacks-from-port-11211/
form more details.