### PR TITLE
Add xdebug.remote_autostart to simplify xdebug sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Add `xdebug.remote_autostart` to simplify xdebug sessions  ([#985](https://github.com/roots/trellis/pull/985))
 * Support git url format `ssh://user@host/path/to/repo` ([#975](https://github.com/roots/trellis/pull/975))
 * Fix path to h5bp/mime.types ([#974](https://github.com/roots/trellis/pull/974))
 * Vendor h5bp Nginx configs ([#973](https://github.com/roots/trellis/pull/973))

--- a/group_vars/development/php.yml
+++ b/group_vars/development/php.yml
@@ -7,3 +7,4 @@ php_opcache_enable: 0
 
 xdebug_remote_enable: 1
 xdebug_remote_connect_back: 1
+xdebug_remote_autostart: 1

--- a/roles/xdebug/defaults/main.yml
+++ b/roles/xdebug/defaults/main.yml
@@ -3,6 +3,7 @@ php_xdebug_package: php-xdebug
 # XDebug Remote Debugging
 xdebug_remote_enable: 0
 xdebug_remote_connect_back: 0
+xdebug_remote_autostart: 0
 xdebug_remote_host: localhost
 xdebug_remote_port: 9000
 xdebug_remote_log: /tmp/xdebug.log

--- a/roles/xdebug/templates/xdebug.ini.j2
+++ b/roles/xdebug/templates/xdebug.ini.j2
@@ -6,6 +6,7 @@ zend_extension=xdebug.so
 ; Remote Debugging
 xdebug.remote_enable={{ xdebug_remote_enable }}
 xdebug.remote_connect_back={{ xdebug_remote_connect_back }}
+xdebug.remote_autostart={{ xdebug_remote_autostart }}
 xdebug.remote_host={{ xdebug_remote_host }}
 xdebug.remote_port={{ xdebug_remote_port }}
 xdebug.remote_handler=dbgp


### PR DESCRIPTION
This adds an additional flag to simplify using Xdebug locally. Instead of requiring a certain HTTP header or `$_REQUEST` value, setting `xdebug.remote_autostart=1` tells Xdebug to attempt a connection with a debugger regardless of their presence.