### PR TITLE
Void rolled back releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Nginx: Block `composer/installed.json` ([#1150](https://github.com/roots/trellis/pull/1150))
 * Run `git clean` after checking `git clone` is successful ([#1151](https://github.com/roots/trellis/pull/1151))
 * Lint: Fix: `[206] Variables should have spaces before and after: {{ var_name }}` ([#1152](https://github.com/roots/trellis/pull/1152))
+* Void rolled back releases ([#1148](https://github.com/roots/trellis/pull/1148))
 
 ### 1.3.0: December 7th, 2019
 * Add `git_sha` and `release_version` to `.env` on deploy ([#1124](https://github.com/roots/trellis/pull/1124))

--- a/roles/rollback/tasks/main.yml
+++ b/roles/rollback/tasks/main.yml
@@ -1,22 +1,31 @@
 ---
+- name: Get real path of current symlinked release
+  command: "readlink {{ project_current_path }}"
+  args:
+    chdir: "{{ project_root }}"
+  register: current_release_readlink_result
+
+- name: Clean up old and failed releases
+  deploy_helper:
+    state: clean
+    path: "{{ project_root }}"
+    current_path: "{{ project_current_path }}"
+    release: "{{ current_release_readlink_result.stdout }}"
+    keep_releases: "{{ project.deploy_keep_releases | default(deploy_keep_releases | default(omit)) }}"
+
 - import_tasks: user-release.yml
   when: release is defined
 
 - import_tasks: prior-release.yml
   when: release is not defined
 
-- name: Check whether target release was from a successful deploy
-  stat:
-    path: "{{ new_release_path }}/DEPLOY_UNFINISHED"
-  register: target
-
-- name: Fail if target release was from failed deploy
-  fail:
-    msg: "Cannot switch to release at {{ new_release_path }}. It is from an unfinished deploy. You may manually specify a different release using --extra-vars='release=12345678901234'."
-  when: target.stat.exists | default(False)
-
 - name: Link 'current' directory to target release
   file:
     path: "{{ project_root }}/{{ project_current_path }}"
     src: "{{ new_release_path }}"
     state: link
+
+- name: Write unfinished file to old symlinked release
+  file:
+    path: "{{ current_release_readlink_result.stdout }}/DEPLOY_UNFINISHED"
+    state: touch


### PR DESCRIPTION
### Problem A

1. deploy (`current` symlink to `releases/11111111`)
1. deploy some changes (`current` symlink to `releases/22222222`)
1. find out `releases/22222222` is buggy; rollback (`current` symlink to `releases/11111111`)
1. deploy bug fixes (`current` symlink to `releases/33333333`)
1. find out `releases/33333333` is also buggy; rollback (`current` symlink to `releases/22222222`)

We already know `releases/22222222` is buggy and rolled back in step 3. However, Trellis doesn't know. Trellis rolls back to the last release which older than `current`

https://github.com/roots/trellis/blob/ac87cd5af42ea8194499606119b610db265ec501/roles/rollback/tasks/prior-release.yml#L21

### Solution A

Write `DEPLOY_UNFINISHED` to release we move away from.

---

### Problem B

If the last release which older than `current` contains `DEPLOY_UNFINISH`, rollback fails.

https://github.com/roots/trellis/blob/ac87cd5af42ea8194499606119b610db265ec501/roles/rollback/tasks/main.yml#L8-L11

### Solution B

Clean up old and failed (`DEPLOY_UNFINISH`) releases at the beginning of `rollback.yml`

---

Do we count this as beraking changes?
