### PR TITLE
Re-enable xdebug remote

### DIFF
--- a/group_vars/development/php.yml
+++ b/group_vars/development/php.yml
@@ -4,3 +4,6 @@ php_display_startup_errors: 'On'
 php_track_errors: 'On'
 php_mysqlnd_collect_memory_statistics: 'On'
 php_opcache_enable: 0
+
+xdebug_remote_enable: 1
+xdebug_remote_connect_back: 1


### PR DESCRIPTION
Got a little red happy in the previous commit. It was unnecessary to remove the xdebug remote defaults in development. This keeps it on for development with the ability to trigger debug requests with an HTTP param or Cookie without performance degradation.