### PR TITLE
Bump Ansible version_tested_max to 2.8.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### HEAD
+* Bump Ansible version_tested_max to 2.8.10 ([#1167](https://github.com/roots/trellis/pull/1167))
+
 ### 1.4.0: April 2nd, 2020
 * Update PHP to 7.4 ([#1164](https://github.com/roots/trellis/pull/1164))
 * Update `wp_cli_version` to 2.4.0 ([#1131](https://github.com/roots/trellis/pull/1131))

--- a/lib/trellis/plugins/vars/version.py
+++ b/lib/trellis/plugins/vars/version.py
@@ -15,7 +15,7 @@ except ImportError:
     display = Display()
 
 version_requirement = '2.7.12'
-version_tested_max = '2.8.4'
+version_tested_max = '2.8.10'
 python3_required_version = '2.5.3'
 
 if version_info[0] == 3 and not ge(LooseVersion(__version__), LooseVersion(python3_required_version)):


### PR DESCRIPTION
I've been using 2.8.7 for a long time without issue and I've just tested 2.8.10 as well. Also confirmed via the changelog that there shouldn't be anything that causes issues (nothing major/obvious at least).