### PR TITLE
Mark vars that shouldn't be templated with AnsibleUnsafe instead of {% raw %}

### DIFF
--- a/lib/trellis/plugins/callback/vars.py
+++ b/lib/trellis/plugins/callback/vars.py
@@ -12,6 +12,7 @@ from ansible.playbook.play_context import PlayContext
 from ansible.playbook.task import Task
 from ansible.plugins.callback import CallbackBase
 from ansible.template import Templar
+from ansible.utils.unsafe_proxy import wrap_var
 
 
 class CallbackModule(CallbackBase):
@@ -35,7 +36,7 @@ class CallbackModule(CallbackBase):
         # wrap values if they match raw_vars pattern
         elif isinstance(item, AnsibleUnicode):
             match = next((pattern for pattern in patterns if re.match(pattern, key_string)), None)
-            return AnsibleUnicode(''.join(['{% raw %}', item, '{% endraw %}'])) if not item.startswith(('{% raw', '{%raw')) and match else item
+            return wrap_var(item) if match else item
 
         else:
             return item


### PR DESCRIPTION
Hey! 👋 

Been a long time since I contributed here. I maintain https://github.com/louim/bedrock-site-protect and I was investigating https://github.com/louim/bedrock-site-protect/issues/19. The issue is related to string containing jinja delimiters like `{{` or `{%`, like salts or passwords. I see that trellis deal with those strings with raw_vars to wrap those string with jinja {% raw %} tags. 

However, it seems like templating those value in a variable (using the values in a variable that will itself be templated) will break the raw escaping, which is causing the issue in my case. I had a look at [an  issue](https://github.com/ansible/ansible/issues/16443) where they recommended using [`!unsafe`](https://docs.ansible.com/ansible/latest/user_guide/playbooks_advanced_syntax.html) to deal with values that need to be escaped in yaml variables.

I had a look at what the `raw_vars` does in trellis, and tweaked it a little to  use [Ansible UnsafeProxy](https://github.com/ansible/ansible/blob/devel/lib/ansible/utils/unsafe_proxy.py) instead of wrapping the variables with raw tags. UnsafeProxy `wrap_var`  is what adding `!unsafe` in a [yaml template does under the hood](https://github.com/ansible/ansible/blob/e4d0be39c36d1441cfc4db06bc148d6546bcdacd/lib/ansible/parsing/yaml/constructor.py#L112-L113).

I redid the test that @fullyint mentioned in https://github.com/roots/trellis/pull/615#issue-77215367 to confirm that the code is still producing the same result.

I also confirmed that it fixes https://github.com/louim/bedrock-site-protect/issues/19.

However, It's been a loooong time since I used Trellis, I may not be aware of all the subtleties of the code and uses-case, so I would really appreciate 👀 to ensure I haven't broken anything by mistake. Also happy to discuss! 🎉 