### PR TITLE
Update CircleCI Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,94 +1,136 @@
 version: 2.1
 
 orbs:
-  trellis:
-    executors:
-      python-2:
-        docker:
-          - image: 'circleci/python:2-stretch'
-      python-3:
-        docker:
-          - image: 'circleci/python:3-stretch'
+  python: circleci/python@0.3
 
-    jobs:
-      syntax-check:
-        parameters:
-          ansible-version:
-            type: string
-          python-version:
-            type: enum
-            enum: ['3', '2']
-        executor: python-<< parameters.python-version >>
-        steps:
-          - run: python --version
-          - checkout
-          - restore_cache:
-              keys:
-                - ansible-v1-<< parameters.python-version >>-<< parameters.ansible-version >>-{{ checksum "galaxy.yml" }}
-          - run:
-              name: Install Python dependencies in a venv
-              command: |
-                virtualenv venv
-                . venv/bin/activate
-                pip install ansible<< parameters.ansible-version >>
-                ansible --version
-          - run:
-              name: Install Galaxy roles
-              command: |
-                . venv/bin/activate
-                ansible-galaxy install -r galaxy.yml
-          - save_cache:
-              key: ansible-v1-<< parameters.python-version >>-<< parameters.ansible-version >>-{{ checksum "galaxy.yml" }}
-              paths:
-                - venv
-                - vendor
-          - run:
-              name: Check Playbook syntax
-              command: |
-                . venv/bin/activate
-                ansible-playbook --syntax-check -e env=development deploy.yml
-                ansible-playbook --syntax-check -e env=development dev.yml
-                ansible-playbook --syntax-check -e env=development server.yml
-                ansible-playbook --syntax-check -e env=development rollback.yml
-                ansible-playbook --syntax-check -e xdebug_tunnel_inventory_host=1 xdebug-tunnel.yml
+commands:
+  install-pip-package:
+    parameters:
+      package:
+        type: string
+      python-version:
+        type: string
+    steps:
+      - restore_cache:
+            name: Restore pip Cache
+            keys:
+              - pip-v2-<<parameters.python-version>>-<<parameters.package>>-
+      - run:
+          name: Install pip Package
+          command: pip install --user --upgrade <<parameters.package>>
+      - save_cache:
+          name: Save pip Cache
+          key: pip-v2-<<parameters.python-version>>-<<parameters.package>>-{{ epoch }}
+          paths:
+            - /home/circleci/.local/bin/
+            - /home/circleci/.local/lib/
+            - /home/circleci/.cache/pip/
+  install-galaxy-roles:
+    steps:
+      - restore_cache:
+            name: Restore Galaxy Role Cache
+            keys:
+              - galaxy-role-v2-{{ checksum "galaxy.yml" }}
+      - run:
+          name: Install Galaxy Roles
+          command: ansible-galaxy install -r galaxy.yml
+      - save_cache:
+          name: Save Galaxy Role Cache
+          key: galaxy-role-v2-{{ checksum "galaxy.yml" }}
+          paths:
+            - vendor/
+  check-playbook-syntax:
+    steps:
+      - run:
+          name: Check Playbook Syntax
+          command: |
+            ansible-playbook --syntax-check -e env=development deploy.yml
+            ansible-playbook --syntax-check -e env=development dev.yml
+            ansible-playbook --syntax-check -e env=development server.yml
+            ansible-playbook --syntax-check -e env=development rollback.yml
+            ansible-playbook --syntax-check -e xdebug_tunnel_inventory_host=1 xdebug-tunnel.yml
 
