### PR TITLE
Remove nginx_includes_deprecated feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* [BREAKING] Remove `nginx_includes_deprecated` feature ([#1173](https://github.com/roots/trellis/pull/1173))
 * Bump Ansible version_tested_max to 2.8.10 ([#1167](https://github.com/roots/trellis/pull/1167))
 
 ### 1.4.0: April 2nd, 2020

--- a/roles/wordpress-setup/defaults/main.yml
+++ b/roles/wordpress-setup/defaults/main.yml
@@ -34,8 +34,7 @@ nginx_cache_background_update: "on"
 
 # Nginx includes
 nginx_includes_templates_path: nginx-includes
-nginx_includes_deprecated: roles/wordpress-setup/templates/includes.d
-nginx_includes_pattern: "^({{ nginx_includes_templates_path | regex_escape }}|{{ nginx_includes_deprecated | regex_escape }})/(.*)\\.j2$"
+nginx_includes_pattern: "^({{ nginx_includes_templates_path | regex_escape }})/(.*)\\.j2$"
 nginx_includes_d_cleanup: true
 
 # h5bp helpers

--- a/roles/wordpress-setup/tasks/nginx-includes.yml
+++ b/roles/wordpress-setup/tasks/nginx-includes.yml
@@ -3,17 +3,11 @@
   find:
     paths:
       - "{{ nginx_includes_templates_path }}"
-      - "{{ nginx_includes_deprecated }}"
     pattern: "*.conf.j2"
     recurse: yes
   become: no
   delegate_to: localhost
   register: nginx_includes_templates
-
-- name: Warn about deprecated Nginx includes directory
-  debug:
-    msg: "[DEPRECATION WARNING]: The `{{ nginx_includes_deprecated }}` directory for Trellis Nginx includes templates is deprecated and will no longer function beginning with Trellis 1.0. Please move these templates to a directory named `{{ nginx_includes_templates_path }}` in the root of this project. For more information, see https://roots.io/trellis/docs/nginx-includes/"
-  when: True in nginx_includes_templates.files | map(attribute='path') | map('search', nginx_includes_deprecated | regex_escape) | list
 
 - name: Create includes.d directories
   file:


### PR DESCRIPTION
This has been deprecated for almost 4 years now. The proper solution is
documented at https://roots.io/docs/trellis/master/nginx-includes/.

Some docs to update as well: https://roots.io/docs/trellis/master/nginx-includes/#deprecated-templates-directory