### PR TITLE
Check hooked deploy scripts exist before including

### DIFF
--- a/roles/deploy/tasks/build.yml
+++ b/roles/deploy/tasks/build.yml
@@ -1,8 +1,14 @@
 ---
-- include_tasks: "{{ include_path }}"
+- name: Check if deploy_build_before scripts exist
+  local_action: stat path="{{ item }}"
+  register: deploy_build_before_paths
   with_items: "{{ deploy_build_before | default([]) }}"
+
+- include_tasks: "{{ include_path.item }}"
+  with_items: "{{ deploy_build_before_paths.results }}"
   loop_control:
     loop_var: include_path
+  when: include_path.stat.exists
   tags: deploy-build-before
 
 - name: Copy project templates
@@ -23,8 +29,14 @@
   with_items: "{{ project_folder_paths.results }}"
   when: item.stat.exists
 
-- include_tasks: "{{ include_path }}"
+- name: Check if deploy_build_after scripts exist
+  local_action: stat path="{{ item }}"
+  register: deploy_build_after_paths
   with_items: "{{ deploy_build_after | default([]) }}"
+
+- include_tasks: "{{ include_path.item }}"
+  with_items: "{{ deploy_build_after_paths.results }}"
   loop_control:
     loop_var: include_path
+  when: include_path.stat.exists
   tags: deploy-build-after

--- a/roles/deploy/tasks/finalize.yml
+++ b/roles/deploy/tasks/finalize.yml
@@ -1,8 +1,14 @@
 ---
-- include_tasks: "{{ include_path }}"
+- name: Check if deploy_finalize_before scripts exist
+  local_action: stat path="{{ item }}"
+  register: deploy_finalize_before_paths
   with_items: "{{ deploy_finalize_before | default([]) }}"
+
+- include_tasks: "{{ include_path.item }}"
+  with_items: "{{ deploy_finalize_before_paths.results }}"
   loop_control:
     loop_var: include_path
+  when: include_path.stat.exists
   tags: deploy-finalize-before
 
 - name: Finalize the deploy
@@ -13,10 +19,16 @@
     state: finalize
     keep_releases: "{{ project.deploy_keep_releases | default(deploy_keep_releases | default(omit)) }}"
 
-- include_tasks: "{{ include_path }}"
+- name: Check if deploy_finalize_after scripts exist
+  local_action: stat path="{{ item }}"
+  register: deploy_finalize_after_paths
   with_items: "{{ deploy_finalize_after | default([]) }}"
+
+- include_tasks: "{{ include_path.item }}"
+  with_items: "{{ deploy_finalize_after_paths.results }}"
   loop_control:
     loop_var: include_path
+  when: include_path.stat.exists
   tags: deploy-finalize-after
 
 - debug:

--- a/roles/deploy/tasks/initialize.yml
+++ b/roles/deploy/tasks/initialize.yml
@@ -1,8 +1,14 @@
 ---
-- include_tasks: "{{ include_path }}"
+- name: Check if deploy_initialize_before scripts exist
+  local_action: stat path="{{ item }}"
+  register: deploy_initialize_before_paths
   with_items: "{{ deploy_initialize_before | default([]) }}"
+
+- include_tasks: "{{ include_path.item }}"
+  with_items: "{{ deploy_initialize_before_paths.results }}"
   loop_control:
     loop_var: include_path
+  when: include_path.stat.exists
   tags: deploy-initialize-before
 
 - name: Initialize
@@ -11,8 +17,14 @@
     path: "{{ project_root }}"
     state: present
 
-- include_tasks: "{{ include_path }}"
+- name: Check if deploy_initialize_after scripts exist
+  local_action: stat path="{{ item }}"
+  register: deploy_initialize_after_paths
   with_items: "{{ deploy_initialize_after | default([]) }}"
+
+- include_tasks: "{{ include_path.item }}"
+  with_items: "{{ deploy_initialize_after_paths.results }}"
   loop_control:
     loop_var: include_path
+  when: include_path.stat.exists
   tags: deploy-initialize-after

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -1,8 +1,14 @@
 ---
-- include_tasks: "{{ include_path }}"
+- name: Check if deploy_before scripts exist
+  local_action: stat path="{{ item }}"
+  register: deploy_before_paths
   with_items: "{{ deploy_before | default([]) }}"
+
+- include_tasks: "{{ include_path.item }}"
+  with_items: "{{ deploy_before_paths.results }}"
   loop_control:
     loop_var: include_path
+  when: include_path.stat.exists
   tags: deploy-before
 
 - import_tasks: initialize.yml
@@ -12,8 +18,14 @@
 - import_tasks: share.yml
 - import_tasks: finalize.yml
 
-- include_tasks: "{{ include_path }}"
+- name: Check if deploy_after scripts exist
+  local_action: stat path="{{ item }}"
+  register: deploy_after_paths
   with_items: "{{ deploy_after | default([]) }}"
+
+- include_tasks: "{{ include_path.item }}"
+  with_items: "{{ deploy_after_paths.results }}"
   loop_control:
     loop_var: include_path