-      lint:
-        executor: python-3
-        steps:
-          - run: python --version
-          - checkout
-          - run: sudo pip install ansible-lint
-          - run: ansible-lint --version
-          - run: ansible-lint deploy.yml dev.yml server.yml rollback.yml xdebug-tunnel.yml
+jobs:
+  syntax-check:
+    parameters:
+      ansible-version:
+        type: string
+      python-version:
+        type: string
+    executor:
+      name: python/default
+      tag: <<parameters.python-version>>
+    steps:
+      - run: python --version
+      - checkout
+      - install-pip-package:
+          package: ansible<< parameters.ansible-version >>
+          python-version: <<parameters.python-version>>
+      - run: ansible --version
+      - install-galaxy-roles
+      - check-playbook-syntax
+
+  syntax-check-with-requirements-txt:
+    parameters:
+      python-version:
+        type: string
+    executor:
+      name: python/default
+      tag: <<parameters.python-version>>
+    steps:
+      - run: python --version
+      - checkout
+      - restore_cache:
+            name: Restore pip Cache
+            keys:
+              - pip-v2-<<parameters.python-version>>-{{ checksum "requirements.txt" }}-
+      - run:
+          name: Install packages from requirements.txt (or any other file) via Pip.
+          command: pip install --user --upgrade --requirement requirements.txt
+      - save_cache:
+          name: Save pip Cache
+          key: pip-v2-<<parameters.python-version>>-{{ checksum "requirements.txt" }}-{{ epoch }}
+          paths:
+            - /home/circleci/.local/bin/
+            - /home/circleci/.local/lib/
+            - /home/circleci/.cache/pip
+      - run: ansible --version
+      - install-galaxy-roles
+      - check-playbook-syntax
+
+  lint:
+    parameters:
+      python-version:
+        type: string
+    executor:
+      name: python/default
+      tag: <<parameters.python-version>>
+    steps:
+      - run: python --version
+      - checkout
+      - install-pip-package:
+          package: ansible-lint
+          python-version: <<parameters.python-version>>
+      - run: ansible-lint --version
+      - run: ansible-lint deploy.yml dev.yml server.yml rollback.yml xdebug-tunnel.yml
 
 workflows:
   syntax-check:
     jobs:
-      - trellis/syntax-check:
-          name: syntax-check-python-3-ansible-latest
-          python-version: '3'
-          ansible-version: ''
-      - trellis/syntax-check:
-          name: syntax-check-python-3-ansible-2.9
-          python-version: '3'
-          ansible-version: ~=2.9.0
-      - trellis/syntax-check:
-          name: syntax-check-python-3-ansible-2.8
-          python-version: '3'
-          ansible-version: ~=2.8.0
+      - syntax-check:
+          name: syntax-check-python-<<matrix.python-version>>-ansible<<matrix.ansible-version>>
+          matrix:
+            parameters:
+              python-version: ["3.7", "2.7"]
+              ansible-version: ["~=2.9.0", "~=2.8.0"]
+      - syntax-check-with-requirements-txt:
+          name: syntax-check-python-<<matrix.python-version>>-requirements-txt
+          matrix:
+            parameters:
+              python-version: ["3.7", "2.7"]
 
-      - trellis/syntax-check:
-          name: syntax-check-python-2-ansible-latest
-          python-version: '2'
-          ansible-version: ''
-      - trellis/syntax-check:
-          name: syntax-check-python-2-ansible-2.9
-          python-version: '2'
-          ansible-version: ~=2.9.0
-      - trellis/syntax-check:
-          name: syntax-check-python-2-ansible-2.8
-          python-version: '2'
-          ansible-version: ~=2.8.0
   lint:
     jobs:
-      - trellis/lint
+      - lint:
+          name: lint-python-3.7
+          python-version: "3.7"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [BREAKING] Remove `nginx_includes_deprecated` feature ([#1173](https://github.com/roots/trellis/pull/1173))
 * Bump Ansible version_tested_max to 2.8.10 ([#1167](https://github.com/roots/trellis/pull/1167))
 * Bump Ansible requirement to 2.8.0 ([#1147](https://github.com/roots/trellis/pull/1147))
+* Update CircleCI Config ([#1184](https://github.com/roots/trellis/pull/1184))
 
 ### 1.4.0: April 2nd, 2020
 * Update PHP to 7.4 ([#1164](https://github.com/roots/trellis/pull/1164))


### PR DESCRIPTION
- use offical CircleCI [next-gen docker images](https://circleci.com/docs/2.0/circleci-images/#next-generation-convenience-images)
- use [`matrix`](https://circleci.com/docs/2.0/configuration-reference/#matrix-requires-version-21)
- add tests for ansible version defined in requirements.txt (`pip install -r requirements-txt`)
- remove tests for latest ansible version (`pip install anisble`) in favour of `requirements-txt`
- fix pip not upgrading to packages' latest versions when older versions are cached
- add caching to the lint job