### PR TITLE
Don't add HSTS header for self-signed

### DIFF
--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -78,7 +78,9 @@ server {
   ssl_dhparam /etc/nginx/ssl/dhparams.pem;
   ssl_buffer_size 1400; # 1400 bytes to fit in one MTU
 
+  {% if item.value.ssl.provider | default('manual') != 'self-signed' -%}
   add_header Strict-Transport-Security "max-age={{ [hsts_max_age, hsts_include_subdomains, hsts_preload] | reject('none') | join('; ') }}";
+  {% endif -%}
 
   {% if item.value.ssl.client_cert_url is defined -%}
   ssl_verify_client       on;


### PR DESCRIPTION
HSTS doesn't make much sense when using self-signed certs. Also an annoying warning is shown for each request in Firefox console:
`Strict-Transport-Security: The connection to the site is untrustworthy, so the specified header was ignored.`
So I simply added a condition to the template.