### PR TITLE
Lint: Fix: `[306] Shells that use pipes should set the pipefail option`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Nginx: Block `composer/installed.json` ([#1150](https://github.com/roots/trellis/pull/1150))
 * Run `git clean` after checking `git clone` is successful ([#1151](https://github.com/roots/trellis/pull/1151))
 * Lint: Fix: `[206] Variables should have spaces before and after: {{ var_name }}` ([#1152](https://github.com/roots/trellis/pull/1152))
+* Lint: Fix: `[306] Shells that use pipes should set the pipefail option ([#1153](https://github.com/roots/trellis/pull/1153))
 
 ### 1.3.0: December 7th, 2019
 * Add `git_sha` and `release_version` to `.env` on deploy ([#1124](https://github.com/roots/trellis/pull/1124))

--- a/roles/deploy/tasks/prepare.yml
+++ b/roles/deploy/tasks/prepare.yml
@@ -22,15 +22,21 @@
     state: directory
 
 - name: Run git archive to populate new build dir
-  shell: git archive {{ project_version }} | tar xf - -C {{ deploy_helper.new_release_path }}
+  shell: |
+    set -eo pipefail
+    git archive {{ project_version }} | tar xf - -C {{ deploy_helper.new_release_path }}
   args:
     chdir: "{{ project_source_path }}"
+    executable: /bin/bash
   when: project.repo_subtree_path is not defined
 
 - name: Run git archive with subdirectory to populate new build dir
-  shell: git archive {{ project_version }} {{ project.repo_subtree_path }} | tar -x --strip-components {{ project.repo_subtree_path.split('/') | count }} -f - -C {{ deploy_helper.new_release_path }}
+  shell: |
+    set -eo pipefail
+    git archive {{ project_version }} {{ project.repo_subtree_path }} | tar -x --strip-components {{ project.repo_subtree_path.split('/') | count }} -f - -C {{ deploy_helper.new_release_path }}
   args:
     chdir: "{{ project_source_path }}"
+    executable: /bin/bash
   when: project.repo_subtree_path is defined
 
 - name: write unfinished file

--- a/roles/letsencrypt/tasks/certificates.yml
+++ b/roles/letsencrypt/tasks/certificates.yml
@@ -15,9 +15,12 @@
 
 - name: Generate Lets Encrypt certificate IDs
   shell: |
+    set -eo pipefail
     echo "{{ [site_hosts | join(' '), letsencrypt_ca, acme_tiny_commit] | join('\n') }}" |
     cat {{ letsencrypt_account_key }} {{ letsencrypt_keys_dir }}/{{ item.key }}.key - |
     md5sum | cut -c -7
+  args:
+    executable: /bin/bash
   register: generate_cert_ids
   changed_when: false
   when: site_uses_letsencrypt

--- a/roles/rollback/tasks/prior-release.yml
+++ b/roles/rollback/tasks/prior-release.yml
@@ -1,8 +1,11 @@
 ---
 - name: Get list position of current symlinked release
-  shell: "ls releases | grep -n $(basename $(readlink {{ project_current_path }})) | cut -f1 -d:"
+  shell: |
+    set -eo pipefail
+    ls releases | grep -n $(basename $(readlink {{ project_current_path }})) | cut -f1 -d:
   args:
     chdir: "{{ project_root }}"
+    executable: /bin/bash
   register: current_release_position
 
 - name: Fail if current release is the oldest available release


### PR DESCRIPTION
Tested deploy without subdirectory and rollback.

Need help testing deploy with subdirectory and Lets Encrypt.

---

Discussion: Is it safe to assume `bash` lives at `/bin/bash`?

Alternatively, we can do `executable: {{ bash_path }}`
See also: https://github.com/roots/trellis/blob/f11a7cefbc978831d1ff6b4156298e618ff2ff80/roles/letsencrypt/tasks/certificates.yml#L30