### PR TITLE
Deploy: Remove obsoleted `git` remote checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Deploy: Remove obsoleted `git` remote checking ([#999](https://github.com/roots/trellis/pull/999))
 * Update xdebug tunnel configuration ([#1007](https://github.com/roots/trellis/pull/1007))
 * Verify `wp-cli.phar` checksum ([#996](https://github.com/roots/trellis/pull/996))
 * Enable `fastcgi_cache_background_update` by default ([#962](https://github.com/roots/trellis/pull/962))

--- a/roles/deploy/tasks/update.yml
+++ b/roles/deploy/tasks/update.yml
@@ -13,31 +13,13 @@
     state: "{{ item.state | default('present') }}"
   with_items: "{{ known_hosts | default([]) }}"
 
-- name: Check whether project source path is a git repo
-  stat:
-    path: "{{ project_source_path }}/.git"
-  register: git_project
-
-- name: Get current git remote URL
-  command: git config --get remote.origin.url
-  args:
-    chdir: "{{ project_source_path }}"
-  register: remote_origin_url
-  when: git_project.stat.exists
-  changed_when: false
-
-- name: Update git remote URL
-  command: git remote set-url origin {{ project_git_repo }}
-  args:
-    chdir: "{{ project_source_path }}"
-  when: git_project.stat.exists and remote_origin_url.stdout != project_git_repo
-
 - name: Clone project files
   git:
     repo: "{{ project_git_repo }}"
     dest: "{{ project_source_path }}"
     version: "{{ project_version }}"
     accept_hostkey: "{{ project.repo_accept_hostkey | default(repo_accept_hostkey | default(true)) }}"
+    force: yes
   ignore_errors: true
   no_log: true
   register: git_clone


### PR DESCRIPTION
Remove obsoleted `git` remote checking tasks introduced in #299 because recent Ansible versions are able to detect/handle `git` remote changes.

See: https://discourse.roots.io/t/do-we-still-need-git-remote-checking-during-deploy/12639