### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ansible>=2.8.0,<3.0
+ansible>=2.8.0,<2.10.0
 passlib


### PR DESCRIPTION
Ansible 2.10 changes the following warning to an error:

```
[WARNING]: The src option requires state to be 'link' or 'hard'.  This will become an error in Ansible 2.10
```

Since `requirements.txt` doesn't exclude Ansible 2.10, the current Trellis `WordPress` role produces the following error on `trellis up`:

```
src option requires state to be 'link' or 'hard'
failed: [default] (item={'src': 'ssl.no-default.conf.j2', 'enabled': False}) => {"ansible_loop_var": "item", "changed": false, "item": {"enabled": false, "src": "ssl.no-default.conf.j2"}, "path": "/etc/nginx/sites-enabled/ssl.no-default.conf"}
```

I _think_ this indicates a need to change [these lines](https://github.com/roots/trellis/blob/master/roles/wordpress-setup/defaults/main.yml#L15-L16) to meet Ansible 2.10+'s new requirements, but for the meantime this PR prevents 2.10 from being installed, since it's not actually supported.