### PR TITLE
Update MariaDB to 10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Update MariaDB package to 10.5 ([#1212](https://github.com/roots/trellis/pull/1212))
 * Switch to official Nginx Ubuntu package ([#1208](https://github.com/roots/trellis/pull/1208))
 
 ### 1.5.0: August 5th, 2020

--- a/roles/mariadb/defaults/main.yml
+++ b/roles/mariadb/defaults/main.yml
@@ -1,6 +1,6 @@
 mariadb_keyserver: "hkp://keyserver.ubuntu.com:80"
 mariadb_keyserver_id: "0xF1656F24C74CD1D8"
-mariadb_ppa: "deb [arch=amd64] http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.2/ubuntu {{ ansible_distribution_release }} main"
+mariadb_ppa: "deb [arch=amd64] http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.5/ubuntu {{ ansible_distribution_release }} main"
 
 mariadb_client_package: mariadb-client
 mariadb_server_package: mariadb-server


### PR DESCRIPTION
This bumps the MariaDB PPA from 10.2 to 10.5.

Note that this will *not* actually upgrade the version of MariaDB already installed on a server.

Upgrading is a manual process that involves:

1. stopping the service
2. removing the installed package
3. re-installing the package

The full process is detailed at https://mariadb.com/kb/en/upgrading-from-mariadb-104-to-mariadb-105/

Though it's not required, backing up your database before the upgrade is recommended.

Note: this is split out from the [Ubuntu 20.04](https://github.com/roots/trellis/pull/1197) PR. Upgrading to 10.5 means we can keep the same versions across 18.04 and 20.04.