### PR TITLE
Add ansible_python_interpreter task to playbooks

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -11,6 +11,13 @@
   roles:
     - { role: connection, tags: [connection, always] }
 
+- name: Set ansible_python_interpreter
+  hosts: web:&{{ env }}
+  gather_facts: false
+  become: yes
+  roles:
+    - { role: python_interpreter, tags: [always] }
+
 - name: Deploy WP site
   hosts: web:&{{ env }}
   remote_user: "{{ web_user }}"

--- a/rollback.yml
+++ b/rollback.yml
@@ -11,6 +11,13 @@
   roles:
     - { role: connection, tags: [connection, always] }
 
+- name: Set ansible_python_interpreter
+  hosts: web:&{{ env }}
+  gather_facts: false
+  become: yes
+  roles:
+    - { role: python_interpreter, tags: [always] }
+
 - name: Rollback a Deploy
   hosts: web:&{{ env }}
   remote_user: "{{ web_user }}"


### PR DESCRIPTION
`deploy.yml` and `rollback.yml` were missing this task to set
`ansible_python_interpreter` which `server.yml` had.

It should be in all playbooks.

ref: https://discourse.roots.io/t/task-letsencrypt-generate-the-certificates-usr-bin-env-python-no-such-file-or-directory/14493/3?u=swalkinshaw
