### PR TITLE
Update WP-CLI to 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Update wp-cli to 1.5.1 ([#982](https://github.com/roots/trellis/pull/982))
 * Support git url format `ssh://user@host/path/to/repo` ([#975](https://github.com/roots/trellis/pull/975))
 * Fix path to h5bp/mime.types ([#974](https://github.com/roots/trellis/pull/974))
 * Vendor h5bp Nginx configs ([#973](https://github.com/roots/trellis/pull/973))

--- a/roles/wp-cli/defaults/main.yml
+++ b/roles/wp-cli/defaults/main.yml
@@ -1,4 +1,4 @@
-wp_cli_version: 1.5.0
+wp_cli_version: 1.5.1
 wp_cli_bin_path: /usr/bin/wp
 wp_cli_phar_url: "https://github.com/wp-cli/wp-cli/releases/download/v{{ wp_cli_version }}/wp-cli-{{ wp_cli_version }}.phar"
 wp_cli_completion_url: "https://raw.githubusercontent.com/wp-cli/wp-cli/v{{ wp_cli_version }}/utils/wp-completion.bash"


### PR DESCRIPTION
See [release notes](https://make.wordpress.org/cli/2018/04/21/version-1-5-1-released/).