### PR TITLE
Revert "Don't force install Ansible Galaxy in dev"

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -128,7 +128,6 @@ Vagrant.configure('2') do |config|
     ansible.playbook = File.join(provisioning_path, 'dev.yml')
     ansible.galaxy_role_file = File.join(provisioning_path, 'requirements.yml') unless vconfig.fetch('vagrant_skip_galaxy') || ENV['SKIP_GALAXY']
     ansible.galaxy_roles_path = File.join(provisioning_path, 'vendor/roles')
-    ansible.galaxy_command = 'ansible-galaxy install --role-file=%{role_file} --roles-path=%{roles_path}'
 
     ansible.groups = {
       'web' => ['default'],


### PR DESCRIPTION
Reverts roots/trellis#1044

For reasoning, see https://github.com/roots/trellis/pull/1044#issuecomment-455698503

The better solution to this would be to create your own `vagrant.local.yml` config override and set `vagrant_skip_galaxy` to `true`.