### PR TITLE
Require Vagrant >= 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Require Vagrant >= 2.1.0 ([#1046](https://github.com/roots/trellis/pull/1046))
 * Bump Ansible `version_tested_max` to 2.7.5 ([#1045](https://github.com/roots/trellis/pull/1045))
 * Add Vagrant `ssh-config` to `~/.ssh/config` on `vagrant up` ([#1042](https://github.com/roots/trellis/pull/1042))
 * [BREAKING] Add Ubuntu 18.04 support and default to it ([#992](https://github.com/roots/trellis/pull/992))

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Full documentation is available at [https://roots.io/trellis/docs/](https://root
 Make sure all dependencies have been installed before moving on:
 
 * [Virtualbox](https://www.virtualbox.org/wiki/Downloads) >= 4.3.10
-* [Vagrant](https://www.vagrantup.com/downloads.html) >= 2.0.1
+* [Vagrant](https://www.vagrantup.com/downloads.html) >= 2.1.0
 
 ## Installation
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,7 @@ ensure_plugins(vconfig.fetch('vagrant_plugins')) if vconfig.fetch('vagrant_insta
 
 trellis_config = Trellis::Config.new(root_path: ANSIBLE_PATH)
 
-Vagrant.require_version '>= 2.0.1'
+Vagrant.require_version '>= 2.1.0'
 
 Vagrant.configure('2') do |config|
   config.vm.box = vconfig.fetch('vagrant_box')


### PR DESCRIPTION
#1042 introduced functionality that requires at least vagrant 2.1.0