### PR TITLE
Update `geerlingguy.mailhog` from Ansible Galaxy

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -16,4 +16,4 @@
 
 - name: mailhog
   src: geerlingguy.mailhog
-  version: 2.1.4
+  version: 2.2.0


### PR DESCRIPTION
Update Ansible Galaxy dependency.
No issues detected on my servers.

All other Ansible Galaxy dependencies are up to date.