### PR TITLE
Add `WP_DEBUG_LOG` to `.env`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Lint: Fix: `[306] Shells that use pipes should set the pipefail option ([#1153](https://github.com/roots/trellis/pull/1153))
 * Lint: Fix `[301] Commands should not change things if nothing needs doing ([#1139](https://github.com/roots/trellis/pull/1139))
 * Void rolled back releases ([#1148](https://github.com/roots/trellis/pull/1148))
+* Add `WP_DEBUG_LOG` to `.env` on deploy ([#1160](https://github.com/roots/trellis/pull/1160))
 
 ### 1.3.0: December 7th, 2019
 * Add `git_sha` and `release_version` to `.env` on deploy ([#1124](https://github.com/roots/trellis/pull/1124))

--- a/group_vars/all/helpers.yml
+++ b/group_vars/all/helpers.yml
@@ -8,6 +8,7 @@ wordpress_env_defaults:
   wp_home: "{{ ssl_enabled | ternary('https', 'http') }}://{{ site_hosts_canonical | first }}"
   wp_siteurl: "{{ ssl_enabled | ternary('https', 'http') }}://{{ site_hosts_canonical | first }}/wp"
   domain_current_site: "{{ site_hosts_canonical | first }}"
+  wp_debug_log: "{{ www_root }}/{{ item.key }}/logs/debug.log"
 
 site_env: "{{ wordpress_env_defaults | combine(vault_wordpress_env_defaults | default({}), item.value.env | default({}), vault_wordpress_sites[item.key].env) }}"
 site_hosts_canonical: "{{ item.value.site_hosts | map(attribute='canonical') | list }}"

--- a/roles/deploy/vars/main.yml
+++ b/roles/deploy/vars/main.yml
@@ -9,5 +9,6 @@ wordpress_env_defaults:
   domain_current_site: "{{ project.site_hosts | map(attribute='canonical') | first }}"
   git_sha: "{{ git_clone.after }}"
   release_version: "{{ deploy_helper.new_release }}"
+  wp_debug_log: "{{ project_root }}/logs/debug.log"
 
 site_env: "{{ wordpress_env_defaults | combine(vault_wordpress_env_defaults | default({}), project.env | default({}), vault_wordpress_sites[site].env) }}"


### PR DESCRIPTION
Add environment variable `WP_DEBUG_LOG=/srv/www/example.com/logs` to `.env`

> Reminder: Any values set to WP_DEBUG_LOG and WP_DEBUG_DISPLAY will be ignored unless WP_DEBUG is set to true.
>
> -- https://make.wordpress.org/core/2019/01/23/miscellaneous-developer-focused-changes-in-5-1/

---

Need help testing on vargrant VMs.

---

Bedrock needs to be updated when this is merged.

---

close #1159