### PR TITLE
Allow force generate self signed certificates

### DIFF
--- a/roles/wordpress-setup/tasks/self-signed-certificate.yml
+++ b/roles/wordpress-setup/tasks/self-signed-certificate.yml
@@ -43,7 +43,7 @@
     - ssl_enabled
     - item.value.ssl.provider | default('manual') == 'self-signed'
   notify: reload nginx
-  tags: [never, force-generate-self-signed-certificates]
+  tags: never
 
 - name: Clean up openssl configs directory
   file:

--- a/roles/wordpress-setup/tasks/self-signed-certificate.yml
+++ b/roles/wordpress-setup/tasks/self-signed-certificate.yml
@@ -30,6 +30,21 @@
     - item.value.ssl.provider | default('manual') == 'self-signed'
   notify: reload nginx
 
+- name: Force generate self-signed certificates
+  command: "openssl req -new -newkey rsa:2048 \
+    -days 825 -nodes -x509 -sha256 \
+    -extensions req_ext -config {{ nginx_ssl_path }}/self-signed-openssl-configs/{{ item.key }}.cnf \
+    -keyout {{ item.key | quote }}.key -out {{ item.key | quote }}.cert"
+  args:
+    chdir: "{{ nginx_ssl_path }}"
+  with_dict: "{{ wordpress_sites | combine(ssl_default_site) }}"
+  when:
+    - sites_use_ssl
+    - ssl_enabled
+    - item.value.ssl.provider | default('manual') == 'self-signed'
+  notify: reload nginx
+  tags: [never, force-generate-self-signed-certificates]
+
 - name: Clean up openssl configs directory
   file:
     path: "{{ nginx_ssl_path }}/self-signed-openssl-configs/"


### PR DESCRIPTION
Complements #1189 and makes possible to use #1191 without reinstalling the server or manual intervention.

**Warning**

Ansible tag `never` does not work as the docs let understand

[Tag inheritance](https://docs.ansible.com/ansible/latest/user_guide/playbooks_tags.html#tag-inheritance) in fact overwrites [special tags](
https://docs.ansible.com/ansible/latest/user_guide/playbooks_tags.html#special-tags). Wording of Ansible docs is erroneous: "never" means "not always" and "only" means "also when" (i.e. `AND===OR`), and "all" means "not never" (i.e. `OR===AND`). "It's not a bug, it's a feature": https://github.com/ansible/ansible/issues/40400.

There seems to be no way not to avoid [tag inheritance](https://docs.ansible.com/ansible/latest/user_guide/playbooks_tags.html#tag-inheritance), not even with dynamic includes, except for
- not using tag inheritance and specifying tags manually on each role (bad);
- making this single task an independent role (worse).

Thus, this task is skipped, including when using `--tags all`, except when specifying `--tags never`, (in which case it returns with an error), `--tags wordpress`, `--tags wordpress-setup` or `--tags wordpress-setup-self-signed-certificate`.
Not ideal.

How do we proceed?