### PR TITLE
Common: Install `git` instead of `git-core`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Common: Install `git` instead of `git-core`  ([#989](https://github.com/roots/trellis/pull/989))
 * Add `xdebug.remote_autostart` to simplify xdebug sessions  ([#985](https://github.com/roots/trellis/pull/985))
 * Enable nginx to start on boot ([#980](https://github.com/roots/trellis/pull/980))
 * Update geerlingguy.ntp 1.5.2->1.6.0 ([#984](https://github.com/roots/trellis/pull/984))

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -26,7 +26,7 @@ apt_packages_default:
   build-essential: "{{ apt_package_state }}"
   python-mysqldb: "{{ apt_package_state }}"
   curl: "{{ apt_package_state }}"
-  git-core: "{{ apt_package_state }}"
+  git: "{{ apt_package_state }}"
   dbus: "{{ apt_package_state }}"
   libnss-myhostname: "{{ apt_package_state }}"
 


### PR DESCRIPTION
Because `git-core` is now a dummy package of `git`.

See: http://git.661346.n2.nabble.com/git-core-vs-git-package-on-ubuntu-tp7576083p7576085.html