### PR TITLE
Ansible 2.8 support: Generate self-signed certificates

### DIFF
--- a/roles/wordpress-setup/tasks/self-signed-certificate.yml
+++ b/roles/wordpress-setup/tasks/self-signed-certificate.yml
@@ -1,18 +1,24 @@
 ---
+- name: Ensure openssl configs directory are present
+  file:
+    path: "{{ nginx_ssl_path }}/self-signed-openssl-configs/"
+    state: directory
+    mode: "0755"
+
+- name: Template openssl configs
+  template:
+    src: self-signed-openssl-config.j2
+    dest: "{{ nginx_ssl_path }}/self-signed-openssl-configs/{{ item.key }}.cnf"
+  with_dict: "{{ wordpress_sites | combine(ssl_default_site) }}"
+  when:
+    - sites_use_ssl
+    - ssl_enabled
+    - item.value.ssl.provider | default('manual') == 'self-signed'
+
 - name: Generate self-signed certificates
   shell: "openssl req -new -newkey rsa:2048 \
     -days 3650 -nodes -x509 -sha256 \
-    -extensions req_ext -config <( \
-cat <<' EOF'\n
-[req]\n
-prompt = no\n
-distinguished_name = req_dn\n
-[req_dn]\n
-commonName = {{ item.value.site_hosts[0].canonical }}\n
-[req_ext]\n
-subjectAltName = {{ site_hosts | union(multisite_subdomains_wildcards) | map('regex_replace', '(.*)', 'DNS:\\1') | join(',') }}\n
-EOF\n
-    ) \
+    -extensions req_ext -config {{ nginx_ssl_path }}/self-signed-openssl-configs/{{ item.key }}.cnf \
     -keyout {{ item.key | quote }}.key -out {{ item.key | quote }}.cert"
   args:
     executable: "/bin/bash"
@@ -24,3 +30,8 @@ EOF\n
     - ssl_enabled
     - item.value.ssl.provider | default('manual') == 'self-signed'
   notify: reload nginx
+
+- name: Clean up openssl configs directory
+  file:
+    path: "{{ nginx_ssl_path }}/self-signed-openssl-configs/"
+    state: absent

--- a/roles/wordpress-setup/templates/self-signed-openssl-config.j2
+++ b/roles/wordpress-setup/templates/self-signed-openssl-config.j2
@@ -1,0 +1,7 @@
+[req]
+prompt = no
+distinguished_name = req_dn
+[req_dn]
+commonName = {{ item.value.site_hosts[0].canonical }}
+[req_ext]
+subjectAltName = {{ site_hosts | union(multisite_subdomains_wildcards) | map('regex_replace', '(.*)', 'DNS:\\1') | join(',') }}


### PR DESCRIPTION
Follow up https://github.com/roots/trellis/pull/1103

https://github.com/roots/trellis/blob/a36eb264024b6eb2e34b863509020dee9de64631/roles/wordpress-setup/tasks/self-signed-certificate.yml#L3-L16 behaves differently since ansible 2.8

Ansible 2.7.13:
```
"cmd": "openssl req -new -newkey rsa:2048 -days 3650 -nodes -x509 -sha256 -extensions req_ext -config <( cat <<' EOF'\n [req]\n prompt = no\n distinguished_name = req_dn\n [req_dn]\n commonName = typist.test\n [req_ext]\n subjectAltName = DNS:typist.test,DNS:www.typist.test\n EOF\n ) -keyout typist.tech.key -out typist.tech.cert",
```

Ansible 2.8.5:
```
"cmd": "openssl req -new -newkey rsa:2048 -days 3650 -nodes -x509 -sha256 -extensions req_ext -config <( cat <<' EOF'\n[req]\nprompt = no\ndistinguished_name = req_dn\n[req_dn]\ncommonName = typist.test\n[req_ext]\nsubjectAltName = DNS:typist.test,DNS:www.typist.test\nEOF\n) -keyout typist.tech.key -out typist.tech.cert",
```

This pull request template the config files to `{{ nginx_ssl_path }}/self-signed-openssl-configs/` temporarily instead of inlining `cat`.

Note: This pull request needs testing!

See:
- https://discourse.roots.io/t/self-signed-certificates-not-being-generated-in-development/16695/
- https://discourse.roots.io/t/bash-error-during-trellis-server-provisioning/14414/
- https://discourse.roots.io/t/generating-lets-encrypt-certificates-on-staging-fails/16684