### PR TITLE
Add support for Lets Encrypt contact emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Add support for Lets Encrypt contact emails ([#1206](https://github.com/roots/trellis/pull/1206))
 * Support branch variable for deploys ([#1204](https://github.com/roots/trellis/pull/1204))
 * Removes ID from Lets Encrypt bundled certificate and make filename stable ([#834](https://github.com/roots/trellis/pull/834))
 * Make Fail2ban settings extensible ([#1177](https://github.com/roots/trellis/pull/1177))

--- a/roles/letsencrypt/tasks/setup.yml
+++ b/roles/letsencrypt/tasks/setup.yml
@@ -1,4 +1,26 @@
 ---
+- name: Fail if letsencrypt_contact_emails is not defined
+  fail:
+    msg: >
+      Error: the required `letsencrypt_contact_emails` variable is not defined.
+
+
+      Please define it in `groups_vars/all/main.yml` with at least one email:
+
+        letsencrypt_contact_emails:
+          - changeme@example.com
+
+      The contact email is used by Let's Encrypt to send expiry notices when a certificate is coming up for renewal.
+
+
+      See https://letsencrypt.org/docs/expiration-emails/ for more information.
+
+
+      Since Trellis attempts to renew certificates after {{ letsencrypt_min_renewal_age }} days ({{ 90 - letsencrypt_min_renewal_age }} days before renewal),
+      getting an expiry notice email means something has gone wrong giving you enough notice to fix the problem.
+
+  when: letsencrypt_contact_emails is not defined
+
 - name: Create directories and set permissions
   file:
     mode: "{{ item.mode | default(omit) }}"

--- a/roles/letsencrypt/templates/renew-certs.py
+++ b/roles/letsencrypt/templates/renew-certs.py
@@ -34,6 +34,7 @@ for site in {{ sites_using_letsencrypt }}:
             '--ca {{ letsencrypt_ca }} '
             '--account-key {{ letsencrypt_account_key }} '
             '--csr {} '
+            '--contact {{ letsencrypt_contact_emails | map('regex_replace', '(^.*$)', 'mailto:\\1') | join (' ') }} '
             '--acme-dir {{ acme_tiny_challenges_directory }}'
         ).format(csr_path)
 


### PR DESCRIPTION
Let's Encrypt sends certificate expiry notice emails if a contact email is provided during account creation. Unfortunately Trellis never did this up until now; if there was a problem with the cron renewal script, there was no easy way to get notified.

This adds a new required `letsencrypt_contact_emails` variable which is passed to the acme-tiny script which it passes along to Let's Encrypt.

Let's Encrypt sends emails 20 days, 10 days, and finally 1 day before expiry. Since Trellis tries to renew certificates 30 days before renewal (by default), these expiry notice emails should never be sent unless something has gone wrong.