+  when: include_path.stat.exists
   tags: deploy-after

--- a/roles/deploy/tasks/prepare.yml
+++ b/roles/deploy/tasks/prepare.yml
@@ -1,8 +1,14 @@
 ---
-- include_tasks: "{{ include_path }}"
+- name: Check if deploy_prepare_before scripts exist
+  local_action: stat path="{{ item }}"
+  register: deploy_prepare_before_paths
   with_items: "{{ deploy_prepare_before | default([]) }}"
+
+- include_tasks: "{{ include_path.item }}"
+  with_items: "{{ deploy_prepare_before_paths.results }}"
   loop_control:
     loop_var: include_path
+  when: include_path.stat.exists
   tags: deploy-prepare-before
 
 - name: Check for project repo subtree
@@ -44,8 +50,14 @@
     path: "{{ deploy_helper.new_release_path }}/{{ deploy_helper.unfinished_filename }}"
     state: touch
 
-- include_tasks: "{{ include_path }}"
+- name: Check if deploy_prepare_after scripts exist
+  local_action: stat path="{{ item }}"
+  register: deploy_prepare_after_paths
   with_items: "{{ deploy_prepare_after | default([]) }}"
+
+- include_tasks: "{{ include_path.item }}"
+  with_items: "{{ deploy_prepare_after_paths.results }}"
   loop_control:
     loop_var: include_path
+  when: include_path.stat.exists
   tags: deploy-prepare-after

--- a/roles/deploy/tasks/share.yml
+++ b/roles/deploy/tasks/share.yml
@@ -1,8 +1,14 @@
 ---
-- include_tasks: "{{ include_path }}"
+- name: Check if deploy_share_before scripts exist
+  local_action: stat path="{{ item }}"
+  register: deploy_share_before_paths
   with_items: "{{ deploy_share_before | default([]) }}"
+
+- include_tasks: "{{ include_path.item }}"
+  with_items: "{{ deploy_share_before_paths.results }}"
   loop_control:
     loop_var: include_path
+  when: include_path.stat.exists
   tags: deploy-share-before
 
 - name: Ensure shared sources are present -- directories
@@ -48,8 +54,14 @@
     state: link
   with_items: "{{ project.project_shared_children | default(project_shared_children) }}"
 
-- include_tasks: "{{ include_path }}"
+- name: Check if deploy_share_after scripts exist
+  local_action: stat path="{{ item }}"
+  register: deploy_share_after_paths
   with_items: "{{ deploy_share_after | default([]) }}"
+
+- include_tasks: "{{ include_path.item }}"
+  with_items: "{{ deploy_share_after_paths.results }}"
   loop_control:
     loop_var: include_path
+  when: include_path.stat.exists
   tags: deploy-share-after

--- a/roles/deploy/tasks/update.yml
+++ b/roles/deploy/tasks/update.yml
@@ -1,8 +1,14 @@
 ---
-- include_tasks: "{{ include_path }}"
+- name: Check if deploy_update_before scripts exist
+  local_action: stat path="{{ item }}"
+  register: deploy_update_before_paths
   with_items: "{{ deploy_update_before | default([]) }}"
+
+- include_tasks: "{{ include_path.item }}"
+  with_items: "{{ deploy_update_before_paths.results }}"
   loop_control:
     loop_var: include_path
+  when: include_path.stat.exists
   tags: deploy-update-before
 
 - name: Add known_hosts
@@ -40,8 +46,14 @@
   register: git_clean
   changed_when: not not(git_clean.stdout)
 
-- include_tasks: "{{ include_path }}"
+- name: Check if deploy_update_after scripts exist
+  local_action: stat path="{{ item }}"
+  register: deploy_update_after_paths
   with_items: "{{ deploy_update_after | default([]) }}"
+
+- include_tasks: "{{ include_path.item }}"
+  with_items: "{{ deploy_update_after_paths.results }}"
   loop_control:
     loop_var: include_path
+  when: include_path.stat.exists
   tags: deploy-update-after


### PR DESCRIPTION
Making use of the suggested method to [include deploy scripts per site](https://github.com/roots/trellis/blob/master/roles/deploy/defaults/main.yml#L69) requires you to have a script set up for every site:
```
deploy_build_after:
  - "{{ playbook_dir }}/roles/deploy/hooks/build-after.yml"
  # - "{{ playbook_dir }}/deploy-hooks/sites/{{ site }}-build-after.yml" <-- this line
```
If you set up a deploy hook for domain1.com (e.g. `domain1.com-build-after.yml`), you won't be able to deploy to domain2.com, unless you also create `domain2.com-build-after.yml`. 

This PR checks if the file exists before trying to include it, so that if you only need one site to have additional tasks run, you don't need to create unnecessary files. 

For now, it only covers:
- `deploy_build_before`
- `deploy_build_after`

I wanted to run this by you first before going and updating the rest of them: I'm very happy to do it, but thought it's worth checking if a) this is wanted and b) if there's a better way, first. 