### PR TITLE
Ensure ssh config dir exists before writing file

### DIFF
--- a/lib/trellis/vagrant.rb
+++ b/lib/trellis/vagrant.rb
@@ -102,6 +102,7 @@ def update_ssh_config(main_hostname)
 
     File.write(config_file, content)
   else
+    FileUtils.mkdir_p(File.dirname(config_file), mode: 0700)
     File.write(config_file, vagrant_ssh_config)
   end
 end


### PR DESCRIPTION
Ref: https://discourse.roots.io/t/playbookcli-object-has-no-attribute-options/15809

This assumed `~/.ssh/` would exist and just the file didn't.

Now it will create the directory as well if it doesn't exist.

cc @retlehs 