### PR TITLE
Vagrant: Use DHCP by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Vagrant: Use DHCP by default ([#960](https://github.com/roots/trellis/pull/960))
 * Fix `raw_vars` feature to properly handle int values ([#959](https://github.com/roots/trellis/pull/959))
 * [BREAKING] Update Ansible default plugin paths in config files ([#958](https://github.com/roots/trellis/pull/958))
 * Add Nginx `ssl.no-default.conf` to drop requests for unknown hosts ([#888](https://github.com/roots/trellis/pull/888))

--- a/vagrant.default.yml
+++ b/vagrant.default.yml
@@ -1,5 +1,5 @@
 ---
-vagrant_ip: '192.168.50.5'
+vagrant_ip: 'dhcp'
 vagrant_cpus: 1
 vagrant_memory: 1024 # in MB
 vagrant_box: 'bento/ubuntu-16.04'


### PR DESCRIPTION
Upstream issues resolved.

Related: https://github.com/roots/trellis/issues/902

Tested on:
* macOS 10.13.3
* ansible 2.4.3.0
* vagrant-bindfs 1.1.0
* vagrant-hostmanager 1.8.7

# Help Wanted

This patch needs tests on other OS.