### PR TITLE
Verify `wp-cli.phar` checksum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Verify `wp-cli.phar` checksum ([#996](https://github.com/roots/trellis/pull/996))
 * Enable `fastcgi_cache_background_update` by default ([#962](https://github.com/roots/trellis/pull/962))
 * Bump Ansible `version_tested_max` to 2.5.3 ([#981](https://github.com/roots/trellis/pull/981))
 * deploy.sh: Return non-zero exit code when misuse  ([#990](https://github.com/roots/trellis/pull/990))

--- a/roles/wp-cli/defaults/main.yml
+++ b/roles/wp-cli/defaults/main.yml
@@ -1,4 +1,5 @@
 wp_cli_version: 1.5.1
+wp_cli_phar_checksum: "sha512:8dd68c98c6fa00e1acc5e036f9393c8b052937045b5232e4aa0eb4f15773908eae48760607bc853a4f951bd5ba69e5050337e5d9dcfa48df87a12cebb1de3432"
 wp_cli_bin_path: /usr/bin/wp
 wp_cli_phar_url: "https://github.com/wp-cli/wp-cli/releases/download/v{{ wp_cli_version }}/wp-cli-{{ wp_cli_version }}.phar"
 wp_cli_completion_url: "https://raw.githubusercontent.com/wp-cli/wp-cli/v{{ wp_cli_version }}/utils/wp-completion.bash"

--- a/roles/wp-cli/tasks/main.yml
+++ b/roles/wp-cli/tasks/main.yml
@@ -3,6 +3,7 @@
   get_url:
     url: "{{ wp_cli_phar_url }}"
     dest: /tmp/wp-cli-{{ wp_cli_version }}.phar
+    checksum: "{{ wp_cli_phar_checksum }}"
 
 - name: Install WP-CLI
   command: rsync -c --chmod=0755 --info=name /tmp/wp-cli-{{ wp_cli_version }}.phar {{ wp_cli_bin_path }}


### PR DESCRIPTION
Checksum can be found on:
- https://github.com/wp-cli/wp-cli/releases
- https://github.com/wp-cli/builds/tree/gh-pages/phar

---

Sadly, the wp cli team using GPG in a weird way. Otherwise, using GPG verification is a better choice. 