### PR TITLE
Ansible Lint: Fail if `experimental` rules are failed

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,4 +1,6 @@
 ---
+warn_list: []
+
 skip_list:
   - 106 # Role name {} does not match ``^[a-z][a-z0-9_]+$`` pattern
   - 204 # Lines should be no longer than 160 chars


### PR DESCRIPTION
See: https://github.com/ansible/ansible-lint/issues/1031#issuecomment-687241617

Fix #1231

Note: CircleCI lint job should fail on this PR
