### PR TITLE
Ensure Diffie-Hellman group is generated for Let's Encrypt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Ensure Diffie-Hellman group is generated for Let's Encrypt ([#964](https://github.com/roots/trellis/pull/964))
 * Fix `raw_vars` feature to properly handle int values ([#959](https://github.com/roots/trellis/pull/959))
 * [BREAKING] Update Ansible default plugin paths in config files ([#958](https://github.com/roots/trellis/pull/958))
 * Add Nginx `ssl.no-default.conf` to drop requests for unknown hosts ([#888](https://github.com/roots/trellis/pull/888))

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -23,7 +23,7 @@
     creates: "{{ nginx_path }}/ssl/dhparams.pem"
   when: sites_use_ssl
   notify: reload nginx
-  tags: [diffie-hellman, wordpress, wordpress-setup, nginx-includes, nginx-sites]
+  tags: [diffie-hellman, letsencrypt, wordpress, wordpress-setup, nginx-includes, nginx-sites]
 
 - name: Grab h5bp/server-configs-nginx
   git:


### PR DESCRIPTION
This PR adds the `letsencrypt` tag to the task generating the Diffie-Hellman group, ensuring the task runs when playbook is run with `--tags letsencrypt`. I intended to add this among the new tags in #888 but missed it. Thanks @partounian for noticing and reporting in #963.