### PR TITLE
CircleCI: `ansible-lint` playbooks

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,3 @@
+---
+skip_list:
+  - 204 # Lines should be no longer than 160 chars

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,15 @@ orbs:
                 ansible-playbook --syntax-check -e env=development rollback.yml
                 ansible-playbook --syntax-check -e xdebug_tunnel_inventory_host=1 xdebug-tunnel.yml
 
+      lint:
+        executor: python-3
+        steps:
+          - run: python --version
+          - checkout
+          - run: sudo pip install ansible-lint
+          - run: ansible-lint --version
+          - run: ansible-lint deploy.yml dev.yml server.yml rollback.yml xdebug-tunnel.yml
+
 workflows:
   syntax-check:
     jobs:
@@ -80,3 +89,6 @@ workflows:
           name: syntax-check-python-2-ansible-2.7
           python-version: '2'
           ansible-version: ~=2.7.0
+  lint:
+    jobs:
+      - trellis/lint

--- a/roles/deploy/tasks/update.yml
+++ b/roles/deploy/tasks/update.yml
@@ -33,7 +33,7 @@
       > https://roots.io/trellis/docs/ssh-keys/#cloning-remote-repo-using-ssh-agent-forwarding
   when: git_clone is failed
 
-- name: Remove untracked files from project folder
+- name: Remove untracked files from project folder # noqa 303
   command: git clean -fdx
   args:
     chdir: "{{ project_source_path }}"

--- a/roles/rollback/tasks/main.yml
+++ b/roles/rollback/tasks/main.yml
@@ -4,6 +4,7 @@
   args:
     chdir: "{{ project_root }}"
   register: current_release_readlink_result
+  changed_when: false
 
 - name: Clean up old and failed releases
   deploy_helper:


### PR DESCRIPTION
> Ansible Lint is a commandline tool for linting playbooks. Use it to detect behaviors and practices that could potentially be improved.
>
> -- https://docs.ansible.com/ansible-lint/

`ansible-lint` is useful to catch depreciation sooner.

Taken from https://github.com/ItinerisLtd/trellis_install_wp_cli_via_composer/blob/a1bc936d033641cc54556da5a7501d0685f8361d/.circleci/config.yml#L24-L32

See: https://docs.ansible.com/ansible-lint/rules/default_rules.html