### PR TITLE
Use official Nginx package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### HEAD
+* Switch to official Nginx Ubuntu package ([#1208](https://github.com/roots/trellis/pull/1208))
+
 ### 1.5.0: August 5th, 2020
 * Improve Nginx reloading for failed Let's Encrypt certificates ([#1207](https://github.com/roots/trellis/pull/1207))
 * Add support for Lets Encrypt contact emails ([#1206](https://github.com/roots/trellis/pull/1206))

--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
-nginx_ppa: "ppa:nginx/mainline"
+nginx_keyserver: "https://nginx.org/keys/nginx_signing.key"
+nginx_keyserver_id: "ABF5BD827BD9BF62"
+nginx_ppa: "deb http://nginx.org/packages/mainline/ubuntu {{ ansible_distribution_release }} nginx"
 nginx_package: nginx
 nginx_conf: nginx.conf.j2
 nginx_path: /etc/nginx

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Add Nginx APT key
+  apt_key:
+    keyserver: "{{ nginx_keyserver }}"
+    id: "{{ nginx_keyserver_id }}"
+
 - name: Add Nginx PPA
   apt_repository:
     repo: "{{ nginx_ppa }}"
@@ -9,6 +14,14 @@
     name: "{{ nginx_package }}"
     state: "{{ nginx_package_state | default(apt_package_state) }}"
     cache_valid_time: "{{ apt_cache_valid_time }}"
+
+- name: Ensure site directories exist
+  file:
+    path: "{{ nginx_path }}/{{ item }}"
+    state: directory
+  with_items:
+    - sites-available
+    - sites-enabled
 
 - name: Create SSL directory
   file:


### PR DESCRIPTION
Extracted from https://github.com/roots/trellis/pull/1197

Note: this will *not* re-install Nginx if you re-provision an already provisioned server since it's the same apt package name.