### PR TITLE
Silence Ansible warning

### DIFF
--- a/roles/wordpress-setup/tasks/database.yml
+++ b/roles/wordpress-setup/tasks/database.yml
@@ -20,6 +20,7 @@
       login_host: "{{ site_env.db_host }}"
       login_user: "{{ mysql_root_user }}"
       login_password: "{{ mysql_root_password }}"
+    no_log: true
     with_dict: "{{ wordpress_sites }}"
 
   when: site_uses_local_db and item.value.db_create | default(true)


### PR DESCRIPTION
```
TASK [wordpress-setup : Create/assign database user to db and grant permissions] *********
ok: [development_host] => (item=******)
[WARNING]: Module did not set no_log for update_password
```