### PR TITLE
Add `vault_wordpress_env_defaults`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Add `vault_wordpress_env_defaults` ([#1048](https://github.com/roots/trellis/pull/1048))
 * Allow overriding rollback variables ([#1047](https://github.com/roots/trellis/pull/1047))
 * Require Vagrant >= 2.1.0 ([#1046](https://github.com/roots/trellis/pull/1046))
 * Bump Ansible `version_tested_max` to 2.7.5 ([#1045](https://github.com/roots/trellis/pull/1045))

--- a/group_vars/all/helpers.yml
+++ b/group_vars/all/helpers.yml
@@ -9,7 +9,7 @@ wordpress_env_defaults:
   wp_siteurl: "{{ ssl_enabled | ternary('https', 'http') }}://{{ site_hosts_canonical | first }}/wp"
   domain_current_site: "{{ site_hosts_canonical | first }}"
 
-site_env: "{{ wordpress_env_defaults | combine(item.value.env | default({}), vault_wordpress_sites[item.key].env) }}"
+site_env: "{{ wordpress_env_defaults | combine(vault_wordpress_env_defaults | default({}), item.value.env | default({}), vault_wordpress_sites[item.key].env) }}"
 site_hosts_canonical: "{{ item.value.site_hosts | map(attribute='canonical') | list }}"
 site_hosts_redirects: "{{ item.value.site_hosts | selectattr('redirects', 'defined') | sum(attribute='redirects', start=[]) | list }}"
 site_hosts: "{{ site_hosts_canonical | union(site_hosts_redirects) }}"

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -20,4 +20,5 @@ raw_vars:
   - vault_mysql_root_password
   - vault_users.*.password
   - vault_users.*.salt
+  - vault_wordpress_env_defaults
   - vault_wordpress_sites

--- a/group_vars/all/vault.yml
+++ b/group_vars/all/vault.yml
@@ -1,2 +1,8 @@
 # Documentation: https://roots.io/trellis/docs/vault/
 vault_mail_password: smtp_password
+
+# Variables to accompany `wordpress_env_defaults` in `group_vars/all/helpers.yml`
+# Note: These values can be overriden by `vault_wordpress_sites.*.env`
+#
+# vault_wordpress_env_defaults:
+#   my_api_key: 'available to all environments'


### PR DESCRIPTION
`vault_wordpress_env_defaults` works the same way as `wordpress_env_defaults` but expecting to be encrypted by anisble-vault.

Use case:
- non-environment-specific plugin license keys