### PR TITLE
Refactor: Move creation and copying of .env-file to seperate file

### DIFF
--- a/roles/wordpress-install/tasks/dotenv.yml
+++ b/roles/wordpress-install/tasks/dotenv.yml
@@ -1,0 +1,16 @@
+---
+- name: Create .env file
+  template:
+    src: "env.j2"
+    dest: "/tmp/{{ item.key }}.env"
+    owner: "{{ web_user }}"
+    group: "{{ web_group }}"
+  with_dict: "{{ wordpress_sites }}"
+
+- name: Copy .env file into web root
+  synchronize:
+    src: "/tmp/{{ item.key }}.env"
+    dest: "{{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/.env"
+    checksum: true
+  with_dict: "{{ wordpress_sites }}"
+  delegate_to: "{{ inventory_hostname }}"

--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -2,21 +2,8 @@
 - import_tasks: directories.yml
   tags: wordpress-install-directories
 
-- name: Create .env file
-  template:
-    src: "env.j2"
-    dest: "/tmp/{{ item.key }}.env"
-    owner: "{{ web_user }}"
-    group: "{{ web_group }}"
-  with_dict: "{{ wordpress_sites }}"
-
-- name: Copy .env file into web root
-  synchronize:
-    src: "/tmp/{{ item.key }}.env"
-    dest: "{{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/.env"
-    checksum: true
-  with_dict: "{{ wordpress_sites }}"
-  delegate_to: "{{ inventory_hostname }}"
+- import_tasks: dotenv.yml
+  tags: dotenv
 
 - name: Add known_hosts
   known_hosts:


### PR DESCRIPTION
I use multiple instances of trellis (for different servers and with different teams) on the same codebase (wordpress).
Every time I boot a local VM with a different url ( a.test -> b.test ) I need to change the .env-file (in the root of the codebase).

With the "change" in this request I can just execute the needed dotenv-tasks (without a trellis-cli dependency) like:

```yml
- name: "Env"
  hosts: web:&development
  become: yes
  remote_user: vagrant

  tasks:
  - import_role:
      name: wordpress-install
      tasks_from: dotenv
```