### PR TITLE
wordpress-setup: Block dependency manager files by Nginx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Head
+* wordpress-setup: Block dependency manager files by Nginx ([#1116](https://github.com/roots/trellis/pull/1116))
+
 ### 1.2.0: October 11th, 2019
 * Lets Encrypt ACME v2 support ([#1114](https://github.com/roots/trellis/pull/1114))
 * Fix self-signed certificates in Ansible 2.8 ([#1110](https://github.com/roots/trellis/pull/1110))

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -129,6 +129,36 @@ server {
   }
   {% endblock %}
 
+  {% block dependency_managers -%}
+  # composer
+  location ~* composer\.(json|lock)$ {
+    deny all;
+  }
+
+  location ~* auth\.json$ {
+    deny all;
+  }
+
+  # npm
+  location ~* package(-lock)?\.json$ {
+    deny all;
+  }
+  
+  # yarn
+  location ~* yarn\.lock$ {
+    deny all;
+  }
+  
+  # bundler
+  location ~* Gemfile(\.lock)?$ {
+    deny all;
+  }
+
+  location ~* gems\.(rb|locked)?$ {
+    deny all;
+  }
+  {% endblock %}
+
   {% block location_primary -%}
   location / {
     try_files $uri $uri/ /index.php?$args;


### PR DESCRIPTION
Block these dependency managers:
- composer
- npm
- yarn
- bundler

`auth.json` should never be commited under `web_root`. Blocking it because better safe than worry.

bundler should never be commited under `web_root` neither. Blocking it prevent https://github.com/roots/bedrock-capistrano misuses.

Note: This needs testing.