### PR TITLE
Move site_env to defaults

### DIFF
--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -57,7 +57,7 @@ composer_classmap_authoritative: true
 project: "{{ wordpress_sites[site] }}"
 project_root: "{{ www_root }}/{{ site }}"
 project_local_path: "{{ (lookup('env', 'USER') == 'vagrant') | ternary(project_root + '/' + project_current_path, project.local_path) }}"
-
+site_env: "{{ wordpress_env_defaults | combine(vault_wordpress_env_defaults | default({}), project.env | default({}), vault_wordpress_sites[site].env) }}"
 
 # Deploy hooks
 # For list of hooks and explanation, see https://roots.io/trellis/docs/deploys/#hooks

--- a/roles/deploy/vars/main.yml
+++ b/roles/deploy/vars/main.yml
@@ -10,5 +10,3 @@ wordpress_env_defaults:
   git_sha: "{{ git_clone.after }}"
   release_version: "{{ deploy_helper.new_release }}"
   wp_debug_log: "{{ project_root }}/logs/debug.log"
-
-site_env: "{{ wordpress_env_defaults | combine(vault_wordpress_env_defaults | default({}), project.env | default({}), vault_wordpress_sites[site].env) }}"


### PR DESCRIPTION
This allows consumers of the deploy role to provide their own site_env.

Fixes #1218,