### PR TITLE
Update to PHP 7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Head
+* Update PHP to 7.4 ([#1164](https://github.com/roots/trellis/pull/1164))
 * Update `wp_cli_version` to 2.4.0 ([#1131](https://github.com/roots/trellis/pull/1131))
 * Fix `subjectAltName` for self-signed certificates ([#1128](https://github.com/roots/trellis/pull/1128))
 * `composer install` without `--no-scripts` during deploy ([#1133](https://github.com/roots/trellis/pull/1133))

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Trellis will configure a server with the following and more:
 
 * Ubuntu 18.04 Bionic LTS
 * Nginx (with optional FastCGI micro-caching)
-* PHP 7.3
+* PHP 7.4
 * MariaDB (a drop-in MySQL replacement)
 * SSL support (scores an A+ on the [Qualys SSL Labs Test](https://www.ssllabs.com/ssltest/))
 * Let's Encrypt for free SSL certificates

--- a/dev.yml
+++ b/dev.yml
@@ -6,7 +6,7 @@
   roles:
     - { role: python_interpreter, tags: [always] }
 
-- name: "WordPress Server: Install LEMP Stack with PHP 7.3 and MariaDB MySQL"
+- name: "WordPress Server: Install LEMP Stack with PHP 7.4 and MariaDB MySQL"
   hosts: web:&development
   become: yes
   remote_user: vagrant

--- a/group_vars/all/users.yml
+++ b/group_vars/all/users.yml
@@ -19,4 +19,4 @@ users:
 web_user: web
 web_group: www-data
 web_sudoers:
-  - "/usr/sbin/service php7.3-fpm *"
+  - "/usr/sbin/service php7.4-fpm *"

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -9,7 +9,7 @@
 
 - name: reload php-fpm
   service:
-    name: php7.3-fpm
+    name: php7.4-fpm
     state: reloaded
 
 - import_tasks: reload_nginx.yml

--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -34,6 +34,6 @@
   when: wp_installed.rc == 0
 
 - name: Reload php-fpm
-  shell: sudo service php7.3-fpm reload
+  shell: sudo service php7.4-fpm reload
   args:
     warn: false

--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -2,18 +2,18 @@ disable_default_pool: true
 memcached_sessions: false
 
 php_extensions_default:
-  php7.3-cli: "{{ apt_package_state }}"
-  php7.3-common: "{{ apt_package_state }}"
-  php7.3-curl: "{{ apt_package_state }}"
-  php7.3-dev: "{{ apt_package_state }}"
-  php7.3-fpm: "{{ apt_package_state }}"
-  php7.3-gd: "{{ apt_package_state }}"
-  php7.3-mbstring: "{{ apt_package_state }}"
-  php7.3-mysql: "{{ apt_package_state }}"
-  php7.3-opcache: "{{ apt_package_state }}"
-  php7.3-xml: "{{ apt_package_state }}"
-  php7.3-xmlrpc: "{{ apt_package_state }}"
-  php7.3-zip: "{{ apt_package_state }}"
+  php7.4-cli: "{{ apt_package_state }}"
+  php7.4-common: "{{ apt_package_state }}"
+  php7.4-curl: "{{ apt_package_state }}"
+  php7.4-dev: "{{ apt_package_state }}"
+  php7.4-fpm: "{{ apt_package_state }}"
+  php7.4-gd: "{{ apt_package_state }}"
+  php7.4-mbstring: "{{ apt_package_state }}"
+  php7.4-mysql: "{{ apt_package_state }}"
+  php7.4-opcache: "{{ apt_package_state }}"
+  php7.4-xml: "{{ apt_package_state }}"
+  php7.4-xmlrpc: "{{ apt_package_state }}"
+  php7.4-zip: "{{ apt_package_state }}"
 
 php_extensions_custom: {}
 php_extensions: "{{ php_extensions_default | combine(php_extensions_custom) }}"

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -1,21 +1,35 @@
 ---
-- name: Add PHP 7.3 PPA
+- name: Add PHP 7.4 PPA
   apt_repository:
     repo: "ppa:ondrej/php"
     update_cache: yes
 
-- name: Install PHP 7.3
+- name: Install PHP 7.4
   apt:
     name: "{{ item.key }}"
     state: "{{ item.value }}"
     cache_valid_time: "{{ apt_cache_valid_time }}"
   with_dict: "{{ php_extensions }}"
 
-- name: Start php7.3-fpm service
+- name: Start php7.4-fpm service
   service:
-    name: php7.3-fpm
+    name: php7.4-fpm
     state: started
     enabled: true
+
+- name: Check for existing php7.3-fpm service
+  stat:
+    path: /etc/init.d/php7.3-fpm
+  register: php73_status
+
+- name: Stop php7.3-fpm service if it exists
+  service:
+    name: php7.3-fpm
+    state: stopped
+    enabled: false
+  register: service_stopped
+  when: php73_status.stat.exists
+  notify: reload php-fpm
 
 - name: Check for existing php7.2-fpm service
   stat:
@@ -34,5 +48,5 @@
 - name: PHP configuration file
   template:
     src: php.ini.j2
-    dest: /etc/php/7.3/fpm/php.ini
+    dest: /etc/php/7.4/fpm/php.ini
   notify: reload php-fpm

--- a/roles/wordpress-setup/tasks/main.yml
+++ b/roles/wordpress-setup/tasks/main.yml
@@ -26,13 +26,13 @@
 - name: Create WordPress php-fpm configuration file
   template:
     src: php-fpm.conf.j2
-    dest: /etc/php/7.3/fpm/pool.d/wordpress.conf
+    dest: /etc/php/7.4/fpm/pool.d/wordpress.conf
   notify: reload php-fpm
 
 - name: Disable default PHP-FPM pool
-  command: mv /etc/php/7.3/fpm/pool.d/www.conf /etc/php/7.3/fpm/pool.d/www.disabled
+  command: mv /etc/php/7.4/fpm/pool.d/www.conf /etc/php/7.4/fpm/pool.d/www.disabled
   args:
-    creates: /etc/php/7.3/fpm/pool.d/www.disabled
+    creates: /etc/php/7.4/fpm/pool.d/www.disabled
   when: disable_default_pool | default(true)
   notify: reload php-fpm
 

--- a/roles/xdebug/tasks/main.yml
+++ b/roles/xdebug/tasks/main.yml
@@ -9,13 +9,13 @@
   - name: Template the Xdebug configuration file
     template:
       src: xdebug.ini.j2
-      dest: /etc/php/7.3/mods-available/xdebug.ini
+      dest: /etc/php/7.4/mods-available/xdebug.ini
     notify: reload php-fpm
 
   - name: Ensure 20-xdebug.ini is present
     file:
-      src: /etc/php/7.3/mods-available/xdebug.ini
-      dest: /etc/php/7.3/fpm/conf.d/20-xdebug.ini
+      src: /etc/php/7.4/mods-available/xdebug.ini
+      dest: /etc/php/7.4/fpm/conf.d/20-xdebug.ini
       state: link
     notify: reload php-fpm
 
@@ -23,12 +23,12 @@
 
 - name: Disable Xdebug
   file:
-    path: /etc/php/7.3/fpm/conf.d/20-xdebug.ini
+    path: /etc/php/7.4/fpm/conf.d/20-xdebug.ini
     state: absent
   when: not xdebug_remote_enable | bool
   notify: reload php-fpm
 
 - name: Disable Xdebug CLI
   file:
-    path: /etc/php/7.3/cli/conf.d/20-xdebug.ini
+    path: /etc/php/7.4/cli/conf.d/20-xdebug.ini
     state: absent

--- a/server.yml
+++ b/server.yml
@@ -16,7 +16,7 @@
   roles:
     - { role: python_interpreter, tags: [always] }
 
-- name: WordPress Server - Install LEMP Stack with PHP 7.3 and MariaDB MySQL
+- name: WordPress Server - Install LEMP Stack with PHP 7.4 and MariaDB MySQL
   hosts: web:&{{ env }}
   become: yes
   roles:

--- a/xdebug-tunnel.yml
+++ b/xdebug-tunnel.yml
@@ -15,5 +15,5 @@
   handlers:
     - name: reload php-fpm
       service:
-        name: php7.3-fpm
+        name: php7.4-fpm
         state: reloaded


### PR DESCRIPTION
fixes #1163

I left the PHP 7.2 service code in there, as well as adding new PHP 7.3 service code. I figure it doesn't hurt to keep it (it's just a few lines), and if anyone is upgrading from a 2018 version of Trellis to the PHP 7.4 version, it'll handle them leapfrogging PHP 7.3 completely.