### PR TITLE
Update Nginx Mainline ppa

### DIFF
--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-nginx_ppa: "ppa:nginx/development"
+nginx_ppa: "ppa:nginx/mainline"
 nginx_package: nginx
 nginx_conf: nginx.conf.j2
 nginx_path: /etc/nginx


### PR DESCRIPTION
Note: We need to find a way to note how to fix the following warning easily.
```
E:Repository 'http://ppa.launchpad.net/nginx/development/ubuntu bionic
InRelease' changed its 'Label' value from 'NGINX Mainline' to 'NGINX Mainline
(1.15.x)'
```