### PR TITLE
Python3 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Python 3 support ([#1031](https://github.com/roots/trellis/pull/1031))
 * Allow customizing Nginx `worker_connections` ([#1021](https://github.com/roots/trellis/pull/1021))
 * Update wp-cli to 2.0.1 ([#1019](https://github.com/roots/trellis/pull/1019))
 * [BREAKING] Update wp-cli to 2.0.0 and verify its PGP signature ([#1014](https://github.com/roots/trellis/pull/1014))

--- a/lib/trellis/plugins/vars/version.py
+++ b/lib/trellis/plugins/vars/version.py
@@ -14,12 +14,13 @@ except ImportError:
     from ansible.utils.display import Display
     display = Display()
 
-if version_info[0] > 2:
-    raise AnsibleError(('Trellis does not yet support Python {}.{}.{}. \n'
-        'Please use Python 2.7.').format(version_info[0], version_info[1], version_info[2]))
-
 version_requirement = '2.4.0.0'
 version_tested_max = '2.5.3'
+python3_required_version = '2.5.3'
+
+if version_info[0] == 2 and not ge(LooseVersion(__version__), LooseVersion(python3_required_version)):
+    raise AnsibleError(('Ansible >= {} is required when using Python 3.\n'
+        'Either downgrade to Python 2 or update your Ansible version to {}.').format(__version__, python3_required_version))
 
 if not ge(LooseVersion(__version__), LooseVersion(version_requirement)):
     raise AnsibleError(('Trellis no longer supports Ansible {}.\n'

--- a/lib/trellis/utils/output.py
+++ b/lib/trellis/utils/output.py
@@ -9,6 +9,7 @@ import textwrap
 
 from ansible import __version__
 from ansible.module_utils._text import to_text
+from ansible.module_utils.six import string_types
 
 def system(vagrant_version=None):
     # Get most recent Trellis CHANGELOG entry
@@ -89,7 +90,7 @@ def display(obj, result):
     # Must pass unicode strings to Display.display() to prevent UnicodeError tracebacks
     if isinstance(msg, list):
         msg = '\n'.join([to_text(x) for x in msg])
-    elif not isinstance(msg, unicode):
+    elif not isinstance(msg, string_types):
         msg = to_text(msg)
 
     # Wrap text

--- a/requirements.yml
+++ b/requirements.yml
@@ -8,7 +8,7 @@
 
 - name: logrotate
   src: nickhammond.logrotate
-  version: e7a498d
+  version: v0.0.5
 
 - name: swapfile
   src: oefenweb.swapfile

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -48,7 +48,7 @@
       php_extensions_custom: "{{ php_extensions_custom }}"
       sshd_packages_default: "{{ sshd_packages_default }}"
       sshd_packages_custom: "{{ sshd_packages_custom }}"
-    package_vars_wrong_format: "[{% for k,v in package_vars.iteritems() if v | type_debug != 'dict' %}'{{ k }}',{% endfor %}]"
+    package_vars_wrong_format: "[{% for k,v in package_vars.items() | list if v | type_debug != 'dict' %}'{{ k }}',{% endfor %}]"
   tags: [sshd, memcached, php]
 
 - name: Verify dict format for apt package combined variables
@@ -61,7 +61,7 @@
       memcached_packages: "{{ memcached_packages }}"
       php_extensions: "{{ php_extensions }}"
       sshd_packages: "{{ sshd_packages }}"
-    package_vars_wrong_format: "[{% for k,v in package_vars.iteritems() if v | type_debug != 'dict' %}'{{ k }}',{% endfor %}]"
+    package_vars_wrong_format: "[{% for k,v in package_vars.items() | list if v | type_debug != 'dict' %}'{{ k }}',{% endfor %}]"
   tags: [sshd, memcached, php]
 
 - name: Validate Ubuntu version

--- a/roles/letsencrypt/defaults/main.yml
+++ b/roles/letsencrypt/defaults/main.yml
@@ -1,4 +1,4 @@
-sites_using_letsencrypt: "[{% for name, site in wordpress_sites.iteritems() if site.ssl.enabled and site.ssl.provider | default('manual') == 'letsencrypt' %}'{{ name }}',{% endfor %}]"
+sites_using_letsencrypt: "[{% for name, site in wordpress_sites.items() | list if site.ssl.enabled and site.ssl.provider | default('manual') == 'letsencrypt' %}'{{ name }}',{% endfor %}]"
 site_uses_letsencrypt: ssl_enabled and item.value.ssl.provider | default('manual') == 'letsencrypt'
 missing_hosts: "{{ site_hosts | difference((current_hosts.results | selectattr('item.key', 'equalto', item.key) | selectattr('stdout_lines', 'defined') | sum(attribute='stdout_lines', start=[]) | map('trim') | list | join(' ')).split(' ')) }}"
 letsencrypt_cert_ids: "{ {% for item in (generate_cert_ids | default({'results':[{'skipped':True}]})).results if item is not skipped %}'{{ item.item.key }}':'{{ item.stdout }}', {% endfor %} }"

--- a/roles/letsencrypt/library/test_challenges.py
+++ b/roles/letsencrypt/library/test_challenges.py
@@ -2,7 +2,12 @@
 # -*- coding: utf-8 -*-
 
 import socket
-from httplib import HTTPConnection, HTTPException
+
+try:
+    from httplib import HTTPConnection, HTTPException
+except ImportError:
+    # Python 3
+    from http.client import HTTPConnection, HTTPException
 
 DOCUMENTATION = '''
 ---

--- a/roles/mariadb/defaults/main.yml
+++ b/roles/mariadb/defaults/main.yml
@@ -8,4 +8,4 @@ mariadb_server_package: mariadb-server
 mysql_binary_logging_disabled: true
 mysql_root_user: root
 
-sites_using_remote_db: "[{% for name, site in wordpress_sites.iteritems() if site.env is defined and site.env.db_host | default('localhost') != 'localhost' %}'{{ name }}',{% endfor %}]"
+sites_using_remote_db: "[{% for name, site in wordpress_sites.items() | list if site.env is defined and site.env.db_host | default('localhost') != 'localhost' %}'{{ name }}',{% endfor %}]"


### PR DESCRIPTION
This makes Trellis compatible with both Python 2 and 3. To use Python 3 though, Ansible >= 2.5 is required. However, since we already tell people to avoid `2.5.0`, let's just say use `2.5.3` at minimum.