### PR TITLE
Silence Ansible warning

### DIFF
--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -59,6 +59,7 @@
       user: ""
       host: "{{ item }}"
       state: absent
+    no_log: true
     with_items:
       - localhost
       - "{{ inventory_hostname }}"


### PR DESCRIPTION
```
TASK [mariadb : Delete anonymous MySQL server users] **************************************************************************************************************************************
ok: [staging_host] => (item=localhost)
ok: [staging_host] => (item=staging_host)
ok: [staging_host] => (item=******)
[WARNING]: Module did not set no_log for update_password
```

