### PR TITLE
Fix Callback plugin for Ansible 2.9

### DIFF
--- a/lib/trellis/plugins/callback/output.py
+++ b/lib/trellis/plugins/callback/output.py
@@ -5,6 +5,14 @@ __metaclass__ = type
 import os.path
 import sys
 
+DOCUMENTATION = '''
+    callback: output
+    type: stdout
+    short_description: Custom output for Trellis
+    extends_documentation_fragment:
+      - default_callback
+'''
+
 from ansible.plugins.callback.default import CallbackModule as CallbackModule_default
 
 try:


### PR DESCRIPTION
Fixes the error:

```plain
[WARNING]: Failure using method (v2_runner_on_start) in callback plugin (<ansible.plugins.callback.output.CallbackModule object at 0x107f97c18>): 'show_per_host_start'
```