### PR TITLE
Disabling Xdebug requests in development

### DIFF
--- a/group_vars/development/php.yml
+++ b/group_vars/development/php.yml
@@ -4,7 +4,3 @@ php_display_startup_errors: 'On'
 php_track_errors: 'On'
 php_mysqlnd_collect_memory_statistics: 'On'
 php_opcache_enable: 0
-
-xdebug_remote_enable: 1
-xdebug_remote_connect_back: 1
-xdebug_remote_autostart: 1


### PR DESCRIPTION
Unless you're actively debugging, the remote feature of Xdebug isn't necessary. We'll disable by default.