### PR TITLE
Prevent search engines indexing any non-production environments

### DIFF
--- a/roles/wordpress-setup/defaults/main.yml
+++ b/roles/wordpress-setup/defaults/main.yml
@@ -50,6 +50,11 @@ h5bp_cross_domain_fonts_enabled: "{{ h5bp.cross_domain_fonts | default(true) }}"
 h5bp_expires_enabled: "{{ h5bp.expires | default(false) }}"
 h5bp_protect_system_files_enabled: "{{ h5bp.protect_system_files | default(true) }}"
 
+# X-Robots-Tag Header helpers
+not_prod: "{{ env != 'production' }}"
+robots_tag_header: "{{ item.value.robots_tag_header | default({}) }}"
+robots_tag_header_enabled: "{{ robots_tag_header.enabled | default(not_prod) }}"
+
 # PHP FPM
 php_fpm_pm_max_children: 10
 php_fpm_pm_start_servers: 1

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -218,6 +218,14 @@ server {
   {% endif -%}
   {% endblock -%}
 
+  {% block robots_tag_header -%}
+  {% if robots_tag_header_enabled -%}
+  # Prevent search engines from indexing non-production environments
+  add_header X-Robots-Tag "noindex, nofollow" always;
+
+  {% endif -%}
+  {% endblock -%}
+
   {% block location_php -%}
   location ~ \.php$ {
     {% block location_php_basic -%}


### PR DESCRIPTION
Add “X-Robots-Tag: noindex, nofollow” header to nginx conf for all requests when on staging.

See: https://make.wordpress.org/core/2019/09/02/changes-to-prevent-search-engines-indexing-sites/

---

Reference issue: #1157 

---

Can turn this behaviour off with the following settings in the `wordpress_sites.yml`:

```yaml
wordpress_sites:
  example.com:
    ...
    robots_tag_header:
      enabled: true
```