### PR TITLE
Fix #888 & #1189 to comply with RFC2606

### DIFF
--- a/roles/wordpress-setup/defaults/main.yml
+++ b/roles/wordpress-setup/defaults/main.yml
@@ -5,7 +5,7 @@ nginx_ssl_path: "{{ nginx_path }}/ssl"
 ssl_default_site:
   no_default:
     site_hosts:
-      - canonical: example.com
+      - canonical: request.is.invalid
     ssl:
       enabled: true
       provider: self-signed


### PR DESCRIPTION
Fix #888 & #1189 to comply with [RFC2606](https://tools.ietf.org/html/rfc2606#section-2), which specifies that:

>       ".invalid" is intended for use in online construction of domain
>       names that are sure to be invalid and which it is obvious at a
>       glance are invalid.

See discussion in #1189.