### PR TITLE
build-before: Checkout project source code to local temporary directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* build-before: Checkout project source code to local temporary directory ([#997](https://github.com/roots/trellis/pull/997))
 * Verify `wp-cli.phar` checksum ([#996](https://github.com/roots/trellis/pull/996))
 * Enable `fastcgi_cache_background_update` by default ([#962](https://github.com/roots/trellis/pull/962))
 * Bump Ansible `version_tested_max` to 2.5.3 ([#981](https://github.com/roots/trellis/pull/981))

--- a/deploy-hooks/build-before.yml
+++ b/deploy-hooks/build-before.yml
@@ -7,11 +7,20 @@
 # Uncomment the lines below and replace `sage` with your theme folder
 #
 # ---
+# - name: Clone project files
+#   git:
+#     repo: "{{ project_git_repo }}"
+#     version: "{{ project_version }}"
+#     dest: "{{ project_build_path }}"
+#     force: yes
+#   no_log: true
+#   connection: local
+#
 # - name: Install npm dependencies
 #   command: yarn
 #   connection: local
 #   args:
-#     chdir: "{{ project_local_path }}/web/app/themes/sage"
+#     chdir: "{{ project_build_path }}/web/app/themes/sage"
 #
 # - name: Install Composer dependencies
 #   command: composer install --no-ansi --no-dev --no-interaction --no-progress --optimize-autoloader --no-scripts
@@ -22,11 +31,11 @@
 #   command: yarn build:production
 #   connection: local
 #   args:
-#     chdir: "{{ project_local_path }}/web/app/themes/sage"
+#     chdir: "{{ project_build_path }}/web/app/themes/sage"
 #
 # - name: Copy production assets
 #   synchronize:
-#     src: "{{ project_local_path }}/web/app/themes/sage/dist"
+#     src: "{{ project_build_path }}/web/app/themes/sage/dist"
 #     dest: "{{ deploy_helper.new_release_path }}/web/app/themes/sage"
 #     group: no
 #     owner: no

--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -51,8 +51,7 @@ update_db_on_deploy: true
 # Helpers
 project: "{{ wordpress_sites[site] }}"
 project_root: "{{ www_root }}/{{ site }}"
-project_local_path: "{{ (lookup('env', 'USER') == 'vagrant') | ternary(project_root + '/' + project_current_path, project.local_path) }}"
-
+project_build_path: "{{ lookup('env', 'TMPDIR') | default('/tmp/', true) }}trellis/{{ site }}/{{ env }}"
 
 # Deploy hooks
 # For list of hooks and explanation, see https://roots.io/trellis/docs/deploys/#hooks


### PR DESCRIPTION
This pull request clones project files according to `wordpress_sites.yml` configuration(`repo`, `branch`, etc) into a local temporary directory during `build-before`.

Build directory is kept(not deleted) after deploy to speed up subsequent deploys(as `git` and `yarn` caches). By default, build directory is located inside `$TMPDIR/trellis` or `/tmp/trellis`. This is to allow the OS to clean them up automatically (after [reboot](https://askubuntu.com/questions/20783/how-is-the-tmp-directory-cleaned-up/857154#857154) or [once a few days](https://superuser.com/questions/187071/in-macos-how-often-is-tmp-deleted#comment1920236_187105)). After build directory cleanup, the first [`git clone`](https://github.com/TangRufus/trellis/blob/ca2c70646697d0379a7da2d483e00038b40e3849/deploy-hooks/build-before.yml#L16-L23) and [`yarn install`](https://github.com/TangRufus/trellis/blob/ca2c70646697d0379a7da2d483e00038b40e3849/deploy-hooks/build-before.yml#L25-L29) become slow. If you want to avoid build directory cleanup, set `project_build_path` to something else (but not under any `vagrant_synced_folders` to avoid unnecessary file sync between your machine and the vagrant VM).

Tips: 
- [Cache `$TMPDIR/trellis` or `/tmp/trellis` on CI servers](https://github.com/TypistTech/tiller-circleci/blob/f135607a38c81c9ef4e61817f54568fd1f20dc1a/config.yml#L37-L40)
- Change `project_build_path` if you have multiple bedrock projects using the same site key

---

**What is the current behavior?**

`deploy-hooks/build-before.yml` uses whatever project files present locally, ignore the configuration(`repo`, `branch`, etc) in `group_vars/<env>/wordpress_sites.yml`

To ensure deploy works as expected, the developer needs to:
1. `$ cd /path/to/local/bedrock`
1. `$ git checkout THE_BRANCH`
1. Confirm the branch is up to date with 'origin/THE_BRANCH', nothing to commit, working tree clean: `$ git fetch && git status`
1. Actually deploy

These steps are undocumented. This pull request removes the needs of steps 1~3.

**Is there a related [Discourse](https://discourse.roots.io/) thread or were any utilized (please link them)?**

https://discourse.roots.io/t/locally-compiled-sage-assets-on-trellis-deploy/5911


