### PR TITLE
Add Vagrant ssh-config to ~/.ssh/config on vagrant up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Add Vagrant `ssh-config` to `~/.ssh/config` on `vagrant up` ([#1042](https://github.com/roots/trellis/pull/1042))
 * [BREAKING] Add Ubuntu 18.04 support and default to it ([#992](https://github.com/roots/trellis/pull/992))
 * Python 3 support ([#1031](https://github.com/roots/trellis/pull/1031))
 * Allow customizing Nginx `worker_connections` ([#1021](https://github.com/roots/trellis/pull/1021))

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,3 @@
-# -*- mode: ruby -*-
-# vi: set ft=ruby :
-
 ANSIBLE_PATH = __dir__ # absolute path to Ansible directory on host machine
 ANSIBLE_PATH_ON_VM = '/home/vagrant/trellis'.freeze # absolute path to Ansible directory on virtual machine
 
@@ -135,9 +132,19 @@ Vagrant.configure('2') do |config|
       extra_vars = Hash[vars.split(',').map { |pair| pair.split('=') }]
       ansible.extra_vars.merge!(extra_vars)
     end
+
+    if !Vagrant::Util::Platform.windows?
+      config.trigger.after :up do |trigger|
+        # Add Vagrant ssh-config to ~/.ssh/config
+        trigger.run = {
+          path: File.join(provisioning_path, 'bin/ssh-vagrant-config.sh'),
+          args: [main_hostname]
+        }
+      end
+    end
   end
 
-  # Virtualbox settings
+  # VirtualBox settings
   config.vm.provider 'virtualbox' do |vb|
     vb.name = config.vm.hostname
     vb.customize ['modifyvm', :id, '--cpus', vconfig.fetch('vagrant_cpus')]

--- a/bin/ssh-vagrant-config.sh
+++ b/bin/ssh-vagrant-config.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+vagrant_host=$1
+
+# Add Vagrant ssh-config to ~/.ssh/config
+sed "/^$/d;s/Host /$NL&/" ~/.ssh/config | sed '/^Host '"$vagrant_host"'$/,/^$/d;' > config &&
+cat config > ~/.ssh/config &&
+rm config &&
+vagrant ssh-config --host ${vagrant_host} >> ~/.ssh/config

--- a/bin/xdebug-tunnel.sh
+++ b/bin/xdebug-tunnel.sh
@@ -1,5 +1,4 @@
-#!/usr/bin/env bash
-
+#!/bin/bash
 show_usage() {
   echo "
 Usage: bin/xdebug-tunnel.sh <action> <host>


### PR DESCRIPTION
uses https://www.vagrantup.com/docs/triggers/ to run a bash script that outputs `vagrant ssh-config` to the end of your local SSH config