### PR TITLE
Ubuntu 18.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* [BREAKING] Add Ubuntu 18.04 support and default to it ([#992](https://github.com/roots/trellis/pull/992))
 * Python 3 support ([#1031](https://github.com/roots/trellis/pull/1031))
 * Allow customizing Nginx `worker_connections` ([#1021](https://github.com/roots/trellis/pull/1021))
 * Update wp-cli to 2.0.1 ([#1019](https://github.com/roots/trellis/pull/1019))

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -20,15 +20,25 @@ site_keys_by_env_pair: "[
   {% endfor %}
 ]"
 
-apt_packages_default:
-  python-software-properties: "{{ apt_package_state }}"
-  python-pycurl: "{{ apt_package_state }}"
+_apt_packages_default:
   build-essential: "{{ apt_package_state }}"
-  python-mysqldb: "{{ apt_package_state }}"
   curl: "{{ apt_package_state }}"
-  git: "{{ apt_package_state }}"
   dbus: "{{ apt_package_state }}"
+  git: "{{ apt_package_state }}"
   libnss-myhostname: "{{ apt_package_state }}"
+
+apt_packages_python:
+  '2':
+    python-software-properties: "{{ apt_package_state }}"
+    python-mysqldb: "{{ apt_package_state }}"
+    python-pycurl: "{{ apt_package_state }}"
+  '3':
+    python3-software-properties: "{{ apt_package_state }}"
+    python3-mysqldb: "{{ apt_package_state }}"
+    python3-pycurl: "{{ apt_package_state }}"
+
+python_major_version: "{{ ansible_python_version[0] }}"
+apt_packages_default: "{{ _apt_packages_default | combine(apt_packages_python[python_major_version]) }}"
 
 apt_packages_custom: {}
 apt_packages: "{{ apt_packages_default | combine(apt_packages_custom) }}"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -67,7 +67,7 @@
 - name: Validate Ubuntu version
   debug:
     msg: |
-      Trellis is built for Ubuntu 16.04 Xenial as of https://github.com/roots/trellis/pull/626
+      Trellis is built for Ubuntu 18.04 Bionic as of https://github.com/roots/trellis/pull/992
 
       Your Ubuntu version is {{ ansible_distribution_version }} {{ ansible_distribution_release }}
 
@@ -77,8 +77,8 @@
 
       Development via Vagrant: `vagrant destroy && vagrant up`
 
-      Staging/Production: Create a new server with Ubuntu 16.04 and provision
-  when: ansible_distribution_release != 'xenial'
+      Staging/Production: Create a new server with Ubuntu 18.04 and provision
+  when: ansible_distribution_release != 'bionic'
 
 - name: Check whether passlib is needed
   fail:

--- a/roles/mariadb/defaults/main.yml
+++ b/roles/mariadb/defaults/main.yml
@@ -1,6 +1,6 @@
-mariadb_keyserver: keyserver.ubuntu.com
+mariadb_keyserver: "hkp://keyserver.ubuntu.com:80"
 mariadb_keyserver_id: "0xF1656F24C74CD1D8"
-mariadb_ppa: "deb [arch=amd64,i386,ppc64el] http://ftp.osuosl.org/pub/mariadb/repo/10.2/ubuntu xenial main"
+mariadb_ppa: "deb [arch=amd64] http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.2/ubuntu {{ ansible_distribution_release }} main"
 
 mariadb_client_package: mariadb-client
 mariadb_server_package: mariadb-server

--- a/roles/sshd/defaults/main.yml
+++ b/roles/sshd/defaults/main.yml
@@ -46,11 +46,9 @@ sshd_login_grace_time: 30
 sshd_macs_default:
   - hmac-sha2-512-etm@openssh.com
   - hmac-sha2-256-etm@openssh.com
-  - hmac-ripemd160-etm@openssh.com
   - umac-128-etm@openssh.com
   - hmac-sha2-512
   - hmac-sha2-256
-  - hmac-ripemd160
 
 sshd_macs_extra: []
 

--- a/server.yml
+++ b/server.yml
@@ -9,6 +9,23 @@
   roles:
     - { role: connection, tags: [connection, always] }
 
+- name: Set ansible_python_interpreter
+  hosts: web:&{{ env }}
+  gather_facts: false
+  become: yes
+  tasks:
+    - block:
+      - name: Get Ubuntu release
+        raw: lsb_release -cs
+        register: ubuntu_release
+        changed_when: false
+      - name: Set ansible_python_interpreter for Ubuntu 18.04 Bionic
+        set_fact:
+          ansible_python_interpreter: python3
+        when: ubuntu_release.stdout_lines[0] == 'bionic'
+      when: ansible_python_interpreter is not defined
+      tags: always
+
 - name: WordPress Server - Install LEMP Stack with PHP 7.2 and MariaDB MySQL
   hosts: web:&{{ env }}
   become: yes

--- a/vagrant.default.yml
+++ b/vagrant.default.yml
@@ -2,8 +2,8 @@
 vagrant_ip: '192.168.50.5'
 vagrant_cpus: 1
 vagrant_memory: 1024 # in MB
-vagrant_box: 'bento/ubuntu-16.04'
-vagrant_box_version: '>= 201801.02.0'
+vagrant_box: 'bento/ubuntu-18.04'
+vagrant_box_version: '>= 201807.12.0'
 vagrant_ansible_version: '2.5.3'
 vagrant_skip_galaxy: false
 vagrant_mount_type: 'nfs'


### PR DESCRIPTION
Adds support for the new Ubuntu 18.04 Bionic LTS release. This also *defaults* to Bionic in development (via the default Vagrant box).

This change is marked as `[BREAKING]`. Read below for more details.

Trellis will continue to work on both 16.04 and 18.04. If you want to update Trellis to the latest version but *continue* using 16.04 Xenial, you'll encounter two minor issues to deal with:

1. Revert the `vagrant_box` and `vagrant_box_version` options in `vagrant.default.yml` to the 16.04 values you previously had. Or better yet, create a `vagrant.local.yml` config to override those default values.
2. You'll see a warning that Trellis is now built for 18.04. You can safely ignore this error message if you want to stay on 16.04.