### PR TITLE
Clarify that changelog entry indicates Trellis version

### DIFF
--- a/lib/trellis/utils/output.py
+++ b/lib/trellis/utils/output.py
@@ -29,7 +29,7 @@ def system(vagrant_version=None):
         else:
             change = re.search(r'^\*\s?(\[BREAKING\])?([^\(\n\[]+)', str, re.M|re.I)
             if change is not None:
-                changelog_msg = '\n  Trellis at "{0}"'.format(change.group(2).strip())
+                changelog_msg = '\n  Trellis version (per changelog): "{0}"'.format(change.group(2).strip())
 
     # Vagrant info, if available
     vagrant = ' Vagrant {0};'.format(vagrant_version) if vagrant_version else ''


### PR DESCRIPTION
The `System info:` section of the Trellis failure output indicates version for Ansible, control machine OS, and Trellis. Users occasionally misinterpret the Trellis portion with the latest changelog entry as an indication of where the failure occurred, e.g., https://github.com/roots/trellis/pull/985#issuecomment-386823961

This PR adjusts the failure output to be more explicit about the purpose of the printed changelog entry, e.g.,
```diff
 TASK [fail] ****************************************************************
 System info:
   Ansible 2.5.2; Darwin
-  Trellis at "The most recent changelog entry"
+  Trellis version (per changelog): "The most recent changelog entry"
 ---------------------------------------------------
```

