### PR TITLE
Prevent direct access for .blade.php files

### DIFF
--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -122,8 +122,8 @@ server {
   }
   {% endblock %}
   
-  {% block blade_twig_php -%}
-  # Prevent Blade and Twig files from being accessed directly.
+  {% block blade_twig_templates -%}
+  # Prevent Blade and Twig templates from being accessed directly.
   location ~* \.(blade.php|twig)$ {
     deny all;
   }

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -124,7 +124,7 @@ server {
   
   {% block blade_twig_templates -%}
   # Prevent Blade and Twig templates from being accessed directly.
-  location ~* \.(blade\.php)(/.*)?$ {
+  location ~* \.(blade\.php|twig)(/.*)?$ {
     return 401;
   }
   {% endblock %}

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -124,8 +124,8 @@ server {
   
   {% block blade_twig_templates -%}
   # Prevent Blade and Twig templates from being accessed directly.
-  location ~* \.(blade\.php|twig)$ {
-    deny all;
+  location ~* \.(blade\.php)(/.*)?$ {
+    return 401;
   }
   {% endblock %}
 

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -124,7 +124,7 @@ server {
   
   {% block blade_twig_templates -%}
   # Prevent Blade and Twig templates from being accessed directly.
-  location ~* \.(blade.php|twig)$ {
+  location ~* \.(blade\.php|twig)$ {
     deny all;
   }
   {% endblock %}

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -121,6 +121,13 @@ server {
     deny all;
   }
   {% endblock %}
+  
+  {% block blade_php -%}
+  # Prevent .blade.php files from being accessed directly.
+  location ~* \.(blade.php)$ {
+    deny all;
+  }
+  {% endblock %}
 
   {% block location_primary -%}
   location / {

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -122,9 +122,9 @@ server {
   }
   {% endblock %}
   
-  {% block blade_php -%}
-  # Prevent .blade.php files from being accessed directly.
-  location ~* \.(blade.php)$ {
+  {% block blade_twig_php -%}
+  # Prevent Blade and Twig files from being accessed directly.
+  location ~* \.(blade.php|twig)$ {
     deny all;
   }
   {% endblock %}

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -124,8 +124,8 @@ server {
   
   {% block blade_twig_templates -%}
   # Prevent Blade and Twig templates from being accessed directly.
-  location ~* \.(blade\.php|twig)(/.*)?$ {
-    return 401;
+  location ~* \.(blade\.php|twig)$ {
+    deny all;
   }
   {% endblock %}
 


### PR DESCRIPTION
In Trellis' current state, `.blade.php` files are viewable in plain-text by accessing them directly. Laravel avoids this problem by having views outside of the `public` directory, but unfortunately, that isn't a sane solution with WordPress.

Outside of Trellis, this also calls for an addition to the Sage docs to provide examples on preventing access with apache and/or nginx.

Credit to pkarjala from [this thread](https://discourse.roots.io/t/blade-templates-directly-accessible-via-web-browser-on-server/15059) for finding this.

[Real World Example](https://roots-example-project.com/app/themes/sage/resources/views/index.blade.php)