### PR TITLE
Use Ruby for ssh-config trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Use Ruby script for ssh-config trigger ([#1053](https://github.com/roots/trellis/pull/1053))
 * Update to PHP 7.3 ([#1052](https://github.com/roots/trellis/pull/1052))
 * Enable per-user `update_password` behavior ([#767](https://github.com/roots/trellis/pull/767))
 * Fix Vagrant trigger path ([#1051](https://github.com/roots/trellis/pull/1051))

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -137,10 +137,10 @@ Vagrant.configure('2') do |config|
     if !Vagrant::Util::Platform.windows?
       config.trigger.after :up do |trigger|
         # Add Vagrant ssh-config to ~/.ssh/config
-        trigger.run = {
-          path: File.join(ANSIBLE_PATH, 'bin/ssh-vagrant-config.sh'),
-          args: [main_hostname]
-        }
+        trigger.info = "Adding vagrant ssh-config for #{main_hostname } to ~/.ssh/config"
+        trigger.ruby do
+          update_ssh_config(main_hostname)
+        end
       end
     end
   end

--- a/bin/ssh-vagrant-config.sh
+++ b/bin/ssh-vagrant-config.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-vagrant_host=$1
-
-# Add Vagrant ssh-config to ~/.ssh/config
-sed "/^$/d;s/Host /$NL&/" ~/.ssh/config | sed '/^Host '"$vagrant_host"'$/,/^$/d;' > config &&
-cat config > ~/.ssh/config &&
-rm config &&
-vagrant ssh-config --host ${vagrant_host} >> ~/.ssh/config

--- a/lib/trellis/vagrant.rb
+++ b/lib/trellis/vagrant.rb
@@ -76,3 +76,24 @@ def which(cmd)
     system("#{path} --help", %i(out err) => File::NULL)
   end
 end
+
+def update_ssh_config(main_hostname)
+  regexp = /(Host #{Regexp.quote(main_hostname)}(?:(?!^Host).)*)/m
+  config_file = File.expand_path('~/.ssh/config')
+  vagrant_ssh_config = `vagrant ssh-config --host #{main_hostname}`.chomp
+
+  if File.exists?(config_file)
+    FileUtils.cp(config_file, "#{config_file}.trellis_backup")
+    ssh_config = File.read(config_file)
+
+    content = if ssh_config =~ regexp
+      ssh_config.gsub(regexp, vagrant_ssh_config)
+    else
+      ssh_config << "\n#{vagrant_ssh_config}"
+    end
+
+    File.write(config_file, content)
+  else
+    File.write(config_file, vagrant_ssh_config)
+  end
+end


### PR DESCRIPTION
This replaces the bash implementation in https://github.com/roots/trellis/pull/1042 with a Ruby one instead.

It has some improvements and safety guards. Most important of all, it creates a backup of the existing config file before doing anything.