### PR TITLE
Validate that letsencrypt_contact_emails is a list

### DIFF
--- a/roles/letsencrypt/tasks/setup.yml
+++ b/roles/letsencrypt/tasks/setup.yml
@@ -2,10 +2,10 @@
 - name: Fail if letsencrypt_contact_emails is not defined
   fail:
     msg: >
-      Error: the required `letsencrypt_contact_emails` variable is not defined.
+      Error: the required `letsencrypt_contact_emails` variable is not defined or invalid.
 
 
-      Please define it in `groups_vars/all/main.yml` with at least one email:
+      Please define it in `groups_vars/all/main.yml` with at least one email (as a list/array, *not* a string):
 
         letsencrypt_contact_emails:
           - changeme@example.com
@@ -19,7 +19,7 @@
       Since Trellis attempts to renew certificates after {{ letsencrypt_min_renewal_age }} days ({{ 90 - letsencrypt_min_renewal_age }} days before renewal),
       getting an expiry notice email means something has gone wrong giving you enough notice to fix the problem.
 
-  when: letsencrypt_contact_emails is not defined
+  when: (letsencrypt_contact_emails is not defined) or (letsencrypt_contact_emails is string)
 
 - name: Create directories and set permissions
   file:


### PR DESCRIPTION
We already validate that `letsencrypt_contact_emails` needs to be defined. This further validates that it's defined as a list and not a string.

Ref: https://discourse.roots.io/t/unable-to-update-account-too-many-contacts-provided/19153

cc @strarsis 