### PR TITLE
Update geerlingguy.ntp 1.5.2->1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Update geerlingguy.ntp 1.5.2->1.6.0 ([#984](https://github.com/roots/trellis/pull/984))
 * Update geerlingguy.composer 1.6.1->1.7.0 ([#983](https://github.com/roots/trellis/pull/983))
 * Update wp-cli to 1.5.1 ([#982](https://github.com/roots/trellis/pull/982))
 * Support git url format `ssh://user@host/path/to/repo` ([#975](https://github.com/roots/trellis/pull/975))

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,7 +4,7 @@
 
 - name: ntp
   src: geerlingguy.ntp
-  version: 1.5.2
+  version: 1.6.0
 
 - name: logrotate
   src: nickhammond.logrotate


### PR DESCRIPTION
partial fix for #943 

Avoids deprecation warnings introduced in Ansible 2.4:
`The use of 'include' for tasks has been deprecated.`