### PR TITLE
Add Vagrant files for staging

### DIFF
--- a/staging/Vagrantfile
+++ b/staging/Vagrantfile
@@ -1,0 +1,108 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+ANSIBLE_PATH = File.join(__dir__, '..') # absolute path to Ansible directory on host machine
+ANSIBLE_PATH_ON_VM = '/home/vagrant/trellis' # absolute path to Ansible directory on virtual machine
+
+require File.join(ANSIBLE_PATH, 'lib', 'trellis', 'vagrant')
+require File.join(ANSIBLE_PATH, 'lib', 'trellis', 'config')
+require 'yaml'
+
+vconfig = YAML.load_file("#{ANSIBLE_PATH}/staging/vagrant.staging.yml")
+
+if File.exist?("#{ANSIBLE_PATH}/staging/vagrant.local.yml")
+  local_config = YAML.load_file("#{ANSIBLE_PATH}/staging/vagrant.local.yml")
+  vconfig.merge!(local_config) if local_config
+end
+
+ensure_plugins(vconfig.fetch('vagrant_plugins')) if vconfig.fetch('vagrant_install_plugins')
+
+trellis_config = Trellis::Config.new(root_path: ANSIBLE_PATH)
+
+Vagrant.require_version '>= 1.8.5'
+
+Vagrant.configure('2') do |config|
+  config.vm.box = vconfig.fetch('vagrant_box')
+  config.vm.box_version = vconfig.fetch('vagrant_box_version')
+  config.ssh.forward_agent = true
+  config.vm.post_up_message = post_up_message
+
+  # Fix for: "stdin: is not a tty"
+  # https://github.com/mitchellh/vagrant/issues/1673#issuecomment-28288042
+  config.ssh.shell = %{bash -c 'BASH_ENV=/etc/profile exec bash'}
+
+  main_hostname, *hostnames = trellis_config.site_hosts_canonical
+  config.vm.hostname = main_hostname
+
+  if Vagrant.has_plugin?('vagrant-hostmanager') && !trellis_config.multisite_subdomains?
+    redirects = trellis_config.site_hosts_redirects
+
+    config.hostmanager.enabled = true
+    config.hostmanager.manage_host = true
+    config.hostmanager.aliases = hostnames + redirects
+  elsif Vagrant.has_plugin?('landrush') && trellis_config.multisite_subdomains?
+    config.landrush.enabled = true
+    config.landrush.tld = config.vm.hostname
+    hostnames.each { |host| config.landrush.host host, vconfig.fetch('vagrant_ip') }
+  else
+    fail_with_message "vagrant-hostmanager missing, please install the plugin with this command:\nvagrant plugin install vagrant-hostmanager\n\nOr install landrush for multisite subdomains:\nvagrant plugin install landrush"
+  end
+
+  provisioner = local_provisioning? ? :ansible_local : :ansible
+  provisioning_path = local_provisioning? ? ANSIBLE_PATH_ON_VM : ANSIBLE_PATH
+
+  config.vm.provision provisioner do |ansible|
+    if local_provisioning?
+      ansible.install_mode = 'pip'
+      ansible.provisioning_path = provisioning_path
+      ansible.version = vconfig.fetch('vagrant_ansible_version')
+    end
+
+    ansible.playbook = File.join(provisioning_path, 'server.yml')
+    ansible.galaxy_role_file = File.join(provisioning_path, 'requirements.yml') unless vconfig.fetch('vagrant_skip_galaxy') || ENV['SKIP_GALAXY']
+    ansible.galaxy_roles_path = File.join(provisioning_path, 'vendor/roles')
+
+    ansible.groups = {
+      'web' => ['default'],
+      'staging' => ['default'],
+      'mail' => ['default']
+    }
+
+    ansible.tags = ENV['ANSIBLE_TAGS']
+    ansible.extra_vars = { 'env': 'staging', 'vagrant_version' => Vagrant::VERSION }
+
+    if vars = ENV['ANSIBLE_VARS']
+      extra_vars = Hash[vars.split(',').map { |pair| pair.split('=') }]
+      ansible.extra_vars.merge!(extra_vars)
+    end
+  end
+
+  # Virtualbox settings
+  config.vm.provider 'virtualbox' do |vb|
+    vb.name = config.vm.hostname
+    vb.customize ['modifyvm', :id, '--cpus', vconfig.fetch('vagrant_cpus')]
+    vb.customize ['modifyvm', :id, '--memory', vconfig.fetch('vagrant_memory')]
+    vb.customize ['modifyvm', :id, '--ioapic', vconfig.fetch('vagrant_ioapic', 'on')]
+
+    # Fix for slow external network connections
+    vb.customize ['modifyvm', :id, '--natdnshostresolver1', vconfig.fetch('vagrant_natdnshostresolver', 'on')]
+    vb.customize ['modifyvm', :id, '--natdnsproxy1', vconfig.fetch('vagrant_natdnsproxy', 'on')]
+  end
+
+  # VMware Workstation/Fusion settings
+  ['vmware_fusion', 'vmware_workstation'].each do |provider|
+    config.vm.provider provider do |vmw, override|
+      vmw.name = config.vm.hostname
+      vmw.vmx['numvcpus'] = vconfig.fetch('vagrant_cpus')
+      vmw.vmx['memsize'] = vconfig.fetch('vagrant_memory')
+    end
+  end
+
+  # Parallels settings
+  config.vm.provider 'parallels' do |prl, override|
+    prl.name = config.vm.hostname
+    prl.cpus = vconfig.fetch('vagrant_cpus')
+    prl.memory = vconfig.fetch('vagrant_memory')
+    prl.update_guest_tools = true
+  end
+end

--- a/staging/vagrant.staging.yml
+++ b/staging/vagrant.staging.yml
@@ -1,0 +1,13 @@
+---
+vagrant_ip: '192.168.50.6'
+vagrant_cpus: 4
+vagrant_memory: 4096 # in MB
+vagrant_box: 'bento/ubuntu-16.04'
+vagrant_box_version: '<= 201710.25.0'
+vagrant_ansible_version: '2.4.2.0'
+vagrant_skip_galaxy: false
+
+vagrant_install_plugins: true
+vagrant_plugins:
+  - name: vagrant-disksize
+  - name: vagrant-hostmanager


### PR DESCRIPTION
This PR adds Vagrant related files for a staging server. This is helpful for testing new playbooks and deploys to a staging server and generally a VM that behaves like a "true" server.