### PR TITLE
Allow customizing Nginx `worker_connections`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Allow customizing Nginx `worker_connections` ([#1021](https://github.com/roots/trellis/pull/1021))
 * Update wp-cli to 2.0.1 ([#1019](https://github.com/roots/trellis/pull/1019))
 * [BREAKING] Update wp-cli to 2.0.0 and verify its PGP signature ([#1014](https://github.com/roots/trellis/pull/1014))
 * Deploy: Remove obsoleted `git` remote checking ([#999](https://github.com/roots/trellis/pull/999))

--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -3,6 +3,7 @@ nginx_ppa: "ppa:nginx/development"
 nginx_package: nginx
 nginx_conf: nginx.conf.j2
 nginx_path: /etc/nginx
+nginx_worker_connections: 8000
 nginx_logs_root: /var/log/nginx
 nginx_user: www-data www-data
 nginx_fastcgi_buffers: 8 8k

--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -32,7 +32,7 @@ events {
   # That's probably the point at which you hire people who are smarter than you as this is *a lot* of requests.
   # Should be < worker_rlimit_nofile.
   # Default: 512
-  worker_connections 8000;
+  worker_connections {{ nginx_worker_connections }};
 }
 {% endblock %}
 


### PR DESCRIPTION
> If you need more connections than this[8000], you start optimizing your OS. That's probably the point at which you hire people who are smarter than you as this is *a lot* of requests.
> Should be < worker_rlimit_nofile.
>
> https://github.com/h5bp/server-configs-nginx/blob/c5c6602232e0976d9e69d69874aa84d2a2698265/nginx.conf#L19-L25

Nginx Default `worker_connections`: 512
Trellis / h5bp Default `worker_connections`: 8000
Trellis / h5bp Default `worker_rlimit_nofile`: 8192