### PR TITLE
Enable nginx to start on boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Enable nginx to start on boot ([#980](https://github.com/roots/trellis/pull/980))
 * Update geerlingguy.ntp 1.5.2->1.6.0 ([#984](https://github.com/roots/trellis/pull/984))
 * Update geerlingguy.composer 1.6.1->1.7.0 ([#983](https://github.com/roots/trellis/pull/983))
 * Update wp-cli to 1.5.1 ([#982](https://github.com/roots/trellis/pull/982))

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -43,3 +43,10 @@
     path: "{{ nginx_path }}/sites-enabled/default"
     state: absent
   notify: reload nginx
+
+- name: Enable Nginx to start on boot
+  service:
+    name: nginx
+    enabled: yes
+    state: started
+    use: service


### PR DESCRIPTION
The nginx service isn't enabled, so it doesn't automatically start on
boot. Fixes https://github.com/roots/trellis/issues/979