### PR TITLE
Vendor h5bp Nginx configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Vendor h5bp Nginx configs ([#973](https://github.com/roots/trellis/pull/973))
 * Add support for includes.d on all sites ([#966](https://github.com/roots/trellis/pull/966))
 * Fix `--subdomains` flag in the Install WP task ([#968](https://github.com/roots/trellis/pull/968))
 * Ensure Diffie-Hellman group is generated for Let's Encrypt ([#964](https://github.com/roots/trellis/pull/964))

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -25,17 +25,10 @@
   notify: reload nginx
   tags: [diffie-hellman, letsencrypt, wordpress, wordpress-setup, nginx-includes, nginx-sites]
 
-- name: Grab h5bp/server-configs-nginx
-  git:
-    repo: "https://github.com/h5bp/server-configs-nginx.git"
-    dest: "{{ nginx_path }}/h5bp-server-configs"
-    version: c5c6602232e0976d9e69d69874aa84d2a2698265
-    force: yes
-
-- name: Move h5bp configs
-  command: rsync -ac --delete --info=NAME {{ nginx_path }}/h5bp-server-configs/h5bp/ {{ nginx_path }}/h5bp
-  register: h5bp_nginx_sync
-  changed_when: h5bp_nginx_sync.stdout != ''
+- name: Copy h5bp configs
+  copy:
+    src: templates/h5bp
+    dest: "{{ nginx_path }}"
   notify: reload nginx
 
 - name: Create nginx.conf

--- a/roles/nginx/templates/h5bp/directive-only/cache-file-descriptors.conf
+++ b/roles/nginx/templates/h5bp/directive-only/cache-file-descriptors.conf
@@ -1,0 +1,19 @@
+# This tells Nginx to cache open file handles, "not found" errors, metadata about files and their permissions, etc.
+#
+# The upside of this is that Nginx can immediately begin sending data when a popular file is requested,
+# and will also know to immediately send a 404 if a file is missing on disk, and so on.
+#
+# However, it also means that the server won't react immediately to changes on disk, which may be undesirable.
+#
+# In the below configuration, inactive files are released from the cache after 20 seconds, whereas
+# active (recently requested) files are re-validated every 30 seconds.
+#
+# Descriptors will not be cached unless they are used at least 2 times within 20 seconds (the inactive time).
+#
+# A maximum of the 1000 most recently used file descriptors can be cached at any time.
+#
+# Production servers with stable file collections will definitely want to enable the cache.
+open_file_cache          max=1000 inactive=20s;
+open_file_cache_valid    30s;
+open_file_cache_min_uses 2;
+open_file_cache_errors   on;

--- a/roles/nginx/templates/h5bp/directive-only/cross-domain-insecure.conf
+++ b/roles/nginx/templates/h5bp/directive-only/cross-domain-insecure.conf
@@ -1,0 +1,14 @@
+# Cross domain AJAX requests
+
+# http://www.w3.org/TR/cors/#access-control-allow-origin-response-header
+
+# **Security Warning**
+# Do not use this without understanding the consequences.
+# This will permit access from any other website.
+#
+add_header "Access-Control-Allow-Origin" "*";
+
+# Instead of using this file, consider using a specific rule such as:
+#
+# Allow access based on [sub]domain:
+#    add_header "Access-Control-Allow-Origin" "subdomain.example.com";

--- a/roles/nginx/templates/h5bp/directive-only/extra-security.conf
+++ b/roles/nginx/templates/h5bp/directive-only/extra-security.conf
@@ -1,0 +1,17 @@
+# The X-Frame-Options header indicates whether a browser should be allowed
+# to render a page within a frame or iframe.
+add_header X-Frame-Options SAMEORIGIN always;
+
+# MIME type sniffing security protection
+#	There are very few edge cases where you wouldn't want this enabled.
+add_header X-Content-Type-Options nosniff always;
+
+# The X-XSS-Protection header is used by Internet Explorer version 8+
+# The header instructs IE to enable its inbuilt anti-cross-site scripting filter.
+add_header X-XSS-Protection "1; mode=block" always;
+
+# with Content Security Policy (CSP) enabled (and a browser that supports it (http://caniuse.com/#feat=contentsecuritypolicy),
+# you can tell the browser that it can only download content from the domains you explicitly allow
+# CSP can be quite difficult to configure, and cause real issues if you get it wrong
+# There is website that helps you generate a policy here http://cspisawesome.com/
+# add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' https://www.google-analytics.com;" always;

--- a/roles/nginx/templates/h5bp/directive-only/no-transform.conf
+++ b/roles/nginx/templates/h5bp/directive-only/no-transform.conf
@@ -1,0 +1,11 @@
+# Prevent mobile network providers from modifying your site
+#
+# (!) If you are using `ngx_pagespeed`, please note that setting
+# the `Cache-Control: no-transform` response header will prevent
+# `PageSpeed` from rewriting `HTML` files, and, if
+# `pagespeed DisableRewriteOnNoTransform off` is not used, also
+# from rewriting other resources.
+#
+# https://developers.google.com/speed/pagespeed/module/configuration#notransform
+
+add_header "Cache-Control" "no-transform";

--- a/roles/nginx/templates/h5bp/directive-only/ssl-stapling.conf
+++ b/roles/nginx/templates/h5bp/directive-only/ssl-stapling.conf
@@ -1,0 +1,9 @@
+# OCSP stapling...
+ssl_stapling on;
+ssl_stapling_verify on;
+
+#trusted cert must be made up of your intermediate certificate followed by root certificate
+#ssl_trusted_certificate /path/to/ca.crt;
+
+resolver 8.8.8.8 8.8.4.4 216.146.35.35 216.146.36.36 valid=60s;
+resolver_timeout 2s;

--- a/roles/nginx/templates/h5bp/directive-only/ssl.conf
+++ b/roles/nginx/templates/h5bp/directive-only/ssl.conf
@@ -1,0 +1,47 @@
+# Protect against the BEAST and POODLE attacks by not using SSLv3 at all. If you need to support older browsers (IE6) you may need to add
+# SSLv3 to the list of protocols below.
+ssl_protocols              TLSv1 TLSv1.1 TLSv1.2;
+
+# Ciphers set to best allow protection from Beast, while providing forwarding secrecy, as defined by Mozilla (Intermediate Set) - https://wiki.mozilla.org/Security/Server_Side_TLS#Nginx
+ssl_ciphers                ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS;
+ssl_prefer_server_ciphers  on;
+
+# Optimize SSL by caching session parameters for 10 minutes. This cuts down on the number of expensive SSL handshakes.
+# The handshake is the most CPU-intensive operation, and by default it is re-negotiated on every new/parallel connection.
+# By enabling a cache (of type "shared between all Nginx workers"), we tell the client to re-use the already negotiated state.
+# Further optimization can be achieved by raising keepalive_timeout, but that shouldn't be done unless you serve primarily HTTPS.
+ssl_session_cache    shared:SSL:10m; # a 1mb cache can hold about 4000 sessions, so we can hold 40000 sessions
+ssl_session_timeout  24h;
+
+# SSL buffer size was added in 1.5.9
+#ssl_buffer_size      1400; # 1400 bytes to fit in one MTU
+
+# Session tickets appeared in version 1.5.9
+#
+# nginx does not auto-rotate session ticket keys: only a HUP / restart will do so and
+# when a restart is performed the previous key is lost, which resets all previous
+# sessions. The fix for this is to setup a manual rotation mechanism:
+# http://trac.nginx.org/nginx/changeset/1356a3b9692441e163b4e78be4e9f5a46c7479e9/nginx
+#
+# Note that you'll have to define and rotate the keys securely by yourself. In absence
+# of such infrastructure, consider turning off session tickets:
+#ssl_session_tickets off;
+
+# Use a higher keepalive timeout to reduce the need for repeated handshakes
+keepalive_timeout 300s; # up from 75 secs default
+
+# HSTS (HTTP Strict Transport Security)
+# This header tells browsers to cache the certificate for a year and to connect exclusively via HTTPS.
+#add_header Strict-Transport-Security "max-age=31536000" always;
+# This version tells browsers to treat all subdomains the same as this site and to load exclusively over HTTPS
+#add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+# This version tells browsers to treat all subdomains the same as this site and to load exclusively over HTTPS
+# Recommend is also to use preload service
+#add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+
+# This default SSL certificate will be served whenever the client lacks support for SNI (Server Name Indication).
+# Make it a symlink to the most important certificate you have, so that users of IE 8 and below on WinXP can see your main site without SSL errors.
+#ssl_certificate      /etc/nginx/default_ssl.crt;
+#ssl_certificate_key  /etc/nginx/default_ssl.key;
+
+# Consider using OCSP Stapling as shown in ssl-stapling.conf

--- a/roles/nginx/templates/h5bp/directive-only/x-ua-compatible.conf
+++ b/roles/nginx/templates/h5bp/directive-only/x-ua-compatible.conf
@@ -1,0 +1,2 @@
+# Force the latest IE version
+add_header "X-UA-Compatible" "IE=Edge";

--- a/roles/nginx/templates/h5bp/location/cache-busting.conf
+++ b/roles/nginx/templates/h5bp/location/cache-busting.conf
@@ -1,0 +1,10 @@
+# Built-in filename-based cache busting
+
+# https://github.com/h5bp/html5-boilerplate/blob/5370479476dceae7cc3ea105946536d6bc0ee468/.htaccess#L403
+# This will route all requests for /css/style.20120716.css to /css/style.css
+# Read also this: github.com/h5bp/html5-boilerplate/wiki/cachebusting
+# This is not included by default, because it'd be better if you use the build
+# script to manage the file names.
+location ~* (.+)\.(?:\d+)\.(js|css|png|jpg|jpeg|gif)$ {
+  try_files $uri $1.$2;
+}

--- a/roles/nginx/templates/h5bp/location/cross-domain-fonts.conf
+++ b/roles/nginx/templates/h5bp/location/cross-domain-fonts.conf
@@ -1,0 +1,12 @@
+# Cross domain webfont access
+location ~* \.(?:ttf|ttc|otf|eot|woff|woff2)$ {
+  include h5bp/directive-only/cross-domain-insecure.conf;
+
+  # Also, set cache rules for webfonts.
+  #
+  # See http://wiki.nginx.org/HttpCoreModule#location
+  # And https://github.com/h5bp/server-configs/issues/85
+  # And https://github.com/h5bp/server-configs/issues/86
+  access_log off;
+  add_header Cache-Control "max-age=2592000";
+}

--- a/roles/nginx/templates/h5bp/location/expires.conf
+++ b/roles/nginx/templates/h5bp/location/expires.conf
@@ -1,0 +1,45 @@
+# Expire rules for static content
+
+# No default expire rule. This config mirrors that of apache as outlined in the
+# html5-boilerplate .htaccess file. However, nginx applies rules by location,
+# the apache rules are defined by type. A consequence of this difference is that
+# if you use no file extension in the url and serve html, with apache you get an
+# expire time of 0s, with nginx you'd get an expire header of one month in the
+# future (if the default expire rule is 1 month). Therefore, do not use a
+# default expire rule with nginx unless your site is completely static
+
+# cache.appcache, your document html and data
+location ~* \.(?:manifest|appcache|html?|xml|json)$ {
+  add_header Cache-Control "max-age=0";
+}
+
+# Feed
+location ~* \.(?:rss|atom)$ {
+  add_header Cache-Control "max-age=3600";
+}
+
+# Media: images, icons, video, audio, HTC
+location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|mp4|ogg|ogv|webm|htc)$ {
+  access_log off;
+  add_header Cache-Control "max-age=2592000";
+}
+
+# Media: svgz files are already compressed.
+location ~* \.svgz$ {
+  access_log off;
+  gzip off;
+  add_header Cache-Control "max-age=2592000";
+}
+
+# CSS and Javascript
+location ~* \.(?:css|js)$ {
+  add_header Cache-Control "max-age=31536000";
+  access_log off;
+}
+
+# WebFonts
+# If you are NOT using cross-domain-fonts.conf, uncomment the following directive
+# location ~* \.(?:ttf|ttc|otf|eot|woff|woff2)$ {
+#  add_header Cache-Control "max-age=2592000";
+#  access_log off;
+# }

--- a/roles/nginx/templates/h5bp/location/protect-system-files.conf
+++ b/roles/nginx/templates/h5bp/location/protect-system-files.conf
@@ -1,0 +1,13 @@
+# Prevent clients from accessing hidden files (starting with a dot)
+# This is particularly important if you store .htpasswd files in the site hierarchy
+# Access to `/.well-known/` is allowed.
+# https://www.mnot.net/blog/2010/04/07/well-known
+# https://tools.ietf.org/html/rfc5785
+location ~* /\.(?!well-known\/) {
+  deny all;
+}
+
+# Prevent clients from accessing to backup/config/source files
+location ~* (?:\.(?:bak|conf|dist|fla|in[ci]|log|psd|sh|sql|sw[op])|~)$ {
+  deny all;
+}


### PR DESCRIPTION
These configs rarely change (and haven't in almost a year) so there is no point in pulling them down from GitHub. It just makes it harder to edit them if need be.

No behaviour changes with this commit. The templates/files included are from the same commit SHA.