### PR TITLE
Issue warning for all Ubuntu releases that are not Xenial

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -78,8 +78,7 @@
       Development via Vagrant: `vagrant destroy && vagrant up`
 
       Staging/Production: Create a new server with Ubuntu 16.04 and provision
-  when: ansible_distribution_release == 'trusty'
-  run_once: true
+  when: ansible_distribution_release != 'xenial'
 
 - name: Check whether passlib is needed
   fail:


### PR DESCRIPTION
This PR helps users avoid incompatibility with the recent Ubuntu 18.04 release, e.g., https://github.com/roots/trellis/pull/985#issuecomment-386823961

I also removed the release validation's `run_once` restriction because I think Trellis should check the Ubuntu release of all hosts. Trellis uses `run_once` for validations that affect only the control machine (e.g., presence of python passlib module for MacOS), in which case it is only necessary to `run_once`.