### PR TITLE
Add imagick and bcmath extensions.

### DIFF
--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -14,6 +14,8 @@ php_extensions_default:
   php7.3-xml: "{{ apt_package_state }}"
   php7.3-xmlrpc: "{{ apt_package_state }}"
   php7.3-zip: "{{ apt_package_state }}"
+  php7.3-imagick: "{{ apt_package_state }}"
+  php7.3-bcmath: "{{ apt_package_state }}"
 
 php_extensions_custom: {}
 php_extensions: "{{ php_extensions_default | combine(php_extensions_custom) }}"

--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -7,7 +7,6 @@ php_extensions_default:
   php7.3-curl: "{{ apt_package_state }}"
   php7.3-dev: "{{ apt_package_state }}"
   php7.3-fpm: "{{ apt_package_state }}"
-  php7.3-gd: "{{ apt_package_state }}"
   php7.3-mbstring: "{{ apt_package_state }}"
   php7.3-mysql: "{{ apt_package_state }}"
   php7.3-opcache: "{{ apt_package_state }}"
@@ -15,7 +14,6 @@ php_extensions_default:
   php7.3-xmlrpc: "{{ apt_package_state }}"
   php7.3-zip: "{{ apt_package_state }}"
   php7.3-imagick: "{{ apt_package_state }}"
-  php7.3-bcmath: "{{ apt_package_state }}"
 
 php_extensions_custom: {}
 php_extensions: "{{ php_extensions_default | combine(php_extensions_custom) }}"


### PR DESCRIPTION
The https://wordpress.org/plugins/health-check/ plugin recommends it even thought the page it links to https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions listing what is recommended by the WP hosting team has bcmath not listed, so not sure what its needed or recommenced for.