### PR TITLE
Let's Encrypt compatibility with python3

### DIFF
--- a/roles/letsencrypt/templates/renew-certs.py
+++ b/roles/letsencrypt/templates/renew-certs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys
@@ -15,15 +15,15 @@ for site in {{ sites_using_letsencrypt }}:
 
     if os.access(cert_path, os.F_OK):
         stat = os.stat(cert_path)
-        print 'Certificate file ' + cert_path + ' already exists'
+        print('Certificate file ' + cert_path + ' already exists')
 
         if time.time() - stat.st_mtime < {{ letsencrypt_min_renewal_age }} * 86400:
-            print '  The certificate is younger than {{ letsencrypt_min_renewal_age }} days. Not creating a new certificate.\n'
+            print('The certificate is younger than {{ letsencrypt_min_renewal_age }} days. Not creating a new certificate.\n')
             continue
 
-    print 'Generating certificate for ' + site
+    print('Generating certificate for ' + site)
 
-    cmd = ('/usr/bin/env python {{ acme_tiny_software_directory }}/acme_tiny.py '
+    cmd = ('/usr/bin/env python3 {{ acme_tiny_software_directory }}/acme_tiny.py '
            '--quiet '
            '--ca {{ letsencrypt_ca }} '
            '--account-key {{ letsencrypt_account_key }} '
@@ -35,19 +35,19 @@ for site in {{ sites_using_letsencrypt }}:
         cert = check_output(cmd, stderr=STDOUT, shell=True)
     except CalledProcessError as e:
         failed = True
-        print 'Error while generating certificate for ' + site
-        print e.output
+        print('Error while generating certificate for ' + site)
+        print(e.output)
     else:
-        with open(cert_path, 'w') as cert_file:
+        with open(cert_path, 'wb') as cert_file:
             cert_file.write(cert)
 
         with open('{{ letsencrypt_intermediate_cert_path }}') as intermediate_cert_file:
             intermediate_cert = intermediate_cert_file.read()
 
-        with open(bundled_cert_path, 'w') as bundled_file:
+        with open(bundled_cert_path, 'wb') as bundled_file:
             bundled_file.write(''.join([cert, intermediate_cert]))
 
-        print 'Created certificate for ' + site
+        print('Created certificate for ' + site)
 
 if failed:
     sys.exit(1)

--- a/roles/letsencrypt/templates/renew-certs.py
+++ b/roles/letsencrypt/templates/renew-certs.py
@@ -45,7 +45,7 @@ for site in {{ sites_using_letsencrypt }}:
             intermediate_cert = intermediate_cert_file.read()
 
         with open(bundled_cert_path, 'wb') as bundled_file:
-            bundled_file.write(''.join([cert, intermediate_cert]))
+            bundled_file.write(b''.join(b[cert, intermediate_cert]))
 
         print('Created certificate for ' + site)
 


### PR DESCRIPTION
The python script is not executable with Trellis >1.0.0 and Ptyhon >3. As I'm not familiar with python, this urgently needs some more tests but fixed it for me.
Please see: https://discourse.roots.io/t/task-letsencrypt-generate-the-certificates-usr-bin-env-python-no-such-file-or-directory/14493