### PR TITLE
Ansible 2.7 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Bump Ansible `version_tested_max` to 2.7.5 ([#1045](https://github.com/roots/trellis/pull/1045))
 * Add Vagrant `ssh-config` to `~/.ssh/config` on `vagrant up` ([#1042](https://github.com/roots/trellis/pull/1042))
 * [BREAKING] Add Ubuntu 18.04 support and default to it ([#992](https://github.com/roots/trellis/pull/992))
 * Python 3 support ([#1031](https://github.com/roots/trellis/pull/1031))

--- a/lib/trellis/plugins/vars/version.py
+++ b/lib/trellis/plugins/vars/version.py
@@ -15,7 +15,7 @@ except ImportError:
     display = Display()
 
 version_requirement = '2.4.0.0'
-version_tested_max = '2.5.3'
+version_tested_max = '2.7.5'
 python3_required_version = '2.5.3'
 
 if version_info[0] == 3 and not ge(LooseVersion(__version__), LooseVersion(python3_required_version)):

--- a/roles/connection/tasks/main.yml
+++ b/roles/connection/tasks/main.yml
@@ -53,7 +53,7 @@
 - block:
   - name: Set remote user for each host
     set_fact:
-      ansible_user: "{{ ansible_user | default((connection_status.stdout_lines | intersect(['root', '\e[0;32mroot']) | count) | ternary('root', admin_user)) }}"
+      ansible_user: "{{ ansible_user | default((connection_status.stdout_lines | intersect(['root', '\e[0;32mroot', '\e[0;33mroot']) | count) | ternary('root', admin_user)) }}"
     check_mode: no
 
   - name: Announce which user was selected

--- a/vagrant.default.yml
+++ b/vagrant.default.yml
@@ -4,7 +4,7 @@ vagrant_cpus: 1
 vagrant_memory: 1024 # in MB
 vagrant_box: 'bento/ubuntu-18.04'
 vagrant_box_version: '>= 201807.12.0'
-vagrant_ansible_version: '2.5.3'
+vagrant_ansible_version: '2.7.5'
 vagrant_skip_galaxy: false
 vagrant_mount_type: 'nfs'
 


### PR DESCRIPTION
updated the connection role to account for this change in ansible versions:

2.5: `[0;32m            "\u001b[0;32mroot", [0m`
2.7: `[0;32m            "\u001b[0;33mroot", [0m`

props @swalkinshaw 

close #1041 