### PR TITLE
Fix path to h5bp/mime.types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Fix path to h5bp/mime.types ([#974](https://github.com/roots/trellis/pull/974))
 * Vendor h5bp Nginx configs ([#973](https://github.com/roots/trellis/pull/973))
 * Add support for sSMTP revaliases configuration ([#956](https://github.com/roots/trellis/pull/956))
 * Add support for includes.d on all sites ([#966](https://github.com/roots/trellis/pull/966))

--- a/roles/nginx/templates/h5bp/mime.types
+++ b/roles/nginx/templates/h5bp/mime.types
@@ -1,0 +1,138 @@
+types {
+
+  # Data interchange
+
+    application/atom+xml                  atom;
+    application/json                      json map topojson;
+    application/ld+json                   jsonld;
+    application/rss+xml                   rss;
+    application/vnd.geo+json              geojson;
+    application/xml                       rdf xml;
+
+
+  # JavaScript
+
+    # Normalize to standard type.
+    # https://tools.ietf.org/html/rfc4329#section-7.2
+    application/javascript                js;
+
+
+  # Manifest files
+
+    application/manifest+json             webmanifest;
+    application/x-web-app-manifest+json   webapp;
+    text/cache-manifest                   appcache;
+
+
+  # Media files
+
+    audio/midi                            mid midi kar;
+    audio/mp4                             aac f4a f4b m4a;
+    audio/mpeg                            mp3;
+    audio/ogg                             oga ogg opus;
+    audio/x-realaudio                     ra;
+    audio/x-wav                           wav;
+    image/bmp                             bmp;
+    image/gif                             gif;
+    image/jpeg                            jpeg jpg;
+    image/jxr                             jxr hdp wdp;
+    image/png                             png;
+    image/svg+xml                         svg svgz;
+    image/tiff                            tif tiff;
+    image/vnd.wap.wbmp                    wbmp;
+    image/webp                            webp;
+    image/x-jng                           jng;
+    video/3gpp                            3gp 3gpp;
+    video/mp4                             f4p f4v m4v mp4;
+    video/mpeg                            mpeg mpg;
+    video/ogg                             ogv;
+    video/quicktime                       mov;
+    video/webm                            webm;
+    video/x-flv                           flv;
+    video/x-mng                           mng;
+    video/x-ms-asf                        asf asx;
+    video/x-ms-wmv                        wmv;
+    video/x-msvideo                       avi;
+
+    # Serving `.ico` image files with a different media type
+    # prevents Internet Explorer from displaying then as images:
+    # https://github.com/h5bp/html5-boilerplate/commit/37b5fec090d00f38de64b591bcddcb205aadf8ee
+
+    image/x-icon                          cur ico;
+
+
+  # Microsoft Office
+
+    application/msword                                                         doc;
+    application/vnd.ms-excel                                                   xls;
+    application/vnd.ms-powerpoint                                              ppt;
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document    docx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet          xlsx;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation  pptx;
+
+
+  # Web fonts
+
+    application/font-woff                 woff;
+    application/font-woff2                woff2;
+    application/vnd.ms-fontobject         eot;
+
+    # Browsers usually ignore the font media types and simply sniff
+    # the bytes to figure out the font type.
+    # https://mimesniff.spec.whatwg.org/#matching-a-font-type-pattern
+    #
+    # However, Blink and WebKit based browsers will show a warning
+    # in the console if the following font types are served with any
+    # other media types.
+
+    application/x-font-ttf                ttc ttf;
+    font/opentype                         otf;
+
+
+  # Other
+
+    application/java-archive              ear jar war;
+    application/mac-binhex40              hqx;
+    application/octet-stream              bin deb dll dmg exe img iso msi msm msp safariextz;
+    application/pdf                       pdf;
+    application/postscript                ai eps ps;
+    application/rtf                       rtf;
+    application/vnd.google-earth.kml+xml  kml;
+    application/vnd.google-earth.kmz      kmz;
+    application/vnd.wap.wmlc              wmlc;
+    application/x-7z-compressed           7z;
+    application/x-bb-appworld             bbaw;
+    application/x-bittorrent              torrent;
+    application/x-chrome-extension        crx;
+    application/x-cocoa                   cco;
+    application/x-java-archive-diff       jardiff;
+    application/x-java-jnlp-file          jnlp;
+    application/x-makeself                run;
+    application/x-opera-extension         oex;
+    application/x-perl                    pl pm;
+    application/x-pilot                   pdb prc;
+    application/x-rar-compressed          rar;
+    application/x-redhat-package-manager  rpm;
+    application/x-sea                     sea;
+    application/x-shockwave-flash         swf;
+    application/x-stuffit                 sit;
+    application/x-tcl                     tcl tk;
+    application/x-x509-ca-cert            crt der pem;
+    application/x-xpinstall               xpi;
+    application/xhtml+xml                 xhtml;
+    application/xslt+xml                  xsl;
+    application/zip                       zip;
+    text/css                              css;
+    text/csv                              csv;
+    text/html                             htm html shtml;
+    text/markdown                         md;
+    text/mathml                           mml;
+    text/plain                            txt;
+    text/vcard                            vcard vcf;
+    text/vnd.rim.location.xloc            xloc;
+    text/vnd.sun.j2me.app-descriptor      jad;
+    text/vnd.wap.wml                      wml;
+    text/vtt                              vtt;
+    text/x-component                      htc;
+
+}

--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -74,7 +74,7 @@ http {
 
   {% block mime_types -%}
   # Specify MIME types for files.
-  include       h5bp-server-configs/mime.types;
+  include       h5bp/mime.types;
 
   # Default: text/plain
   default_type  application/octet-stream;
@@ -199,7 +199,7 @@ http {
   # a specific directory, or on an individual server{} level.
   # gzip_static on;
   {% endblock %}
-  
+
   {% block http_includes_d -%}
   include includes.d/http/*.conf;
   {% endblock -%}


### PR DESCRIPTION
Fixes errors such as https://discourse.roots.io/t/non-zero-return-code-on-reload-nginx/12086

```
RUNNING HANDLER [common : reload nginx] **********************************
System info:
  Ansible 2.4.0.0; Vagrant 2.0.1; Darwin
  Trellis at "Vendor h5bp Nginx configs"
---------------------------------------------------
non-zero return code
nginx: [emerg] open() "/etc/nginx/h5bp-server-configs/mime.types" failed (2:
No such file or directory) in /etc/nginx/nginx.conf:59
nginx: configuration file /etc/nginx/nginx.conf test failed
fatal: [default]: FAILED! => {"changed": true, "cmd": ["nginx", "-t"]...
```

(a followup to #973)