### PR TITLE
Skip Acme Challenge failure message for non-failed sites

### DIFF
--- a/roles/letsencrypt/tasks/nginx.yml
+++ b/roles/letsencrypt/tasks/nginx.yml
@@ -60,5 +60,5 @@
       Make sure that a valid DNS record exists for {{ item.failed_hosts | join(', ') }} and that they point to this server's IP.
       If you don't want these domains in your SSL certificate, then remove them from `site_hosts`.
       See https://roots.io/trellis/docs/ssl for more details.
-  when: not item | skipped and letsencrypt_test_challenges | failed
+  when: item is not skipped and item is failed
   with_items: "{{ letsencrypt_test_challenges.results }}"


### PR DESCRIPTION
When ssl `enabled: true` and `provider: letsencrypt` and ....
```
wordpress_sites:
  example.com:
    site_hosts:
      - canonical: example.com
        redirects:
          - www.example.com
    ...
  inaccessible.com:
    site_hosts:
      - canonical: inaccessible.com
        redirects:
          - www.inaccessible.com
    ...
```

Even though `example.com` is accessible and didn't fail, the Acme Challenge failure notification displays for **both** `example.com` and `inaccessible.com`:
```
TASK [letsencrypt : Notify of challenge failures] ********************************************************
System info:
  Ansible 2.4.3.0; Darwin
  Trellis version (per changelog): "deploy.sh: Return non-zero exit code when misuse"
---------------------------------------------------
Could not access the challenge file for the hosts/domains: . Let's Encrypt
requires every domain/host be publicly accessible. Make sure that a valid DNS
record exists for  and that they point to this server's IP. If you don't want
these domains in your SSL certificate, then remove them from `site_hosts`.
See https://roots.io/trellis/docs/ssl for more details.

failed: [138.68.203.29] (item=example.com) => {"changed": false, "item": "example.com"}
---------------------------------------------------
Could not access the challenge file for the hosts/domains: inaccessible.com,
www.inaccessible.com. Let's Encrypt requires every domain/host be publicly
accessible. Make sure that a valid DNS record exists for inaccessible.com,
www.inaccessible.com and that they point to this server's IP. If you don't
want these domains in your SSL certificate, then remove them from
`site_hosts`. See https://roots.io/trellis/docs/ssl for more details.

failed: [138.68.203.29] (item=inaccessible.com) => {"changed": false, "item": "inaccessible.com"}
```

This PR tightens this up, limiting the Acme Challenge failure notification to only `inaccessible.com`:
```
TASK [letsencrypt : Notify of challenge failures] ********************************************************
skipping: [138.68.203.29] => (item=example.com)
---------------------------------------------------
Could not access the challenge file for the hosts/domains: inaccessible.com,
www.inaccessible.com. Let's Encrypt requires every domain/host be publicly
accessible. Make sure that a valid DNS record exists for inaccessible.com,
www.inaccessible.com and that they point to this server's IP. If you don't
want these domains in your SSL certificate, then remove them from
`site_hosts`. See https://roots.io/trellis/docs/ssl for more details.

failed: [138.68.203.29] (item=inaccessible.com) => {"changed": false, "item": "inaccessible.com"}
```