### PR TITLE
Fixes #1221 - Allow WP cron minute/interval to be configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Allow WP cron intervals to be configurable ([#1222](https://github.com/roots/trellis/pull/1222))
 * Remove default Vagrant SMB credentials ([#1215](https://github.com/roots/trellis/pull/1215))
 * Fix usage of `ANSIBLE_CONFIG` env var ([#1217](https://github.com/roots/trellis/pull/1217))
 * Update MariaDB package to 10.5 ([#1212](https://github.com/roots/trellis/pull/1212))

--- a/roles/wordpress-setup/tasks/main.yml
+++ b/roles/wordpress-setup/tasks/main.yml
@@ -45,7 +45,7 @@
 - name: Setup WP system cron
   cron:
     name: "{{ item.key }} WordPress cron"
-    minute: "*/15"
+    minute: "{{ item.value.cron_interval | default('*/15') }}"
     user: "{{ web_user }}"
     job: "cd {{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }} && wp cron event run --due-now > /dev/null 2>&1"
     cron_file: "wordpress-{{ item.key | replace('.', '_') }}"
@@ -55,7 +55,7 @@
 - name: Setup WP Multisite system cron
   cron:
     name: "{{ item.key }} WordPress network cron"
-    minute: "*/30"
+    minute: "{{ item.value.cron_interval_multisite | default('*/30') }}"
     user: "{{ web_user }}"
     job: "cd {{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }} && wp site list --field=url | xargs -n1 -I \\% wp --url=\\% cron event run --due-now > /dev/null 2>&1"
     cron_file: "wordpress-multisite-{{ item.key | replace('.', '_') }}"


### PR DESCRIPTION
Fixes #1221 

Adds `cron_interval` and `cron_interval_multisite` settings on a wordpress site.

@strarsis this should work? Ideally we probably should have had a `cron` nested hash from the start but this is the easiest way to add these and make it backwards compatible.