### PR TITLE
Bump Ansible version_tested_max to 2.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Bump Ansible `version_tested_max` to 2.5.3 ([#981](https://github.com/roots/trellis/pull/981))
 * deploy.sh: Return non-zero exit code when misuse  ([#990](https://github.com/roots/trellis/pull/990))
 * Add CSP `frame-ancestors`, make `X-Frame-Options` conditional ([#977](https://github.com/roots/trellis/pull/977))
 * Common: Install `git` instead of `git-core`  ([#989](https://github.com/roots/trellis/pull/989))

--- a/deploy.yml
+++ b/deploy.yml
@@ -28,6 +28,6 @@
           Ensure that your site's `repo` variable is defined in `group_vars/{{ env }}/wordpress_sites.yml` and uses the SSH format (example: git@github.com:roots/bedrock.git)
           More info:
           > https://roots.io/trellis/docs/deploys/
-      when: project.repo is not defined or not project.repo | match("^ssh://.+@.+|.+@.+:.+")
+      when: project.repo is not defined or project.repo is not match("^ssh://.+@.+|.+@.+:.+")
   roles:
     - deploy

--- a/lib/trellis/plugins/vars/version.py
+++ b/lib/trellis/plugins/vars/version.py
@@ -19,7 +19,7 @@ if version_info[0] > 2:
         'Please use Python 2.7.').format(version_info[0], version_info[1], version_info[2]))
 
 version_requirement = '2.4.0.0'
-version_tested_max = '2.5.1'
+version_tested_max = '2.5.2'
 
 if not ge(LooseVersion(__version__), LooseVersion(version_requirement)):
     raise AnsibleError(('Trellis no longer supports Ansible {}.\n'

--- a/lib/trellis/plugins/vars/version.py
+++ b/lib/trellis/plugins/vars/version.py
@@ -19,7 +19,7 @@ if version_info[0] > 2:
         'Please use Python 2.7.').format(version_info[0], version_info[1], version_info[2]))
 
 version_requirement = '2.4.0.0'
-version_tested_max = '2.5.2'
+version_tested_max = '2.5.3'
 
 if not ge(LooseVersion(__version__), LooseVersion(version_requirement)):
     raise AnsibleError(('Trellis no longer supports Ansible {}.\n'

--- a/lib/trellis/plugins/vars/version.py
+++ b/lib/trellis/plugins/vars/version.py
@@ -5,7 +5,7 @@ __metaclass__ = type
 from ansible import __version__
 from ansible.errors import AnsibleError
 from distutils.version import LooseVersion
-from operator import ge, gt
+from operator import eq, ge, gt
 from sys import version_info
 
 try:
@@ -19,7 +19,7 @@ if version_info[0] > 2:
         'Please use Python 2.7.').format(version_info[0], version_info[1], version_info[2]))
 
 version_requirement = '2.4.0.0'
-version_tested_max = '2.4.3.0'
+version_tested_max = '2.5.1'
 
 if not ge(LooseVersion(__version__), LooseVersion(version_requirement)):
     raise AnsibleError(('Trellis no longer supports Ansible {}.\n'
@@ -28,6 +28,10 @@ elif gt(LooseVersion(__version__), LooseVersion(version_tested_max)):
     display.warning(u'You Ansible version is {} but this version of Trellis has only been tested for '
             u'compatability with Ansible {} -> {}. It is advisable to check for Trellis updates or '
             u'downgrade your Ansible version.'.format(__version__, version_requirement, version_tested_max))
+
+if eq(LooseVersion(__version__), LooseVersion('2.5.0')):
+    display.warning(u'You Ansible version is {}. Consider upgrading your Ansible version to avoid '
+            u'erroneous warnings such as `Removed restricted key from module data...`'.format(__version__))
 
 # Import BaseVarsPlugin after Ansible version check.
 # Otherwise import error for Ansible versions older than 2.4 would prevent display of version check message.

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -33,7 +33,7 @@ apt_packages_default:
 apt_packages_custom: {}
 apt_packages: "{{ apt_packages_default | combine(apt_packages_custom) }}"
 
-openssh_6_8_plus: "{{ (lookup('pipe', 'ssh -V 2>&1')) | regex_replace('(.*OpenSSH_([\\d\\.]*).*)', '\\2') | version_compare('6.8', '>=') }}"
+openssh_6_8_plus: "{{ (lookup('pipe', 'ssh -V 2>&1')) | regex_replace('(.*OpenSSH_([\\d\\.]*).*)', '\\2') is version_compare('6.8', '>=') }}"
 overlapping_ciphers: "[{% for cipher in (sshd_ciphers_default + sshd_ciphers_extra) if cipher in ssh_client_ciphers %}'{{ cipher }}',{% endfor %}]"
 overlapping_kex: "[{% for kex in (sshd_kex_algorithms_default + sshd_kex_algorithms_extra) if kex in ssh_client_kex %}'{{ kex }}',{% endfor %}]"
 overlapping_macs: "[{% for mac in (sshd_macs_default + sshd_macs_extra) if mac in ssh_client_macs %}'{{ mac }}',{% endfor %}]"

--- a/roles/connection/defaults/main.yml
+++ b/roles/connection/defaults/main.yml
@@ -1,5 +1,5 @@
 ansible_host_known: "{{ lookup('pipe', 'ssh-keygen -F ' + ansible_host + ' > /dev/null 2>&1 && echo True || echo False') }}"
 ssh_config_host: "{{ lookup('pipe', 'ssh -G ' + ansible_host + ' 2>/dev/null | grep \"^hostname\" ||:') | regex_replace('^hostname ([^\\s]+)', '\\1') }}"
 ssh_config_host_known: "{{ lookup('pipe', 'ssh-keygen -F ' + ssh_config_host + ' > /dev/null 2>&1 && echo True || echo False') }}"
-openssh_6_5_plus: "{{ (lookup('pipe', 'ssh -V 2>&1')) | regex_replace('(.*OpenSSH_([\\d\\.]*).*)', '\\2') | version_compare('6.5', '>=') }}"
+openssh_6_5_plus: "{{ (lookup('pipe', 'ssh -V 2>&1')) | regex_replace('(.*OpenSSH_([\\d\\.]*).*)', '\\2') is version_compare('6.5', '>=') }}"
 host_key_algorithms: "{{ openssh_6_5_plus | ternary('ssh-ed25519-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ssh-ed25519,ssh-rsa', 'ssh-rsa-cert-v01@openssh.com,ssh-rsa') }}"

--- a/roles/connection/tasks/main.yml
+++ b/roles/connection/tasks/main.yml
@@ -60,7 +60,7 @@
     debug:
       msg: |
         Note: Ansible will attempt connections as user = {{ ansible_user }}
-        {% if not preferred_host_key_algorithms | skipped %}
+        {% if preferred_host_key_algorithms is not skipped %}
 
         Note: The host `{{ ansible_host }}` was not detected in known_hosts
         so Trellis prompted the host to offer a key type that will work with

--- a/roles/deploy/hooks/finalize-before.yml
+++ b/roles/deploy/hooks/finalize-before.yml
@@ -23,7 +23,7 @@
     chdir: "{{ deploy_helper.current_path }}"
   register: wp_template_root
   changed_when: false
-  failed_when: not wp_template_root.stderr | default('') | match("(|.*Could not get '" + item + "' option\. Does it exist\?)")
+  failed_when: wp_template_root.stderr | default('') is not match("(|.*Could not get '" + item + "' option\. Does it exist\?)")
   when:
     - wp_installed.rc == 0
     - project.update_wp_theme_paths | default(update_wp_theme_paths | default(true)) | bool

--- a/roles/deploy/tasks/update.yml
+++ b/roles/deploy/tasks/update.yml
@@ -49,7 +49,7 @@
       More info:
       > https://roots.io/trellis/docs/deploys/#ssh-keys
       > https://roots.io/trellis/docs/ssh-keys/#cloning-remote-repo-using-ssh-agent-forwarding
-  when: git_clone | failed
+  when: git_clone is failed
 
 - include_tasks: "{{ include_path }}"
   with_items: "{{ deploy_update_after | default([]) }}"

--- a/roles/letsencrypt/defaults/main.yml
+++ b/roles/letsencrypt/defaults/main.yml
@@ -1,7 +1,7 @@
 sites_using_letsencrypt: "[{% for name, site in wordpress_sites.iteritems() if site.ssl.enabled and site.ssl.provider | default('manual') == 'letsencrypt' %}'{{ name }}',{% endfor %}]"
 site_uses_letsencrypt: ssl_enabled and item.value.ssl.provider | default('manual') == 'letsencrypt'
 missing_hosts: "{{ site_hosts | difference((current_hosts.results | selectattr('item.key', 'equalto', item.key) | selectattr('stdout_lines', 'defined') | sum(attribute='stdout_lines', start=[]) | map('trim') | list | join(' ')).split(' ')) }}"
-letsencrypt_cert_ids: "{ {% for item in (generate_cert_ids | default({'results':[{'skipped':True}]})).results if not item | skipped %}'{{ item.item.key }}':'{{ item.stdout }}', {% endfor %} }"
+letsencrypt_cert_ids: "{ {% for item in (generate_cert_ids | default({'results':[{'skipped':True}]})).results if item is not skipped %}'{{ item.item.key }}':'{{ item.stdout }}', {% endfor %} }"
 
 acme_tiny_repo: 'https://github.com/diafygi/acme-tiny.git'
 acme_tiny_commit: '4ed13950c0a9cf61f1ca81ff1874cde1cf48ab32'

--- a/roles/letsencrypt/tasks/nginx.yml
+++ b/roles/letsencrypt/tasks/nginx.yml
@@ -36,7 +36,7 @@
   notify: disable temporary challenge sites
 
 - import_tasks: "{{ playbook_dir }}/roles/common/tasks/reload_nginx.yml"
-  when: challenge_site_confs | changed or challenge_sites_enabled | changed
+  when: challenge_site_confs is changed or challenge_sites_enabled is changed
 
 - name: Create test Acme Challenge file
   shell: touch {{ acme_tiny_challenges_directory }}/ping.txt

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -67,5 +67,5 @@
   tags: [connection-tests, sshd]
 
 - import_tasks: connection-warnings.yml
-  when: not admin_user_status | skipped and admin_user_status.rc != 0
+  when: admin_user_status is not skipped and admin_user_status.rc != 0
   tags: [connection-tests, sshd]

--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -68,7 +68,7 @@
   args:
     chdir: "{{ www_root }}/{{ item.item.key }}/{{ item.item.value.current_path | default('current') }}/"
   with_items: "{{ wp_install.results }}"
-  when: item | changed
+  when: item is changed
 
 - name: Update WP Multisite Home URL
   command: wp option update home {{ site_env.wp_home }} --allow-root

--- a/roles/xdebug-tunnel/tasks/main.yml
+++ b/roles/xdebug-tunnel/tasks/main.yml
@@ -20,9 +20,9 @@
         SSH tunnel already closed!
       {% endif %}
       {{ xdebug_tunnel.stderr | default('Unknown error in handling Xdebug SSH tunnel') }}
-  when: xdebug_tunnel | failed or 'already' in xdebug_tunnel.stderr | default('')
+  when: xdebug_tunnel is failed or 'already' in xdebug_tunnel.stderr | default('')
 
 - name: Announce Xdebug SSH tunnel status
   debug:
     msg: SSH Tunnel was {{ xdebug_remote_enable | bool | ternary('created', 'closed') }}!
-  when: xdebug_tunnel | changed
+  when: xdebug_tunnel is changed

--- a/server.yml
+++ b/server.yml
@@ -17,7 +17,7 @@
     - name: Install Python 2.x
       raw: which python || sudo apt-get update && sudo apt-get install -qq -y python-simplejson
       register: python_check
-      changed_when: not python_check.stdout | search('/usr/bin/python')
+      changed_when: python_check.stdout is not search('/usr/bin/python')
 
 - name: WordPress Server - Install LEMP Stack with PHP 7.2 and MariaDB MySQL
   hosts: web:&{{ env }}

--- a/vagrant.default.yml
+++ b/vagrant.default.yml
@@ -4,7 +4,7 @@ vagrant_cpus: 1
 vagrant_memory: 1024 # in MB
 vagrant_box: 'bento/ubuntu-16.04'
 vagrant_box_version: '>= 201801.02.0'
-vagrant_ansible_version: '2.5.1'
+vagrant_ansible_version: '2.5.2'
 vagrant_skip_galaxy: false
 
 vagrant_install_plugins: true

--- a/vagrant.default.yml
+++ b/vagrant.default.yml
@@ -4,7 +4,7 @@ vagrant_cpus: 1
 vagrant_memory: 1024 # in MB
 vagrant_box: 'bento/ubuntu-16.04'
 vagrant_box_version: '>= 201801.02.0'
-vagrant_ansible_version: '2.4.3.0'
+vagrant_ansible_version: '2.5.1'
 vagrant_skip_galaxy: false
 
 vagrant_install_plugins: true

--- a/vagrant.default.yml
+++ b/vagrant.default.yml
@@ -4,7 +4,7 @@ vagrant_cpus: 1
 vagrant_memory: 1024 # in MB
 vagrant_box: 'bento/ubuntu-16.04'
 vagrant_box_version: '>= 201801.02.0'
-vagrant_ansible_version: '2.5.2'
+vagrant_ansible_version: '2.5.3'
 vagrant_skip_galaxy: false
 
 vagrant_install_plugins: true


### PR DESCRIPTION
### Jinja2 test format

Converts Jinja2 tests from filter format to `var is testname` format ([porting guide](https://docs.ansible.com/ansible/2.5/porting_guides/porting_guide_2.5.html#jinja-tests-used-as-filters)).

### Erroneous warnings in Ansible 2.5.0

Encourages users on Ansible 2.5.0 to upgrade to avoid erroneous warnings fixed in ansible/ansible#37538. After extensive investigation I found only one hack to prevent the warning in 2.5.0 but it seemed slightly risky (modified `remote_user` and `become_pass` entries in [`MAGIC_VARIABLE_MAPPING`](https://github.com/ansible/ansible/blob/v2.5.0/lib/ansible/constants.py#L110) processed in [`clean_facts`](https://github.com/ansible/ansible/blob/v2.5.0/lib/ansible/vars/clean.py#L66-L67)). I chose instead the conservative approach of printing encouragement to upgrade. An example of what users would see:
```
PLAY [Ensure necessary variables are defined] ***********************************
 [WARNING]: You Ansible version is 2.5.0. Consider upgrading your Ansible version to
avoid erroneous warnings such as `Removed restricted key from module data...`

PLAY [Test Connection and Determine Remote User] ********************************
...

TASK [connection : Check whether Ansible can connect as root] *******************
ok: [138.68.203.29 -> localhost]
...

TASK [connection : Set remote user for each host] *******************************
 [WARNING]: Removed restricted key from module data: ansible_user = admin
...
```

### Release version number format

Uses the release version number format 2.5.1 instead of 2.5.1.0 in `vagrant.default.yml` and  `lib/trellis/plugins/vars/version.py` because 2.5.1 is the format of `__version__`. Vagrant's ansible_local fails to find a version 2.5.1.0 to install, but succeeds with 2.5.1.

### Deprecation warnings for `include`

As a side note, Ansible 2.5.0 and 2.5.1 no longer print `[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated` (see #943). I haven't looked into it.