### PR TITLE
Ansible deprecation warning

### DIFF
--- a/lib/trellis/plugins/vars/version.py
+++ b/lib/trellis/plugins/vars/version.py
@@ -15,7 +15,7 @@ except ImportError:
     display = Display()
 
 version_requirement = '2.8.0'
-version_tested_max = '2.9.6'
+version_tested_max = '2.9.9'
 python3_required_version = '2.5.3'
 
 if version_info[0] == 3 and not ge(LooseVersion(__version__), LooseVersion(python3_required_version)):

--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -10,6 +10,6 @@
     user: root
     job: cd {{ acme_tiny_data_directory }} && ./renew-certs.py && /usr/sbin/service nginx reload
     day: "{{ letsencrypt_cronjob_daysofmonth }}"
-    hour: 4
-    minute: 30
+    hour: "4"
+    minute: "30"
     state: present

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -47,7 +47,7 @@
     owner: root
     group: root
     validate: "/usr/sbin/visudo -cf %s"
-  when: web_sudoers
+  when: web_sudoers | bool
 
 - name: Add SSH keys
   authorized_key:


### PR DESCRIPTION
(Nearly) no more warnings with Ansible 2.9.9 during a fresh server setup & deploy. 🥳 

Except for a warning concerning Python 3.