### PR TITLE
Improve ip_whitelist in development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### HEAD
 * Make Fail2ban settings extensible ([#1177](https://github.com/roots/trellis/pull/1177))
+* Improve ip_whitelist in development ([#1183](https://github.com/roots/trellis/pull/1183))
 * Support Ansible 2.9 ([#1169](https://github.com/roots/trellis/pull/1169))
 * [BREAKING] Remove `nginx_includes_deprecated` feature ([#1173](https://github.com/roots/trellis/pull/1173))
 * Bump Ansible version_tested_max to 2.8.10 ([#1167](https://github.com/roots/trellis/pull/1167))

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -9,7 +9,7 @@ ntp_timezone: Etc/UTC
 ntp_manage_config: true
 www_root: /srv/www
 ip_whitelist:
-  - "{{ (env == 'development') | ternary(ansible_default_ipv4.gateway, ipify_public_ip | default('')) }}"
+  - "{{ ipify_public_ip | default('') }}"
 
 # Values of raw_vars will be wrapped in `{% raw %}` to avoid templating problems if values include `{%` and `{{`.
 # Will recurse dicts/lists. `*` is wildcard for one or more dict keys, list indices, or strings. Example:

--- a/group_vars/development/main.yml
+++ b/group_vars/development/main.yml
@@ -1,5 +1,6 @@
 acme_tiny_challenges_directory: "{{ www_root }}/letsencrypt"
 env: development
 ferm_enabled: false
+ip_whitelist: "{{ ansible_all_ipv4_addresses }}"
 mysql_root_password: "{{ vault_mysql_root_password }}" # Define this variable in group_vars/development/vault.yml
 web_user: vagrant


### PR DESCRIPTION
Fixes #1181

`ansible_default_ipv4.gateway` wasn't a good default as it wasn't the actual Vagrant external IP (`192.168.50.5`).

`ansible_all_ipv4_addresses` is the replacement which includes that IP.

This also moves the development specific override to the proper development config.