### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Windows user? [Read the Windows docs](https://roots.io/trellis/docs/windows/) fo
 ## Local development setup
 
 1. Configure your WordPress sites in `group_vars/development/wordpress_sites.yml` and in `group_vars/development/vault.yml`
-2. Run `vagrant up`
+2. Ensure you're in the trellis directory: `cd trellis`
+3. Run `vagrant up`
 
 [Read the local development docs](https://roots.io/trellis/docs/local-development-setup/) for more information.
 


### PR DESCRIPTION
For first time users it might be useful to be explicit about which directory they should be in before running `vagrant up`, else Vagrant will display an error (`A Vagrant environment or target machine is required to run this command.`) when the `Vagrantfile` is not found.