### PR TITLE
Refactor --subdomains flag in the Install WP task

### DIFF
--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -48,7 +48,9 @@
            --url="{{ site_env.wp_home }}"
            {% if item.value.multisite.enabled | default(false) %}
            --base="{{ item.value.multisite.base_path | default('/') }}"
-           --subdomains="{{ item.value.multisite.subdomains | default('false') }}"
+           {% if item.value.multisite.subdomains | default('false') %}
+           --subdomains
+           {% endif %}
            {% endif %}
            --title="{{ item.value.site_title | default(item.key) }}"
            --admin_user="{{ item.value.admin_user | default('admin') }}"


### PR DESCRIPTION
According to the [documentation](https://developer.wordpress.org/cli/commands/core/multisite-install/) the existance of the --subdomains is boolean value. If the `item.value.multisite.subdomains` was set to false (or not set) this task was treating it as it's set to true.

This commit is fixing this.