### PR TITLE
deploy.sh: Return non-zero exit code when misuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* deploy.sh: Return non-zero exit code when misuse  ([#990](https://github.com/roots/trellis/pull/990))
 * Common: Install `git` instead of `git-core`  ([#989](https://github.com/roots/trellis/pull/989))
 * Add `xdebug.remote_autostart` to simplify xdebug sessions  ([#985](https://github.com/roots/trellis/pull/985))
 * Enable nginx to start on boot ([#980](https://github.com/roots/trellis/pull/980))

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -21,7 +21,7 @@ Examples:
 "
 }
 
-[[ $# -lt 2 ]] && { show_usage; exit 0; }
+[[ $# -lt 2 ]] && { show_usage; exit 127; }
 
 for arg
 do
@@ -39,7 +39,7 @@ if [[ ! -e $HOSTS_FILE ]]; then
   echo
   echo "Available environments:"
   ( IFS=$'\n'; echo "${ENVIRONMENTS[*]}" )
-  exit 0
+  exit 1
 fi
 
 $DEPLOY_CMD


### PR DESCRIPTION
- Exit with `127` when not enough arguments
- Exit with `1` when hosts file not exist

See: http://www.tldp.org/LDP/abs/html/exitcodes.html

Use case: Avoid CI servers report false positive when deployment fail.