### PR TITLE
Ubuntu 20.04 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Officially support Ubuntu 20.04 (and default Vagrant to it) ([#1197](https://github.com/roots/trellis/pull/1197))
 
 ### 1.6.0: November 5th, 2020
 * Remove prestissimo for Composer 2.0 support ([#1247](https://github.com/roots/trellis/pull/1247))

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -67,7 +67,9 @@
 - name: Validate Ubuntu version
   debug:
     msg: |
-      Trellis is built for Ubuntu 18.04 Bionic as of https://github.com/roots/trellis/pull/992
+      Ubuntu 18.04 Bionic is the minimum supported version of Ubuntu in Trellis 1.0+ (as of https://github.com/roots/trellis/pull/992)
+
+      20.04 Focal is the recommend version for Trellis 1.7+ (as of https://github.com/roots/trellis/pull/1197)
 
       Your Ubuntu version is {{ ansible_distribution_version }} {{ ansible_distribution_release }}
 
@@ -77,8 +79,8 @@
 
       Development via Vagrant: `vagrant destroy && vagrant up`
 
-      Staging/Production: Create a new server with Ubuntu 18.04 and provision
-  when: ansible_distribution_release != 'bionic'
+      Staging/Production: Create a new server with Ubuntu 20.04 and provision
+  when: ansible_distribution_version is version('18.04', '<')
 
 - name: Check whether passlib is needed
   fail:

--- a/vagrant.default.yml
+++ b/vagrant.default.yml
@@ -2,7 +2,7 @@
 vagrant_ip: '192.168.50.5'
 vagrant_cpus: 1
 vagrant_memory: 1024 # in MB
-vagrant_box: 'bento/ubuntu-18.04'
+vagrant_box: 'bento/ubuntu-20.04'
 vagrant_box_version: '>= 201807.12.0'
 vagrant_ansible_version: '2.8.0'
 vagrant_skip_galaxy: false


### PR DESCRIPTION
The good news is that Trellis didn't require many updates to support Ubuntu 20.04 (Focal). The main work was getting compatible releases of MariaDB and Nginx which was done in https://github.com/roots/trellis/pull/1212 and https://github.com/roots/trellis/pull/1208.

This PR itself just defaults the Vagrant image to 20.04 and updates our warning for supported Ubuntu versions.

Note: if you want to continue to use 18.04 locally with Vagrant, you can override the `vagrant_box` and `vagrant_box_version` options in your `vagrant.local.yml` config file.