### PR TITLE
CircleCI: Invalidate pip caches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,13 +14,13 @@ commands:
       - restore_cache:
             name: Restore pip Cache
             keys:
-              - pip-v2-<<parameters.python-version>>-<<parameters.package>>-
+              - pip-v3-<<parameters.python-version>>-<<parameters.package>>-
       - run:
           name: Install pip Package
           command: pip install --user --upgrade <<parameters.package>>
       - save_cache:
           name: Save pip Cache
-          key: pip-v2-<<parameters.python-version>>-<<parameters.package>>-{{ epoch }}
+          key: pip-v3-<<parameters.python-version>>-<<parameters.package>>-{{ epoch }}
           paths:
             - /home/circleci/.local/bin/
             - /home/circleci/.local/lib/
@@ -83,13 +83,13 @@ jobs:
       - restore_cache:
             name: Restore pip Cache
             keys:
-              - pip-v2-<<parameters.python-version>>-{{ checksum "requirements.txt" }}-
+              - pip-v3-<<parameters.python-version>>-{{ checksum "requirements.txt" }}-
       - run:
           name: Install packages from requirements.txt (or any other file) via Pip.
           command: pip install --user --upgrade --requirement requirements.txt
       - save_cache:
           name: Save pip Cache
-          key: pip-v2-<<parameters.python-version>>-{{ checksum "requirements.txt" }}-{{ epoch }}
+          key: pip-v3-<<parameters.python-version>>-{{ checksum "requirements.txt" }}-{{ epoch }}
           paths:
             - /home/circleci/.local/bin/
             - /home/circleci/.local/lib/


### PR DESCRIPTION
Fix the error when pip cached ansible v2.9 or older:

```

Upgrading directly from ansible-2.9 or less to ansible-2.10 or greater with pip is
known to cause problems.  Please uninstall the old version found at:

/home/circleci/.local/lib/python2.7/site-packages/ansible/__init__.pyc

and install the new version:

    pip uninstall ansible
    pip install ansible

If you have a broken installation, perhaps because ansible-base was installed before
ansible was upgraded, try this to resolve it:

    pip install --force-reinstall ansible ansible-base

If ansible is installed in a different location than you will be installing it now
(for example, if the old version is installed by a system package manager to
/usr/lib/python3.8/site-packages/ansible but you are installing the new version into
~/.local/lib/python3.8/site-packages/ansible with `pip install --user ansible`)
or you want to install anyways and cleanup any breakage afterwards, then you may set
the ANSIBLE_SKIP_CONFLICT_CHECK environment variable to ignore this check:

    ANSIBLE_SKIP_CONFLICT_CHECK=1 pip install --user ansible

```

---

Related: https://github.com/roots/trellis/pull/1222#issuecomment-697116777

cc @swalkinshaw 