### PR TITLE
Set universal_newlines for renew-certs script

### DIFF
--- a/roles/letsencrypt/templates/renew-certs.py
+++ b/roles/letsencrypt/templates/renew-certs.py
@@ -39,7 +39,7 @@ for site in {{ sites_using_letsencrypt }}:
         ).format(csr_path)
 
         try:
-            new_bundled_cert = check_output(cmd, stderr=STDOUT, shell=True)
+            new_bundled_cert = check_output(cmd, stderr=STDOUT, shell=True, universal_newlines=True)
         except CalledProcessError as e:
             failed = True
             print('Error while generating certificate for {}\n{}'.format(site, e.output), file=sys.stderr)


### PR DESCRIPTION
Using `universal_newlines` is better for Python 2/3 compatibility since it will return a string and not bytes to ensure it's the same regardless of the version.