### PR TITLE
Bump ansible requirement to 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Allow `composer install` with `--classmap-authoritative` during deploy ([#1132](https://github.com/roots/trellis/pull/1132))
 * Fix `DEPLOY_UNFINISHED` not being copied over to `release` folder (#[1145])(https://github.com/roots/trellis/pull/1145)
 * Deploy: Remove untracked files from project folder ([#1146](https://github.com/roots/trellis/pull/1146))
+* Bump ansible requirement to 2.8.0 ([#1147](https://github.com/roots/trellis/pull/1147))
 
 ### 1.3.0: December 7th, 2019
 * Add `git_sha` and `release_version` to `.env` on deploy ([#1124](https://github.com/roots/trellis/pull/1124))

--- a/lib/trellis/plugins/vars/version.py
+++ b/lib/trellis/plugins/vars/version.py
@@ -14,7 +14,7 @@ except ImportError:
     from ansible.utils.display import Display
     display = Display()
 
-version_requirement = '2.7.12'
+version_requirement = '2.8.0'
 version_tested_max = '2.8.4'
 python3_required_version = '2.5.3'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ansible>=2.7.12,<2.9
+ansible>=2.8.0,<2.9
 passlib

--- a/vagrant.default.yml
+++ b/vagrant.default.yml
@@ -4,7 +4,7 @@ vagrant_cpus: 1
 vagrant_memory: 1024 # in MB
 vagrant_box: 'bento/ubuntu-18.04'
 vagrant_box_version: '>= 201807.12.0'
-vagrant_ansible_version: '2.7.12'
+vagrant_ansible_version: '2.8.0'
 vagrant_skip_galaxy: false
 vagrant_mount_type: 'nfs'
 


### PR DESCRIPTION
https://github.com/roots/trellis/pull/1141 bases on https://github.com/ansible/ansible-lint/issues/457#issuecomment-455038475
which depends on https://github.com/ansible/ansible/pull/51030 which merged into anisble v2.8.0.

See: https://discourse.roots.io/t/provisioning-server-not-working-because-ansible-ssh-extra-args-is-undefined/17484