### PR TITLE
Allow overriding rollback variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Allow overriding rollback variables ([#1047](https://github.com/roots/trellis/pull/1047))
 * Require Vagrant >= 2.1.0 ([#1046](https://github.com/roots/trellis/pull/1046))
 * Bump Ansible `version_tested_max` to 2.7.5 ([#1045](https://github.com/roots/trellis/pull/1045))
 * Add Vagrant `ssh-config` to `~/.ssh/config` on `vagrant up` ([#1042](https://github.com/roots/trellis/pull/1042))

--- a/roles/rollback/defaults/main.yml
+++ b/roles/rollback/defaults/main.yml
@@ -1,0 +1,2 @@
+project_root: "{{ www_root }}/{{ site }}"
+project_current_path: "{{ wordpress_sites[site].current_path | default('current') }}"

--- a/rollback.yml
+++ b/rollback.yml
@@ -14,10 +14,5 @@
 - name: Rollback a Deploy
   hosts: web:&{{ env }}
   remote_user: "{{ web_user }}"
-
-  vars:
-    project_root: "{{ www_root }}/{{ site }}"
-    project_current_path: "{{ wordpress_sites[site].current_path | default('current') }}"
-
   roles:
     - rollback


### PR DESCRIPTION
This pull request makes `rollback.yml` respects `project_root` and `project_current_path` in `group_vars/<env>/xxx.yml` like `deploy.yml`.

Use case: Rollback on Kinsta.