### PR TITLE
Update `oefenweb.swapfile` from Ansible Galaxy

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -12,7 +12,7 @@
 
 - name: swapfile
   src: oefenweb.swapfile
-  version: v2.0.22
+  version: v2.0.26
 
 - name: mailhog
   src: geerlingguy.mailhog


### PR DESCRIPTION
Update Ansible Galaxy dependency. 
No issues detected on my servers.