### PR TITLE
Ansible `file` module expects a string for `mode`

### DIFF
--- a/roles/fail2ban/tasks/main.yml
+++ b/roles/fail2ban/tasks/main.yml
@@ -30,7 +30,7 @@
   file:
     path: /etc/fail2ban/filter.d/
     state: directory
-    mode: 0755
+    mode: '0755'
 
 - name: template fail2ban filters
   template:


### PR DESCRIPTION
https://docs.ansible.com/ansible/latest/modules/file_module.html#parameter-mode
Comments say that octal numbers are tolerated, but parameter asks for string only, and so do linters…
