### PR TITLE
Support branch variable for deploys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Support branch variable for deploys ([#1204](https://github.com/roots/trellis/pull/1204))
 * Removes ID from Lets Encrypt bundled certificate and make filename stable ([#834](https://github.com/roots/trellis/pull/834))
 * Make Fail2ban settings extensible ([#1177](https://github.com/roots/trellis/pull/1177))
 * Improve ip_whitelist in development ([#1183](https://github.com/roots/trellis/pull/1183))

--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -2,7 +2,7 @@
 # - you must set a repository (no default)
 project_git_repo: "{{ project.repo }}"
 # - you can set the git ref to deploy (can be a branch, tag or commit hash)
-project_version: "{{ project.branch | default('master') }}"
+project_version: "{{ branch is defined | ternary(branch, project.branch) | default('master') }}"
 
 # The source_path is used to fetch the tags from git, or synchronise via rsync. This way
 # you do not have to download/sync the entire project on every deploy


### PR DESCRIPTION
This allows the branch to be specified via a command line argument to `ansible-playbook` (and eventually trellis-cli). Often this makes sense for staging environments where feature branches are deployed instead of a fixed one.

Ref: https://github.com/roots/trellis-cli/issues/125 and https://discourse.roots.io/t/any-way-to-specify-branch-as-command-line-deploy-argument-to-override-default-branch-setting-in-wordpress-sites-yml/11937.