### PR TITLE
Use all canonical site hosts for Landrush TLD

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -58,7 +58,7 @@ Vagrant.configure('2') do |config|
     config.hostmanager.aliases = hostnames + redirects
   elsif Vagrant.has_plugin?('landrush') && trellis_config.multisite_subdomains?
     config.landrush.enabled = true
-    config.landrush.tld = config.vm.hostname
+    config.landrush.tld = trellis_config.site_hosts_canonical
     hostnames.each { |host| config.landrush.host host, vconfig.fetch('vagrant_ip') }
   else
     fail_with_message "vagrant-hostmanager missing, please install the plugin with this command:\nvagrant plugin install vagrant-hostmanager\n\nOr install landrush for multisite subdomains:\nvagrant plugin install landrush"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -58,7 +58,7 @@ Vagrant.configure('2') do |config|
     config.hostmanager.aliases = hostnames + redirects
   elsif Vagrant.has_plugin?('landrush') && trellis_config.multisite_subdomains?
     config.landrush.enabled = true
-    config.landrush.tld = trellis_config.site_hosts_canonical
+    config.landrush.tld = trellis_config.site_hosts_canonical.select { |host| !host[/\.#{main_hostname}$/] }
     hostnames.each { |host| config.landrush.host host, vconfig.fetch('vagrant_ip') }
   else
     fail_with_message "vagrant-hostmanager missing, please install the plugin with this command:\nvagrant plugin install vagrant-hostmanager\n\nOr install landrush for multisite subdomains:\nvagrant plugin install landrush"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -58,7 +58,7 @@ Vagrant.configure('2') do |config|
     config.hostmanager.aliases = hostnames + redirects
   elsif Vagrant.has_plugin?('landrush') && trellis_config.multisite_subdomains?
     config.landrush.enabled = true
-    config.landrush.tld = trellis_config.site_hosts_canonical.select { |host| !host[/\.#{main_hostname}$/] }
+    config.landrush.tld = trellis_config.site_hosts_canonical.reject { |host| host.end_with?(".#{main_hostname}") }
     hostnames.each { |host| config.landrush.host host, vconfig.fetch('vagrant_ip') }
   else
     fail_with_message "vagrant-hostmanager missing, please install the plugin with this command:\nvagrant plugin install vagrant-hostmanager\n\nOr install landrush for multisite subdomains:\nvagrant plugin install landrush"


### PR DESCRIPTION
This is useful if you want to use WordPress’ [multisite domain mapping](https://wordpress.org/support/article/wordpress-multisite-domain-mapping/) locally and if you’ve specified additional canonical hosts which are not sub-domains of the main canonical host.

In other words it lets you rename your domains from `client.example.test` to `client.test` and have them work (since dnsmasq via Landrush will create a `/etc/resolver/` entry for the domain).