### PR TITLE
Lets Encrypt ACME v2 support

### DIFF
--- a/roles/letsencrypt/defaults/main.yml
+++ b/roles/letsencrypt/defaults/main.yml
@@ -4,7 +4,7 @@ missing_hosts: "{{ site_hosts | difference((current_hosts.results | selectattr('
 letsencrypt_cert_ids: "{ {% for item in (generate_cert_ids | default({'results':[{'skipped':True}]})).results if item is not skipped %}'{{ item.item.key }}':'{{ item.stdout }}', {% endfor %} }"
 
 acme_tiny_repo: 'https://github.com/diafygi/acme-tiny.git'
-acme_tiny_commit: '4ed13950c0a9cf61f1ca81ff1874cde1cf48ab32'
+acme_tiny_commit: 'cb094cf3efa34acef8c7139c8480e2135422e755'
 
 acme_tiny_software_directory: /usr/local/letsencrypt
 acme_tiny_data_directory: /var/lib/letsencrypt
@@ -24,13 +24,9 @@ acme_tiny_challenges_directory: "{{ www_root }}/letsencrypt"
 #  KWXliiWjUORxDxI1c56Rw2VCIExnFjWJAdSLv6/XaQWo2T7U28bkKbAlCF9=
 #  -----END RSA PRIVATE KEY-----
 
-letsencrypt_ca: 'https://acme-v01.api.letsencrypt.org'
+letsencrypt_ca: 'https://acme-v02.api.letsencrypt.org'
 
 letsencrypt_account_key: '{{ acme_tiny_data_directory }}/account.key'
-
-letsencrypt_intermediate_cert_path: /etc/ssl/certs/lets-encrypt-x3-cross-signed.pem
-letsencrypt_intermediate_cert_url: 'https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem'
-letsencrypt_intermediate_cert_sha256sum: 'e446c5e9dbef9d09ac9f7027c034602492437a05ff6c40011d7235fca639c79a'
 
 letsencrypt_keys_dir: "{{ nginx_ssl_path }}/letsencrypt"
 letsencrypt_certs_dir: "{{ nginx_ssl_path }}/letsencrypt"

--- a/roles/letsencrypt/tasks/certificates.yml
+++ b/roles/letsencrypt/tasks/certificates.yml
@@ -15,7 +15,7 @@
 
 - name: Generate Lets Encrypt certificate IDs
   shell: |
-    echo "{{ [site_hosts | join(' '), letsencrypt_ca, acme_tiny_commit, letsencrypt_intermediate_cert_sha256sum] | join('\n') }}" |
+    echo "{{ [site_hosts | join(' '), letsencrypt_ca, acme_tiny_commit] | join('\n') }}" |
     cat {{ letsencrypt_account_key }} {{ letsencrypt_keys_dir }}/{{ item.key }}.key - |
     md5sum | cut -c -7
   register: generate_cert_ids

--- a/roles/letsencrypt/tasks/setup.yml
+++ b/roles/letsencrypt/tasks/setup.yml
@@ -37,9 +37,3 @@
   args:
     creates: "{{ letsencrypt_account_key }}"
   when: letsencrypt_account_key_source_content is not defined and letsencrypt_account_key_source_file is not defined
-
-- name: Download intermediate certificate
-  get_url:
-    url: "{{ letsencrypt_intermediate_cert_url }}"
-    dest: "{{ letsencrypt_intermediate_cert_path }}"
-    sha256sum: "{{ letsencrypt_intermediate_cert_sha256sum }}"

--- a/roles/letsencrypt/templates/renew-certs.py
+++ b/roles/letsencrypt/templates/renew-certs.py
@@ -10,44 +10,38 @@ failed = False
 letsencrypt_cert_ids = {{ letsencrypt_cert_ids }}
 
 for site in {{ sites_using_letsencrypt }}:
-    cert_path = os.path.join('{{ letsencrypt_certs_dir }}', site + '-' + letsencrypt_cert_ids[site] + '.cert')
     bundled_cert_path = os.path.join('{{ letsencrypt_certs_dir }}', site + '-' + letsencrypt_cert_ids[site] + '-bundled.cert')
 
-    if os.access(cert_path, os.F_OK):
-        stat = os.stat(cert_path)
-        print 'Certificate file ' + cert_path + ' already exists'
+    if os.access(bundled_cert_path, os.F_OK):
+        stat = os.stat(bundled_cert_path)
+        print('Certificate file ' + bundled_cert_path + ' already exists')
 
         if time.time() - stat.st_mtime < {{ letsencrypt_min_renewal_age }} * 86400:
-            print '  The certificate is younger than {{ letsencrypt_min_renewal_age }} days. Not creating a new certificate.\n'
+            print('  The certificate is younger than {{ letsencrypt_min_renewal_age }} days. Not creating a new certificate.\n')
             continue
 
-    print 'Generating certificate for ' + site
+    print('Generating certificate for ' + site)
 
-    cmd = ('/usr/bin/env python {{ acme_tiny_software_directory }}/acme_tiny.py '
-           '--quiet '
-           '--ca {{ letsencrypt_ca }} '
-           '--account-key {{ letsencrypt_account_key }} '
-           '--csr {{ acme_tiny_data_directory }}/csrs/{0}-{1}.csr '
-           '--acme-dir {{ acme_tiny_challenges_directory }}'
-           ).format(site, letsencrypt_cert_ids[site])
+    cmd = (
+        '/usr/bin/env python {{ acme_tiny_software_directory }}/acme_tiny.py '
+        '--quiet '
+        '--ca {{ letsencrypt_ca }} '
+        '--account-key {{ letsencrypt_account_key }} '
+        '--csr {{ acme_tiny_data_directory }}/csrs/{0}-{1}.csr '
+        '--acme-dir {{ acme_tiny_challenges_directory }}'
+    ).format(site, letsencrypt_cert_ids[site])
 
     try:
         cert = check_output(cmd, stderr=STDOUT, shell=True)
     except CalledProcessError as e:
         failed = True
-        print 'Error while generating certificate for ' + site
-        print e.output
+        print('Error while generating certificate for ' + site)
+        print(e.output)
     else:
-        with open(cert_path, 'w') as cert_file:
+        with open(bundled_cert_path, 'w') as cert_file:
             cert_file.write(cert)
 
-        with open('{{ letsencrypt_intermediate_cert_path }}') as intermediate_cert_file:
-            intermediate_cert = intermediate_cert_file.read()
-
-        with open(bundled_cert_path, 'w') as bundled_file:
-            bundled_file.write(''.join([cert, intermediate_cert]))
-
-        print 'Created certificate for ' + site
+        print('Created certificate for ' + site)
 
 if failed:
     sys.exit(1)


### PR DESCRIPTION
Fixes https://github.com/roots/trellis/issues/1113

Note that v2 now bundles the intermediate certificate automatically 😄 We no longer have to download it separately and bundle it manually.