### PR TITLE
Update apt packages before checking essentials

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -110,6 +110,10 @@
   when: openssh_6_8_plus and validate_ssh | default(true)
   tags: [sshd]
 
+- name: Update apt packages
+  apt:
+    update_cache: yes
+
 - name: Checking essentials
   apt:
     name: "{{ item.key }}"


### PR DESCRIPTION
This step will prevent errors such as "No package matching 'build-essential' is available."
That happened a lot for me when I run the provisioning on Digital Ocean droplets Ubuntu 18.04.