### PR TITLE
Update swapfile role

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -11,8 +11,8 @@
   version: e7a498d
 
 - name: swapfile
-  src: kamaln7.swapfile
-  version: 4850d8a
+  src: tersmitten.swapfile
+  version: v2.0.6
 
 - name: mailhog
   src: geerlingguy.mailhog

--- a/server.yml
+++ b/server.yml
@@ -24,7 +24,7 @@
   become: yes
   roles:
     - { role: common, tags: [common] }
-    - { role: swapfile, swapfile_size: 1GB, tags: [swapfile] }
+    - { role: swapfile, swapfile_size: 1GB, swapfile_file: /swapfile, tags: [swapfile] }
     - { role: fail2ban, tags: [fail2ban] }
     - { role: ferm, tags: [ferm] }
     - { role: ntp, tags: [ntp] }


### PR DESCRIPTION
As stated in #1000 , the [kamaln7.swapfile](https://github.com/kamaln7/ansible-swapfile) role is not longer actively maintained. This PR changes the swapfile task to use the actively maintained [tersmitten.swapfile](https://github.com/Oefenweb/ansible-swapfile) role