### PR TITLE
Use modern SSL config for Nginx

### DIFF
--- a/roles/nginx/templates/h5bp/directive-only/ssl-stapling.conf
+++ b/roles/nginx/templates/h5bp/directive-only/ssl-stapling.conf
@@ -1,9 +1,34 @@
-# OCSP stapling...
+# ----------------------------------------------------------------------
+# | Online Certificate Status Protocol stapling                        |
+# ----------------------------------------------------------------------
+
+# OCSP is a lightweight, only one record to help clients verify the validity of
+# the server certificate.
+# OCSP stapling allows the server to send its cached OCSP record during the TLS
+# handshake, without the need of 3rd party OCSP responder.
+#
+# https://wiki.mozilla.org/Security/Server_Side_TLS#OCSP_Stapling
+# https://tools.ietf.org/html/rfc6066#section-8
+# https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_stapling
+#
+# (1) Use Cloudflare 1.1.1.1 DNS resolver
+#     https://developers.cloudflare.com/1.1.1.1/setting-up-1.1.1.1/
+#
+# (2) Use Google 8.8.8.8 DNS resolver
+#     https://developers.google.com/speed/public-dns/docs/using
+#
+# (3) Use Dyn DNS resolver
+#     https://help.dyn.com/internet-guide-setup/
+
 ssl_stapling on;
 ssl_stapling_verify on;
 
-#trusted cert must be made up of your intermediate certificate followed by root certificate
-#ssl_trusted_certificate /path/to/ca.crt;
-
-resolver 8.8.8.8 8.8.4.4 216.146.35.35 216.146.36.36 valid=60s;
+resolver
+  # (1)
+  1.1.1.1 1.0.0.1 [2606:4700:4700::1111] [2606:4700:4700::1001]
+  # (2)
+  8.8.8.8 8.8.4.4 [2001:4860:4860::8888] [2001:4860:4860::8844]
+  # (3)
+  # 216.146.35.35 216.146.36.36
+  valid=60s;
 resolver_timeout 2s;

--- a/roles/nginx/templates/h5bp/directive-only/ssl.conf
+++ b/roles/nginx/templates/h5bp/directive-only/ssl.conf
@@ -1,6 +1,6 @@
 ssl_protocols TLSv1.2 TLSv1.3;
 ssl_ciphers EECDH+CHACHA20:EECDH+AES;
-ssl_prefer_server_ciphers on;
+ssl_prefer_server_ciphers off;
 
 # Optimize SSL by caching session parameters for 10 minutes. This cuts down on the number of expensive SSL handshakes.
 # The handshake is the most CPU-intensive operation, and by default it is re-negotiated on every new/parallel connection.

--- a/roles/nginx/templates/h5bp/directive-only/ssl.conf
+++ b/roles/nginx/templates/h5bp/directive-only/ssl.conf
@@ -21,7 +21,7 @@ ssl_session_timeout  24h;
 #
 # Note that you'll have to define and rotate the keys securely by yourself. In absence
 # of such infrastructure, consider turning off session tickets:
-#ssl_session_tickets off;
+ssl_session_tickets off;
 
 # Use a higher keepalive timeout to reduce the need for repeated handshakes
 keepalive_timeout 300s; # up from 75 secs default

--- a/roles/nginx/templates/h5bp/directive-only/ssl.conf
+++ b/roles/nginx/templates/h5bp/directive-only/ssl.conf
@@ -1,10 +1,6 @@
-# Protect against the BEAST and POODLE attacks by not using SSLv3 at all. If you need to support older browsers (IE6) you may need to add
-# SSLv3 to the list of protocols below.
-ssl_protocols              TLSv1 TLSv1.1 TLSv1.2;
-
-# Ciphers set to best allow protection from Beast, while providing forwarding secrecy, as defined by Mozilla (Intermediate Set) - https://wiki.mozilla.org/Security/Server_Side_TLS#Nginx
-ssl_ciphers                ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS;
-ssl_prefer_server_ciphers  on;
+ssl_protocols TLSv1.2 TLSv1.3;
+ssl_ciphers EECDH+CHACHA20:EECDH+AES;
+ssl_prefer_server_ciphers on;
 
 # Optimize SSL by caching session parameters for 10 minutes. This cuts down on the number of expensive SSL handshakes.
 # The handshake is the most CPU-intensive operation, and by default it is re-negotiated on every new/parallel connection.


### PR DESCRIPTION
Fixes https://github.com/roots/trellis/issues/1126

Based off of h5bp's config: https://github.com/h5bp/server-configs-nginx/blob/611ed7507bc200b81867423f6061fe79b2f606e8/h5bp/ssl/policy_modern.conf

Drops TLSv1 and TLSv2.1 and updates the cipher suite.

Cipher suite compatibility details: https://cryptcheck.fr/suite/ECDHE+AES:!SHA
TLS 1.2 compatibility: https://caniuse.com/#feat=tls1-2
TLS 1.3 compatibility: https://caniuse.com/#feat=tls1-3

@austinpray 