### PR TITLE
Add CSP frame-ancestors, make X-Frame-Options conditional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Add CSP `frame-ancestors`, make `X-Frame-Options` conditional ([#977](https://github.com/roots/trellis/pull/977))
 * Common: Install `git` instead of `git-core`  ([#989](https://github.com/roots/trellis/pull/989))
 * Add `xdebug.remote_autostart` to simplify xdebug sessions  ([#985](https://github.com/roots/trellis/pull/985))
 * Enable nginx to start on boot ([#980](https://github.com/roots/trellis/pull/980))

--- a/roles/nginx/templates/h5bp/directive-only/extra-security.conf
+++ b/roles/nginx/templates/h5bp/directive-only/extra-security.conf
@@ -6,11 +6,7 @@ set $x_frame_options SAMEORIGIN;
 if ($arg_customize_changeset_uuid) {
   set $x_frame_options "";
 }
-add_header X-Frame-Options $x_frame_options;
-
-# The HTTP Content-Security-Policy (CSP) frame-ancestors directive specifies valid parents
-# that may embed a page using <frame>, <iframe>, <object>, <embed>, or <applet>.
-add_header Content-Security-Policy "frame-ancestors 'self'";
+add_header X-Frame-Options $x_frame_options always;
 
 # MIME type sniffing security protection
 #	There are very few edge cases where you wouldn't want this enabled.
@@ -25,3 +21,7 @@ add_header X-XSS-Protection "1; mode=block" always;
 # CSP can be quite difficult to configure, and cause real issues if you get it wrong
 # There is website that helps you generate a policy here http://cspisawesome.com/
 # add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' https://www.google-analytics.com;" always;
+
+# The HTTP Content-Security-Policy (CSP) frame-ancestors directive specifies valid parents
+# that may embed a page using <frame>, <iframe>, <object>, <embed>, or <applet>.
+add_header Content-Security-Policy "frame-ancestors 'self'" always;

--- a/roles/nginx/templates/h5bp/directive-only/extra-security.conf
+++ b/roles/nginx/templates/h5bp/directive-only/extra-security.conf
@@ -1,12 +1,6 @@
 # The X-Frame-Options header indicates whether a browser should be allowed
 # to render a page within a frame or iframe.
-# Avoid SAMEORIGIN conflict with ALLOW-FROM in Safari with WordPress Customizer
-# until https://core.trac.wordpress.org/ticket/40020 is resolved
-set $x_frame_options SAMEORIGIN;
-if ($arg_customize_changeset_uuid) {
-  set $x_frame_options "";
-}
-add_header X-Frame-Options $x_frame_options always;
+# add_header X-Frame-Options SAMEORIGIN always;
 
 # MIME type sniffing security protection
 #	There are very few edge cases where you wouldn't want this enabled.
@@ -21,7 +15,3 @@ add_header X-XSS-Protection "1; mode=block" always;
 # CSP can be quite difficult to configure, and cause real issues if you get it wrong
 # There is website that helps you generate a policy here http://cspisawesome.com/
 # add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' https://www.google-analytics.com;" always;
-
-# The HTTP Content-Security-Policy (CSP) frame-ancestors directive specifies valid parents
-# that may embed a page using <frame>, <iframe>, <object>, <embed>, or <applet>.
-add_header Content-Security-Policy "frame-ancestors 'self'" always;

--- a/roles/nginx/templates/h5bp/directive-only/extra-security.conf
+++ b/roles/nginx/templates/h5bp/directive-only/extra-security.conf
@@ -1,6 +1,16 @@
 # The X-Frame-Options header indicates whether a browser should be allowed
 # to render a page within a frame or iframe.
-add_header X-Frame-Options SAMEORIGIN always;
+# Avoid SAMEORIGIN conflict with ALLOW-FROM in Safari with WordPress Customizer
+# until https://core.trac.wordpress.org/ticket/40020 is resolved
+set $x_frame_options SAMEORIGIN;
+if ($arg_customize_changeset_uuid) {
+  set $x_frame_options "";
+}
+add_header X-Frame-Options $x_frame_options;
+
+# The HTTP Content-Security-Policy (CSP) frame-ancestors directive specifies valid parents
+# that may embed a page using <frame>, <iframe>, <object>, <embed>, or <applet>.
+add_header Content-Security-Policy "frame-ancestors 'self'";
 
 # MIME type sniffing security protection
 #	There are very few edge cases where you wouldn't want this enabled.

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -161,6 +161,20 @@ server {
 
   {% endblock %}
 
+  {% block embed_security -%}
+  {% if item.value.nginx_embed_security | default(nginx_embed_security | default(true)) -%}
+  add_header Content-Security-Policy "frame-ancestors 'self'" always;
+
+  # Conditional X-Frame-Options until https://core.trac.wordpress.org/ticket/40020 is resolved
+  set $x_frame_options SAMEORIGIN;
+  if ($arg_customize_changeset_uuid) {
+    set $x_frame_options "";
+  }
+  add_header X-Frame-Options $x_frame_options always;
+
+  {% endif -%}
+  {% endblock -%}
+
   {% block location_php -%}
   location ~ \.php$ {
     {% block location_php_basic -%}


### PR DESCRIPTION
This PR adds a workaround to https://discourse.roots.io/t/safari-conflicting-multiple-x-frame-options/10077 until https://core.trac.wordpress.org/ticket/40020 is resolved.  

### `frame-ancestors` CSP

This PR adds the [frame-ancestors](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors) CSP directive which has obsoleted the `X-Frame-Options` header.

Note that it is acceptable to have [multiple CSPs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#Multiple_content_security_policies) (i.e., in case users add other CSP headers).

> CSP is designed to be fully backward compatible... Browsers that don't support it still work with servers that implement it, and vice-versa: browsers that don't support CSP simply ignore it, functioning as usual, defaulting to the standard same-origin policy for web content.  _[--reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)_

### Dynamic `X-Frame-Options`

This PR retains the `X-Frame-Options` header for the sake of older browsers, but returns an empty `X-Frame-Options` value for WordPress Customizer content. This prevents the Safari browser's conflict between `SAMEORIGIN` and the `ALLOW-FROM` option that WordPress adds on its own.


