### PR TITLE
Add git_sha and release_version to .env on deploy

### DIFF
--- a/roles/deploy/vars/main.yml
+++ b/roles/deploy/vars/main.yml
@@ -7,5 +7,7 @@ wordpress_env_defaults:
   wp_home: "{{ project.ssl.enabled | default(false) | ternary('https', 'http') }}://{{ project.site_hosts | map(attribute='canonical') | first }}"
   wp_siteurl: "{{ project.ssl.enabled | default(false) | ternary('https', 'http') }}://{{ project.site_hosts | map(attribute='canonical') | first }}/wp"
   domain_current_site: "{{ project.site_hosts | map(attribute='canonical') | first }}"
+  git_sha: "{{ git_clone.after }}"
+  release_version: "{{ deploy_helper.new_release }}"
 
 site_env: "{{ wordpress_env_defaults | combine(vault_wordpress_env_defaults | default({}), project.env | default({}), vault_wordpress_sites[site].env) }}"


### PR DESCRIPTION
This will provide `GIT_SHA` and `RELEASE_VERSION` env variables. They can be useful for many purposes including application/error monitoring software.