### PR TITLE
Move remote DB check to playbook level

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -26,6 +26,7 @@ _apt_packages_default:
   dbus: "{{ apt_package_state }}"
   git: "{{ apt_package_state }}"
   libnss-myhostname: "{{ apt_package_state }}"
+  mysql-client: "{{ apt_package_state }}"
 
 apt_packages_python:
   '2':

--- a/roles/mariadb/defaults/main.yml
+++ b/roles/mariadb/defaults/main.yml
@@ -1,8 +1,6 @@
 mariadb_keyserver: "hkp://keyserver.ubuntu.com:80"
 mariadb_keyserver_id: "0xF1656F24C74CD1D8"
 mariadb_ppa: "deb [arch=amd64] http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.2/ubuntu {{ ansible_distribution_release }} main"
-
-mariadb_client_package: mariadb-client
 mariadb_server_package: mariadb-server
 
 mysql_binary_logging_disabled: true

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -1,71 +1,68 @@
 ---
-- block:
-  - name: Add MariaDB APT key
-    apt_key:
-      keyserver: "{{ mariadb_keyserver }}"
-      id: "{{ mariadb_keyserver_id }}"
+- name: Add MariaDB APT key
+  apt_key:
+    keyserver: "{{ mariadb_keyserver }}"
+    id: "{{ mariadb_keyserver_id }}"
 
-  - name: Add MariaDB PPA
-    apt_repository:
-      repo: "{{ mariadb_ppa }}"
-      update_cache: yes
+- name: Add MariaDB PPA
+  apt_repository:
+    repo: "{{ mariadb_ppa }}"
+    update_cache: yes
 
 - name: Install MySQL client
-  apt:
-    name: "{{ mariadb_client_package }}"
-    state: "{{ mariadb_client_package_state | default(apt_package_state) }}"
-    cache_valid_time: "{{ apt_cache_valid_time }}"
+apt:
+  name: "{{ mariadb_client_package }}"
+  state: "{{ mariadb_client_package_state | default(apt_package_state) }}"
+  cache_valid_time: "{{ apt_cache_valid_time }}"
 
 - block:
-  - name: Install MySQL server
-    apt:
-      name: "{{ mariadb_server_package }}"
-      state: "{{ mariadb_server_package_state | default(apt_package_state) }}"
-      cache_valid_time: "{{ apt_cache_valid_time }}"
+- name: Install MySQL server
+  apt:
+    name: "{{ mariadb_server_package }}"
+    state: "{{ mariadb_server_package_state | default(apt_package_state) }}"
+    cache_valid_time: "{{ apt_cache_valid_time }}"
 
-  - name: Disable MariaDB binary logging
-    template:
-      src: disable-binary-logging.cnf
-      dest: /etc/mysql/conf.d
-      owner: root
-      group: root
-    when: mysql_binary_logging_disabled
-    notify: restart mysql server
+- name: Disable MariaDB binary logging
+  template:
+    src: disable-binary-logging.cnf
+    dest: /etc/mysql/conf.d
+    owner: root
+    group: root
+  when: mysql_binary_logging_disabled
+  notify: restart mysql server
 
-  - name: Set root user password
-    mysql_user:
-      name: root
-      host: "{{ item }}"
-      password: "{{ mysql_root_password }}"
-      check_implicit_admin: yes
-      state: present
-    with_items:
-      - "{{ inventory_hostname }}"
-      - 127.0.0.1
-      - ::1
-      - localhost
+- name: Set root user password
+  mysql_user:
+    name: root
+    host: "{{ item }}"
+    password: "{{ mysql_root_password }}"
+    check_implicit_admin: yes
+    state: present
+  with_items:
+    - "{{ inventory_hostname }}"
+    - 127.0.0.1
+    - ::1
+    - localhost
 
-  - name: Copy .my.cnf file with root password credentials.
-    template:
-      src: my.cnf.j2
-      dest: ~/.my.cnf
-      owner: root
-      group: root
-      mode: 0600
+- name: Copy .my.cnf file with root password credentials.
+  template:
+    src: my.cnf.j2
+    dest: ~/.my.cnf
+    owner: root
+    group: root
+    mode: 0600
 
-  - name: Delete anonymous MySQL server users
-    mysql_user:
-      user: ""
-      host: "{{ item }}"
-      state: absent
-    with_items:
-      - localhost
-      - "{{ inventory_hostname }}"
-      - "{{ ansible_hostname }}"
+- name: Delete anonymous MySQL server users
+  mysql_user:
+    user: ""
+    host: "{{ item }}"
+    state: absent
+  with_items:
+    - localhost
+    - "{{ inventory_hostname }}"
+    - "{{ ansible_hostname }}"
 
-  - name: Remove the test database
-    mysql_db:
-      name: test
-      state: absent
-
-  when: not sites_using_remote_db | count
+- name: Remove the test database
+  mysql_db:
+    name: test
+    state: absent

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -9,13 +9,6 @@
     repo: "{{ mariadb_ppa }}"
     update_cache: yes
 
-- name: Install MySQL client
-apt:
-  name: "{{ mariadb_client_package }}"
-  state: "{{ mariadb_client_package_state | default(apt_package_state) }}"
-  cache_valid_time: "{{ apt_cache_valid_time }}"
-
-- block:
 - name: Install MySQL server
   apt:
     name: "{{ mariadb_server_package }}"

--- a/server.yml
+++ b/server.yml
@@ -27,7 +27,7 @@
     - { role: ntp, tags: [ntp] }
     - { role: users, tags: [users] }
     - { role: sshd, tags: [sshd] }
-    - { role: mariadb, tags: [mariadb] }
+    - { role: mariadb, tags: [mariadb],  when: not sites_using_remote_db | count }
     - { role: ssmtp, tags: [ssmtp, mail] }
     - { role: php, tags: [php] }
     - { role: memcached, tags: [memcached] }


### PR DESCRIPTION
We should skip the entire `mariadb` role if no local DB is needed.

This is simpler and also more consistent with the `letsencrypt` role.