### PR TITLE
Improve failed_when rule for Wordpress Installed check

### DIFF
--- a/roles/deploy/hooks/finalize-before.yml
+++ b/roles/deploy/hooks/finalize-before.yml
@@ -10,7 +10,7 @@
     chdir: "{{ deploy_helper.new_release_path }}"
   register: wp_installed
   changed_when: false
-  failed_when: wp_installed.stderr != ""
+  failed_when: wp_installed.stderr | default("") != "" or wp_installed.rc > 1
 
 - name: Get WP theme template and stylesheet roots
   shell: >


### PR DESCRIPTION
I have a note of one time experiencing something similar to https://discourse.roots.io/t/trellis-failing-when-trying-to-deploy/11932/4. I do not remember what produced the error in my own case. This PR should slightly improve the error handling and reporting.

In rare cases the `wp_installed` registered var may be missing the `stderr` attribute. Note that Trellis applies `default` values for `stderr` elsewhere. This PR adds a default value for this particular `stderr`. Doing so avoids the Ansible missing attribute error that would just get in the way of finding the actual error that occurred in the `wp core is-installed` command.

The `wp core  is-installed` command return code is `1` if WP is simply not installed. However, in rare cases the command may return some other higher return code indicative of true failure, so this PR makes the task fail if `wp_installed.rc > 1`.