### PR TITLE
Fix `| bool` test for lists

### DIFF
--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -47,7 +47,7 @@
     owner: root
     group: root
     validate: "/usr/sbin/visudo -cf %s"
-  when: web_sudoers | bool
+  when: web_sudoers[0] is defined
 
 - name: Add SSH keys
   authorized_key:


### PR DESCRIPTION
Regarding #1199 but there may be other places where a `list` type got a `| bool` added that needs fixing.

I guess this is the way to do it. Not an Ansible expert though. Could also add another check if the item is actually not empty and a string or something but ...