### PR TITLE
Extract Sage 9 compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### HEAD
+* Extract Sage 9 compiler ([#1030](https://github.com/roots/trellis/pull/1030))
+
 ### 1.0.1: January 16th, 2019
 * Add Python 2 explicitly ([#1061](https://github.com/roots/trellis/pull/1061))
 

--- a/deploy-hooks/build-before.yml
+++ b/deploy-hooks/build-before.yml
@@ -1,10 +1,14 @@
-# Placeholder `deploy_build_before` hook for building theme assets on the
+# Placeholder `deploy_build_before` hook for building frontend assets on the
 # host machine and then copying the files to the remote server
 #
-# ⚠️ This example assumes your theme is using Sage 9
-# An example for themes built with Sage 8 can be found at: https://git.io/vdgUt
+# ⚠️ The following is an simplified example of:
+#  1. installing npm dependencies
+#  2. compiling assets for production
+#  3. uploading assests to remote servers
 #
-# Uncomment the lines below and replace `sage` with your theme folder
+# An role for themes built with Sage 9 can be found at: https://github.com/ItinerisLtd/trellis-sage-9-compiler
+# An example for themes built with Sage 8 can be found at: https://git.io/vdgUt
+# More user contributed extensions can be found at: https://roots.io/trellis/docs/user-contributed-extensions/
 #
 # ---
 # - name: Install npm dependencies
@@ -12,11 +16,6 @@
 #   delegate_to: localhost
 #   args:
 #     chdir: "{{ project_local_path }}/web/app/themes/sage"
-#
-# - name: Install Composer dependencies
-#   command: composer install --no-ansi --no-dev --no-interaction --no-progress --optimize-autoloader --no-scripts
-#   args:
-#     chdir: "{{ deploy_helper.new_release_path }}/web/app/themes/sage"
 #
 # - name: Compile assets for production
 #   command: yarn build:production


### PR DESCRIPTION
Second attempt of #997 plus compile multiple sage themes

---

#### What's wrong with #997?

Technically nothing's wrong. However, changing from `project_local_path` to `project_build_path` confuses developers (https://github.com/roots/trellis/pull/997#issuecomment-397906560, https://github.com/roots/trellis/pull/997#issuecomment-398448690). Using a different variable name is not enough to show the differences between those variables:
- `project_local_path`: the local bedrock path, e.g: `/path/to/trellis/../site/example1`, the one that you developing on
- `project_build_path`: the temporary build path, under `$TMPDIR/trellis` or `/tmp/trellis`, not respecting `project.repo_subtree_path`

Thus, this attempt removes the needs of changing `deploy-hooks/build-before.yml` and requires develoeprs to add their sage theme names in `group_vars/<env>/wordpress_sites.yml`:

```diff
  # group_vars/<env>/wordpress_sites.yml
  wordpress_sites:
    example.com:
+     sage_themes:
+       - my-first-sage-theme-name
+       - my-second-sage-theme-name
```

#### Why multiple sage theme? Or, In what cases it will be helpful?

- Solution to https://discourse.roots.io/t/ansible-get-wrong-theme-directory-for-second-site-in-trellis/6408
- Allow multsite network to use multiple themes

#### Testing needed!!

We have been using it on production for a while with file structure described here in https://github.com/roots/trellis/issues/883#issuecomment-329052189

Never tested on [*the roots-offical-docs way*](https://roots.io/trellis/docs/installing-trellis/#create-a-project).

#### Discussion: Ansible Galaxy Role?

Since `deploy-hooks/build-before.yml` is useless when you don't use sage and support for Laravel projects is planned https://github.com/roots/trellis/pull/951, would it make sense if we extract `build-before.yml` into a separate ansible galaxy role?

---

cc: @codepuncher, @BufferOverNo, @JackAlexander1 