### PR TITLE
Update geerlingguy.composer 1.6.1->1.7.0

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,6 @@
 - name: composer
   src: geerlingguy.composer
-  version: 1.6.1
+  version: 1.7.0
 
 - name: ntp
   src: geerlingguy.ntp


### PR DESCRIPTION
Update from `1.6.1` -> `1.7.0` which addresses #943 ([DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated.)