### PR TITLE
#1027 make output_buffering optional

### DIFF
--- a/group_vars/staging/php.yml
+++ b/group_vars/staging/php.yml
@@ -1,0 +1,9 @@
+php_error_reporting: 'E_ALL'
+php_display_errors: 'On'
+php_display_startup_errors: 'On'
+php_track_errors: 'On'
+php_mysqlnd_collect_memory_statistics: 'On'
+php_opcache_enable: 0
+
+xdebug_remote_enable: 1
+xdebug_remote_connect_back: 1

--- a/group_vars/staging/php.yml
+++ b/group_vars/staging/php.yml
@@ -1,9 +1,0 @@
-php_error_reporting: 'E_ALL'
-php_display_errors: 'On'
-php_display_startup_errors: 'On'
-php_track_errors: 'On'
-php_mysqlnd_collect_memory_statistics: 'On'
-php_opcache_enable: 0
-
-xdebug_remote_enable: 1
-xdebug_remote_connect_back: 1

--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -34,6 +34,7 @@ php_session_cookie_secure: 'Off'
 php_upload_max_filesize: 25M
 php_track_errors: 'Off'
 php_timezone: '{{ ntp_timezone }}'
+php_output_buffering: 'Off'
 
 php_opcache_enable: 1
 php_opcache_enable_cli: 1

--- a/roles/php/templates/php.ini.j2
+++ b/roles/php/templates/php.ini.j2
@@ -17,6 +17,7 @@ track_errors = {{ php_track_errors }}
 upload_max_filesize = {{ php_upload_max_filesize }}
 expose_php = Off
 date.timezone = {{ php_timezone }}
+output_buffering = {{ php_output_buffering }}
 
 [mysqlnd]
 mysqlnd.collect_memory_statistics = {{ php_mysqlnd_collect_memory_statistics }}


### PR DESCRIPTION
If you want to use WordFence's 2FA with Google Authenticator and it to prompt you for a token and not use the silly scheme "{password} wf{token}" as your password, WordFence requires output buffering. see https://www.wordfence.com/help/tools/two-factor-authentication/ 

I believe this will allow you to automatically turn output buffering on if you add a `php.yml` to your target environment's `group_vars`