### PR TITLE
Setup composer HTTP basic authentication for multiple repositories

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,3 @@ workflows:
           name: syntax-check-python-2-ansible-2.5
           python-version: '2'
           ansible-version: ~=2.5.0
-      - trellis/syntax-check:
-          name: syntax-check-python-2-ansible-2.4
-          python-version: '2'
-          ansible-version: ~=2.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Head
+* Setup composer HTTP basic authentication for multiple repositories ([#1091](https://github.com/roots/trellis/pull/1091))
+
 ### 1.0.3: April 30th, 2019
 * Prevent direct access for `.blade.php` files ([#1075](https://github.com/roots/trellis/pull/1075))
 * Show custom error message if external IP resolution fails ([#1078](https://github.com/roots/trellis/pull/1078))

--- a/group_vars/all/helpers.yml
+++ b/group_vars/all/helpers.yml
@@ -18,3 +18,9 @@ ssl_enabled: "{{ item.value.ssl is defined and item.value.ssl.enabled | default(
 ssl_stapling_enabled: "{{ item.value.ssl is defined and item.value.ssl.stapling_enabled | default(true) }}"
 cron_enabled: "{{ site_env.disable_wp_cron and (not item.value.multisite.enabled | default(false) or (item.value.multisite.enabled | default(false) and item.value.multisite.cron | default(true))) }}"
 sites_use_ssl: "{{ wordpress_sites.values() | map(attribute='ssl') | selectattr('enabled') | list | count > 0 }}"
+
+# For backward compatibility, to be removed in Trellis v2.
+site_packagist_org_authentications:
+  - { hostname: repo.packagist.com, username: token, password: "{{ vault_wordpress_sites[site].packagist_token | default('') }}" }
+site_composer_authentications: "{{ vault_wordpress_sites[site].composer_authentications | default([]) }}"
+composer_authentications: "{{ site_packagist_org_authentications + site_composer_authentications }}"

--- a/lib/trellis/plugins/vars/version.py
+++ b/lib/trellis/plugins/vars/version.py
@@ -14,7 +14,7 @@ except ImportError:
     from ansible.utils.display import Display
     display = Display()
 
-version_requirement = '2.4.0.0'
+version_requirement = '2.5.0.0'
 version_tested_max = '2.7.5'
 python3_required_version = '2.5.3'
 

--- a/roles/deploy/hooks/build-after.yml
+++ b/roles/deploy/hooks/build-after.yml
@@ -22,6 +22,7 @@
   loop: "{{ composer_authentications }}"
   loop_control:
     loop_var: composer_authentication
+    label: "{{ composer_authentication.hostname }}"
 
 - name: Install Composer dependencies
   composer:

--- a/roles/deploy/hooks/build-after.yml
+++ b/roles/deploy/hooks/build-after.yml
@@ -17,6 +17,14 @@
   no_log: true
   when: project.packagist_token is defined
 
+- name: Setup composer authentications
+  composer:
+    command: config
+    arguments: --auth http-basic.{{ item.hostname }} {{ item.username }} {{ item.password }}
+    working_dir: "{{ deploy_helper.new_release_path }}"
+  no_log: true
+  loop: "{{ vault_wordpress_sites[site].composer_authentications | default([]) }}"
+
 - name: Install Composer dependencies
   composer:
     no_scripts: yes

--- a/roles/deploy/hooks/build-after.yml
+++ b/roles/deploy/hooks/build-after.yml
@@ -9,21 +9,19 @@
     msg: "Unable to find a `composer.json` file in the root of '{{ deploy_helper.new_release_path }}'. Make sure your repo has a `composer.json` file in its root or edit `repo_subtree_path` for '{{ site }}' in `wordpress_sites.yml` so it points to the directory with a `composer.json` file."
   when: not composer_json.stat.exists
 
-- name: Setup packagist.com authentication
-  composer:
-    command: config
-    arguments: --auth http-basic.repo.packagist.com token {{ project.packagist_token }}
-    working_dir: "{{ deploy_helper.new_release_path }}"
-  no_log: true
-  when: project.packagist_token is defined
-
 - name: Setup composer authentications
   composer:
     command: config
-    arguments: --auth http-basic.{{ item.hostname }} {{ item.username }} {{ item.password }}
+    arguments: --auth http-basic.{{ composer_authentication.hostname }} {{ composer_authentication.username }} {{ composer_authentication.password }}
     working_dir: "{{ deploy_helper.new_release_path }}"
   no_log: true
-  loop: "{{ vault_wordpress_sites[site].composer_authentications | default([]) }}"
+  when:
+    - composer_authentication.hostname is defined and composer_authentication.hostname != ""
+    - composer_authentication.username is defined and composer_authentication.username != ""
+    - composer_authentication.password is defined and composer_authentication.password != ""
+  loop: "{{ composer_authentications }}"
+  loop_control:
+    loop_var: composer_authentication
 
 - name: Install Composer dependencies
   composer:

--- a/roles/deploy/hooks/build-after.yml
+++ b/roles/deploy/hooks/build-after.yml
@@ -15,6 +15,7 @@
     arguments: --auth http-basic.{{ composer_authentication.hostname }} {{ composer_authentication.username }} {{ composer_authentication.password }}
     working_dir: "{{ deploy_helper.new_release_path }}"
   no_log: true
+  changed_when: false
   when:
     - composer_authentication.hostname is defined and composer_authentication.hostname != ""
     - composer_authentication.username is defined and composer_authentication.username != ""

--- a/roles/wordpress-install/tasks/composer-authentications.yml
+++ b/roles/wordpress-install/tasks/composer-authentications.yml
@@ -5,6 +5,10 @@
     arguments: --auth http-basic.{{ composer_authentication.hostname }} {{ composer_authentication.username }} {{ composer_authentication.password }}
     working_dir: "{{ working_dir }}"
   no_log: true
+  when:
+    - composer_authentication.hostname is defined and composer_authentication.hostname != ""
+    - composer_authentication.username is defined and composer_authentication.username != ""
+    - composer_authentication.password is defined and composer_authentication.password != ""
   loop: "{{ composer_authentications }}"
   loop_control:
     loop_var: composer_authentication

--- a/roles/wordpress-install/tasks/composer-authentications.yml
+++ b/roles/wordpress-install/tasks/composer-authentications.yml
@@ -1,0 +1,10 @@
+---
+- name: "Setup composer authentications - {{ site }}"
+  composer:
+    command: config
+    arguments: --auth http-basic.{{ composer_authentication.hostname }} {{ composer_authentication.username }} {{ composer_authentication.password }}
+    working_dir: "{{ working_dir }}"
+  no_log: true
+  loop: "{{ composer_authentications }}"
+  loop_control:
+    loop_var: composer_authentication

--- a/roles/wordpress-install/tasks/composer-authentications.yml
+++ b/roles/wordpress-install/tasks/composer-authentications.yml
@@ -5,6 +5,7 @@
     arguments: --auth http-basic.{{ composer_authentication.hostname }} {{ composer_authentication.username }} {{ composer_authentication.password }}
     working_dir: "{{ working_dir }}"
   no_log: true
+  changed_when: false
   when:
     - composer_authentication.hostname is defined and composer_authentication.hostname != ""
     - composer_authentication.username is defined and composer_authentication.username != ""

--- a/roles/wordpress-install/tasks/composer-authentications.yml
+++ b/roles/wordpress-install/tasks/composer-authentications.yml
@@ -12,3 +12,4 @@
   loop: "{{ composer_authentications }}"
   loop_control:
     loop_var: composer_authentication
+    label: "{{ composer_authentication.hostname }}"

--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -34,6 +34,14 @@
   when: item.value.packagist_token is defined
   with_dict: "{{ wordpress_sites }}"
 
+- include_tasks: tasks/composer-authentications.yml
+  vars:
+    site: "{{ item.key }}"
+    working_dir: "{{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/"
+    composer_authentications: "{{ vault_wordpress_sites[site].composer_authentications | default([]) }}"
+  no_log: true
+  with_dict: "{{ wordpress_sites }}"
+
 - name: Install Dependencies with Composer
   composer:
     no_dev: no

--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -25,20 +25,10 @@
   become: no
   with_items: "{{ known_hosts | default([]) }}"
 
-- name: Setup packagist.com authentication
-  composer:
-    command: config
-    arguments: --auth http-basic.repo.packagist.com token {{ item.value.packagist_token }}
-    working_dir: "{{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/"
-  no_log: true
-  when: item.value.packagist_token is defined
-  with_dict: "{{ wordpress_sites }}"
-
 - include_tasks: tasks/composer-authentications.yml
   vars:
     site: "{{ item.key }}"
     working_dir: "{{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/"
-    composer_authentications: "{{ vault_wordpress_sites[site].composer_authentications | default([]) }}"
   no_log: true
   with_dict: "{{ wordpress_sites }}"
 


### PR DESCRIPTION
## Usage

```yaml
# group_vars/<env>/vault.yml

vault_wordpress_sites:
  typist.tech:
    composer_authentications:
      - { hostname: my.com, username: my-username, password: my-password }
      - { hostname: your.com, username: your-username, password: your-password }
  example.com:
    composer_authentications:
      - { hostname: his.com, username: his-username, password: his-password }
      - { hostname: her.com, username: her-username, password: her-password }
```

## Notes

### Loops

Bumping ansible `version_requirement` to `2.5.0.0` to start using [`loop`](https://docs.ansible.com/ansible/latest/user_guide/playbooks_loops.html).

> With the release of Ansible 2.5, the recommended way to perform loops is the use the new loop keyword instead of with_X style loops.
>
> https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.5.html?highlight=loop#migrating-from-with-x-to-loop

## Setup packagist.com authentication

Keeping the original `Setup packagist.com authentication` task for backward compatibility. 

Maybe remove it in Trellis v2?

## Help Wanted

### Vagrant

When you remove an item from `composer_authentications`, re-provisioning vagrant VM won't delete the removed item. 

Send pull request if you have a better way to do it.

### Why the ugly `include_tasks: tasks/composer-authentications.yml`?

Seems ansible has no way to make a `foreach` inside a `foreach` loop. 

Send pull request if you have a better way to do it.