### PR TITLE
Don't force install Ansible Galaxy in dev

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -119,6 +119,7 @@ Vagrant.configure('2') do |config|
     ansible.playbook = File.join(provisioning_path, 'dev.yml')
     ansible.galaxy_role_file = File.join(provisioning_path, 'requirements.yml') unless vconfig.fetch('vagrant_skip_galaxy') || ENV['SKIP_GALAXY']
     ansible.galaxy_roles_path = File.join(provisioning_path, 'vendor/roles')
+    ansible.galaxy_command = 'ansible-galaxy install --role-file=%{role_file} --roles-path=%{roles_path}'
 
     ansible.groups = {
       'web' => ['default'],


### PR DESCRIPTION
By default Vagrant runs `ansible-galaxy` with the `--force` option causing every Galaxy role to be re-downloaded *every* time. This is annoying, slow, and wasteful.

This customizes the `galaxy_command` to run without the `--force` flag.

Borrowed from this great SO answer: https://stackoverflow.com/questions/46045192/how-to-automatically-install-ansible-galaxy-roles-using-vagrant