### PR TITLE
Reloading Nginx even if some Let's Encrypt certificates renewals has failed

### DIFF
--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -8,7 +8,7 @@
     cron_file: letsencrypt-certificate-renewal
     name: letsencrypt certificate renewal
     user: root
-    job: cd {{ acme_tiny_data_directory }} && ./renew-certs.py && /usr/sbin/service nginx reload
+    job: cd {{ acme_tiny_data_directory }} && ./renew-certs.py ; /usr/sbin/service nginx reload
     day: "{{ letsencrypt_cronjob_daysofmonth }}"
     hour: "4"
     minute: "30"


### PR DESCRIPTION
Sometimes you can have just one or a few of your sites failing in the Let's Encrypt certificate renewal process.
When this occurs, if one of the others sites have its certificate renewed Nginx will not be reloaded which may break things.

This PR is a proposal to fix this issue by reloading Nginx anyways.

Another option could be modifying how the renewal script will terminate in these cases.
But I can't see any huge difference by doing this instead.