### PR TITLE
Remove prestissimo from composer_global_packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Remove prestissimo for Composer 2.0 support ([#1247](https://github.com/roots/trellis/pull/1247))
 * Allow WP cron intervals to be configurable ([#1222](https://github.com/roots/trellis/pull/1222))
 * Remove default Vagrant SMB credentials ([#1215](https://github.com/roots/trellis/pull/1215))
 * Fix usage of `ANSIBLE_CONFIG` env var ([#1217](https://github.com/roots/trellis/pull/1217))

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -1,6 +1,4 @@
 composer_keep_updated: true
-composer_global_packages:
- - { name: hirak/prestissimo }
 apt_cache_valid_time: 3600
 apt_package_state: present
 apt_security_package_state: latest


### PR DESCRIPTION
Ref https://github.com/roots/trellis/issues/1245

Closes https://github.com/roots/trellis/issues/1088

`hirak/prestissimo` is a composer plugin that speeded up `composer install` by downloading packages in parallel.

Composer 2.0 has been released with parallel downloading built-in and unfortunately, `prestissimo` is not compatible with it. Also unfortunately, Trellis auto updates composer to the latest version during provisioning. This means any provision (new or existing servers) will update to Composer 2.0 and it will fail either trying to install `composer_global_packages` or on deploys.

The easiest short-term solution is to remove `hirak/prestissimo` entirely. Anyone provisioning this change will get the latest Composer anyway (assuming they didn't customize `composer_keep_updated`, and if they did, they can customize `composer_global_packages` too).