### PR TITLE
Make Fail2ban settings extensible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Make Fail2ban settings extensible ([#1177](https://github.com/roots/trellis/pull/1177))
 * Support Ansible 2.9 ([#1169](https://github.com/roots/trellis/pull/1169))
 * [BREAKING] Remove `nginx_includes_deprecated` feature ([#1173](https://github.com/roots/trellis/pull/1173))
 * Bump Ansible version_tested_max to 2.8.10 ([#1167](https://github.com/roots/trellis/pull/1167))

--- a/roles/fail2ban/README.md
+++ b/roles/fail2ban/README.md
@@ -1,19 +1,17 @@
-## What is ansible-fail2ban?
+## What is this role?
 
-It is an [ansible](http://www.ansible.com/home) role to install and configure fail2ban.
+This role installs and configures [Fail2ban](https://github.com/fail2ban/fail2ban).
 
-### What problem does it solve and why is it useful?
-
-Security is important and fail2ban is an excellent tool to harden your server with minimal or even no configuration.
+Fail2ban is an excellent tool to harden your server with minimal configuration.
 
 ## Role variables
 
-Below is a list of default values along with a description of what they do.
+Below is a list of available variables, their description and their default value within Trellis.
 
-```
+```yaml
 # Which log level should it be output as?
-# Levels: CRITICAL, ERROR, WARNING, NOTICE, INFO, DEBUG. Default: ERROR
-fail2ban_loglevel: WARNING
+# Levels: CRITICAL, ERROR, WARNING, NOTICE, INFO, DEBUG.
+fail2ban_loglevel: INFO
 
 # Where should log outputs be sent to?
 # SYSLOG, STDERR, STDOUT, file
@@ -56,10 +54,25 @@ fail2ban_chain: INPUT
 # action_, action_mw, action_mwl
 fail2ban_action: action_
 
-# What services should fail2ban monitor?
-# You can define fail2ban_services as an empty string to not monitor anything.
+# Trellis by default only monitors SSH connections
+# For available parameters, see fail2ban_services_custom below.
+fail2ban_services_default:
+  - name: ssh
+    port: ssh
+    filter: sshd
+    logpath: /var/log/auth.log
+
+# In which folder did you place custom filters?
+# Filters MUST have .conf.j2 extension to copied to the servers.
+fail2ban_filter_templates_path: fail2ban_filters
+```
+
+The following list variable is available for custom services (to be set up in `group_vars`):
+
+```yaml
+# Which additional services should fail2ban monitor?
 # You can define multiple services as a standard yaml list.
-fail2ban_services:
+fail2ban_services_custom:
     # The name of the service
     # REQUIRED.
   - name: ssh
@@ -77,11 +90,11 @@ fail2ban_services:
     # OPTIONAL: Defaults to the protocol listed above.
     protocol: tcp
 
-    # What filter should it use?
+    # Which filter should it use?
     # REQUIRED.
     filter: sshd
 
-    # Which log path should it monitor?
+    # Which log file should it monitor?
     # REQUIRED.
     logpath: /var/log/auth.log
 
@@ -96,23 +109,28 @@ fail2ban_services:
     # How should the ban be applied?
     # OPTIONAL: Defaults to the banaction listed above.
     banaction: iptables-multiport
-```
-
-## Example playbook
-
-Let's say you want to edit a few values, you can do this by opening `group_vars/all` and then add the following:
 
 ```
-fail2ban_services:
-  - name: ssh
-    port: ssh
-    filter: sshd
+
+## Custom Settings
+
+To add services, you might add the following to `group_vars/all/security.yml`, e.g.:
+
+```yaml
+fail2ban_services_custom:
+  - name: wordpress
+    filter: wordpress
     logpath: /var/log/auth.log
-  - name: postfix
-    port: smtp,ssmtp
-    filter: postfix
-    logpath: /var/log/mail.log
+    maxretry: 2
 ```
+
+To add the corresponding filter, add it to the folder specified in `fail2ban_filter_templates_path`, i.e. `fail2ban_filters` per default (next to the `group_vars` folder). The filter configuration must be of `.conf.j2` extension for Trellis to recognize it.
+
+Filters might be provided by plugins as `.conf` files: it is then enough to simply append the file name with `.j2`. It is not required to modify these provided filters, but you may customize them to your liking.
+
+To develop custom filters, refer to the Fail2ban wiki: [How Fail2ban works](https://github.com/fail2ban/fail2ban/wiki/How-fail2ban-works) and [How to ban something…](https://github.com/fail2ban/fail2ban/wiki/How-to-ban-something-other-as-host-(IP-address),-like-user-or-mail,-etc.) for simple filter rules or [Developing Filters](https://fail2ban.readthedocs.io/en/latest/filters.html) for complex setups.
+
+If you need to edit the default services, copy the `fail2ban_services_default` list from `roles/fail2ban/defaults/main.yml` to `group_vars/all/security.yml` and edit as needed.
 
 ## Attribution
 

--- a/roles/fail2ban/defaults/main.yml
+++ b/roles/fail2ban/defaults/main.yml
@@ -19,8 +19,11 @@ fail2ban_chain: INPUT
 
 fail2ban_action: action_
 
-fail2ban_services:
+fail2ban_services_default:
   - name: ssh
     port: ssh
     filter: sshd
     logpath: /var/log/auth.log
+
+fail2ban_services_custom: []
+fail2ban_services: "{{ fail2ban_services_default + fail2ban_services_custom }}"

--- a/roles/fail2ban/defaults/main.yml
+++ b/roles/fail2ban/defaults/main.yml
@@ -27,3 +27,6 @@ fail2ban_services_default:
 
 fail2ban_services_custom: []
 fail2ban_services: "{{ fail2ban_services_default + fail2ban_services_custom }}"
+
+fail2ban_filter_templates_path: fail2ban_filters
+fail2ban_filter_templates_pattern: "^({{ fail2ban_filter_templates_path | regex_escape }})/(.*)\\.j2$"

--- a/roles/fail2ban/tasks/main.yml
+++ b/roles/fail2ban/tasks/main.yml
@@ -17,6 +17,28 @@
   notify:
     - restart fail2ban
 
+- name: build list of fail2ban filter templates
+  find:
+    paths:
+      - "{{ fail2ban_filter_templates_path }}"
+    pattern: "*.conf.j2"
+  become: no
+  delegate_to: localhost
+  register: fail2ban_filter_templates
+
+- name: ensure configuration directory exists
+  file:
+    path: /etc/fail2ban/filter.d/
+    state: directory
+    mode: 0755
+
+- name: template fail2ban filters
+  template:
+    src: "{{ item }}"
+    dest: "/etc/fail2ban/filter.d/{{ item | regex_replace(fail2ban_filter_templates_pattern, '\\2') }}"
+  with_items: "{{ fail2ban_filter_templates.files | map(attribute='path') | list | sort(True) }}"
+  notify: restart fail2ban
+
 - name: ensure fail2ban starts on a fresh reboot
   service:
     name: fail2ban


### PR DESCRIPTION
add the ability to add custom services in `group_vars/`;
add the ability to include custom filters in a new `fail2ban-filters/` folder;
inspired from the `nginx-includes` task in `wordpress-setup` role.

- [x] custom services
- [x] custom filters
- [x] readme
- [x] changelog
- [ ] docs