### PR TITLE
Fix subjectAltName for self-signed certificates

### DIFF
--- a/roles/wordpress-setup/templates/self-signed-openssl-config.j2
+++ b/roles/wordpress-setup/templates/self-signed-openssl-config.j2
@@ -4,4 +4,4 @@ distinguished_name = req_dn
 [req_dn]
 commonName = {{ item.value.site_hosts[0].canonical }}
 [req_ext]
-subjectAltName = {{ site_hosts | union(multisite_subdomains_wildcards) | map('regex_replace', '(.*)', 'DNS:\\1') | join(',') }}
+subjectAltName = {{ site_hosts | union(multisite_subdomains_wildcards) | map('regex_replace', '(^.*$)', 'DNS:\\1') | join(',') }}


### PR DESCRIPTION
Ref: https://github.com/roots/trellis/issues/1117

In some cases the `subjectAltName` for self-signed SSL certificates were
invalid due to `DNS:` being both prepended *and* appended to each domain
when it should only be a prefix.

This tweaks `regex_replace` to anchor at the start of the string only.

Before:

```
subjectAltName = DNS:example.testDNS:,DNS:www.example.testDNS:
```

After:

```
subjectAltName = DNS:example.test,DNS:www.example.test
```