### PR TITLE
Update Ansible default plugin paths in config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* [BREAKING] Update Ansible default plugin paths in config files ([#958](https://github.com/roots/trellis/pull/958))
 * Add Nginx `ssl.no-default.conf` to drop requests for unknown hosts ([#888](https://github.com/roots/trellis/pull/888))
 * [BREAKING] Disable memcached UDP support by default ([#955](https://github.com/roots/trellis/pull/955))
 * Git: Ignore `vagrant.local.yml`([#953](https://github.com/roots/trellis/pull/953))

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,13 +1,13 @@
 [defaults]
-callback_plugins = ~/.ansible/plugins/callback_plugins/:/usr/share/ansible_plugins/callback_plugins:lib/trellis/plugins/callback
+callback_plugins = ~/.ansible/plugins/callback:/usr/share/ansible/plugins/callback:lib/trellis/plugins/callback
 stdout_callback = output
-filter_plugins = ~/.ansible/plugins/filter_plugins/:/usr/share/ansible_plugins/filter_plugins:lib/trellis/plugins/filter
+filter_plugins = ~/.ansible/plugins/filter:/usr/share/ansible/plugins/filter:lib/trellis/plugins/filter
 force_color = True
 force_handlers = True
 inventory = hosts
 nocows = 1
 roles_path = vendor/roles
-vars_plugins = ~/.ansible/plugins/vars_plugins/:/usr/share/ansible_plugins/vars_plugins:lib/trellis/plugins/vars
+vars_plugins = ~/.ansible/plugins/vars:/usr/share/ansible/plugins/vars:lib/trellis/plugins/vars
 
 [ssh_connection]
 ssh_args = -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s

--- a/lib/trellis/vagrant.rb
+++ b/lib/trellis/vagrant.rb
@@ -1,10 +1,10 @@
 # Set Ansible paths relative to Ansible directory
 ENV['ANSIBLE_CONFIG'] = ANSIBLE_PATH
-ENV['ANSIBLE_CALLBACK_PLUGINS'] = "~/.ansible/plugins/callback_plugins/:/usr/share/ansible_plugins/callback_plugins:#{File.join(ANSIBLE_PATH, 'lib/trellis/plugins/callback')}"
-ENV['ANSIBLE_FILTER_PLUGINS'] = "~/.ansible/plugins/filter_plugins/:/usr/share/ansible_plugins/filter_plugins:#{File.join(ANSIBLE_PATH, 'lib/trellis/plugins/filter')}"
-ENV['ANSIBLE_LIBRARY'] = "/usr/share/ansible:#{File.join(ANSIBLE_PATH, 'lib/trellis/modules')}"
+ENV['ANSIBLE_CALLBACK_PLUGINS'] = "~/.ansible/plugins/callback:/usr/share/ansible/plugins/callback:#{File.join(ANSIBLE_PATH, 'lib/trellis/plugins/callback')}"
+ENV['ANSIBLE_FILTER_PLUGINS'] = "~/.ansible/plugins/filter:/usr/share/ansible/plugins/filter:#{File.join(ANSIBLE_PATH, 'lib/trellis/plugins/filter')}"
+ENV['ANSIBLE_LIBRARY'] = "~/.ansible/plugins/modules:/usr/share/ansible/plugins/modules:#{File.join(ANSIBLE_PATH, 'lib/trellis/modules')}"
 ENV['ANSIBLE_ROLES_PATH'] = File.join(ANSIBLE_PATH, 'vendor', 'roles')
-ENV['ANSIBLE_VARS_PLUGINS'] = "~/.ansible/plugins/vars_plugins/:/usr/share/ansible_plugins/vars_plugins:#{File.join(ANSIBLE_PATH, 'lib/trellis/plugins/vars')}"
+ENV['ANSIBLE_VARS_PLUGINS'] = "~/.ansible/plugins/vars:/usr/share/ansible/plugins/vars:#{File.join(ANSIBLE_PATH, 'lib/trellis/plugins/vars')}"
 
 def ensure_plugins(plugins)
   logger = Vagrant::UI::Colored.new


### PR DESCRIPTION
[ansible/ansible#12378](https://github.com/ansible/ansible/pull/12378/commits/4aea1f6568eae668728390f06d57ec6afb314ca2#diff-b77962b6b54a830ec373de0602918318R187) changed Ansible's default plugin paths. At the time, Ansible set these defaults in `lib/ansible/constants.py` but now in [`lib/ansible/config/base.yml`](https://github.com/ansible/ansible/blob/v2.4.3.0-1/lib/ansible/config/base.yml#L522) (i.e., [ansible config](http://docs.ansible.com/ansible/latest/intro_configuration.html#callback-plugins); 
location change in ansible/ansible#27448).

This PR updates these default paths in Trellis `ansible.cfg` and `lib/trellis/vagrant.rb`.

The CHANGELOG entry marks this as `[BREAKING]` for the uncommon case that users have plugins in any of the out-of-date locations.