### PR TITLE
Validate python version on control machine

### DIFF
--- a/lib/trellis/plugins/vars/version.py
+++ b/lib/trellis/plugins/vars/version.py
@@ -6,12 +6,17 @@ from ansible import __version__
 from ansible.errors import AnsibleError
 from distutils.version import LooseVersion
 from operator import ge, gt
+from sys import version_info
 
 try:
     from __main__ import display
 except ImportError:
     from ansible.utils.display import Display
     display = Display()
+
+if version_info[0] > 2:
+    raise AnsibleError(('Trellis does not yet support Python {}.{}.{}. \n'
+        'Please use Python 2.7.').format(version_info[0], version_info[1], version_info[2]))
 
 version_requirement = '2.4.0.0'
 version_tested_max = '2.4.3.0'


### PR DESCRIPTION
This PR helps users avoid incompatibility with Python 3 on the control machine. Examples: [one](https://discourse.roots.io/t/not-able-to-setup-trellis-for-the-first-time/12206), [two](https://discourse.roots.io/t/ansible-failes-to-provision-vagrant-vm/11502), [three](https://discourse.roots.io/t/ansible-remote-setup-with-aws/12188).

This PR takes same approach to determining version as [Ansible](https://github.com/ansible/ansible/blob/v2.5.2/lib/ansible/module_utils/facts/system/python.py#L41-L43)

I have some notes on Trellis changes needed for Python 3 compatibility, but here are some starting points at Ansible: 
* http://docs.ansible.com/ansible/playbooks_python_version.html
* http://docs.ansible.com/ansible/latest/python_3_support.html
* http://docs.ansible.com/ansible/latest/dev_guide/developing_python3.html