### PR TITLE
Remove ansible_python_interpreter in server.yml

### DIFF
--- a/server.yml
+++ b/server.yml
@@ -9,23 +9,6 @@
   roles:
     - { role: connection, tags: [connection, always] }
 
-- name: Install prerequisites
-  hosts: web:&{{ env }}
-  gather_facts: false
-  become: yes
-  tasks:
-    - block:
-      - name: Find path to python interpreter
-        raw: which python3 || which python
-        register: python_path
-        changed_when: false
-      - name: Set path to python interpreter on remote
-        set_fact:
-          ansible_python_interpreter: "{{ python_path.stdout }}"
-        when: python_path.rc == 0
-      when: ansible_python_interpreter is not defined
-      tags: always
-
 - name: WordPress Server - Install LEMP Stack with PHP 7.2 and MariaDB MySQL
   hosts: web:&{{ env }}
   become: yes


### PR DESCRIPTION
Fixes #1034

This was changing the interpreter/version of Python used on remote hosts in `server.yml` to support Python 2 or 3.

However, this doesn't work in all cases yet because we're installing Python 2 specific packages on servers.

So for now Python 3 support is limited to the host/control machine which is the bigger issue anyway. Even Ubuntu 18.04 still defaults to Python 2.