### PR TITLE
Fix Ansible deprecation warnings

### DIFF
--- a/roles/ferm/handlers/main.yml
+++ b/roles/ferm/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: restart ferm
   service: name=ferm state=restarted
-  when: ferm_enabled
+  when: ferm_enabled | bool

--- a/roles/ferm/tasks/main.yml
+++ b/roles/ferm/tasks/main.yml
@@ -65,7 +65,7 @@
 - name: ensure iptables rules are enabled
   command: ferm --slow /etc/ferm/ferm.conf
   changed_when: false
-  when: ferm_enabled
+  when: ferm_enabled | bool
 
 - name: ensure iptables rules are disabled
   command: ferm --flush /etc/ferm/ferm.conf

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -29,7 +29,7 @@
       dest: /etc/mysql/conf.d
       owner: root
       group: root
-    when: mysql_binary_logging_disabled
+    when: mysql_binary_logging_disabled | bool
     notify: restart mysql server
 
   - name: Set root user password

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -21,7 +21,7 @@
   args:
     chdir: "{{ nginx_path }}/ssl"
     creates: "{{ nginx_path }}/ssl/dhparams.pem"
-  when: sites_use_ssl
+  when: sites_use_ssl | bool
   notify: reload nginx
   tags: [diffie-hellman, letsencrypt, wordpress, wordpress-setup, nginx-includes, nginx-sites]
 

--- a/roles/wordpress-setup/tasks/nginx-includes.yml
+++ b/roles/wordpress-setup/tasks/nginx-includes.yml
@@ -33,7 +33,7 @@
     pattern: "*.conf"
     recurse: yes
   register: nginx_includes_existing
-  when: nginx_includes_d_cleanup
+  when: nginx_includes_d_cleanup | bool
 
 - name: Remove unmanaged files from includes.d
   file:

--- a/roles/wordpress-setup/tasks/self-signed-certificate.yml
+++ b/roles/wordpress-setup/tasks/self-signed-certificate.yml
@@ -11,8 +11,8 @@
     dest: "{{ nginx_ssl_path }}/self-signed-openssl-configs/{{ item.key }}.cnf"
   with_dict: "{{ wordpress_sites | combine(ssl_default_site) }}"
   when:
-    - sites_use_ssl
-    - ssl_enabled
+    - sites_use_ssl | bool
+    - ssl_enabled | bool
     - item.value.ssl.provider | default('manual') == 'self-signed'
 
 - name: Generate self-signed certificates
@@ -25,8 +25,8 @@
     creates: "{{ item.key }}.*"
   with_dict: "{{ wordpress_sites | combine(ssl_default_site) }}"
   when:
-    - sites_use_ssl
-    - ssl_enabled
+    - sites_use_ssl | bool
+    - ssl_enabled | bool
     - item.value.ssl.provider | default('manual') == 'self-signed'
   notify: reload nginx
 


### PR DESCRIPTION
`[DEPRECATION WARNING]: evaluating `[…]` as a bare variable, this behaviour will go away and you might need to add |bool to the expression in the future.`