### PR TITLE
Manually update Ansible Galaxy roles 

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -12,7 +12,7 @@
 
 - name: swapfile
   src: oefenweb.swapfile
-  version: v2.0.26
+  version: v2.0.32
 
 - name: mailhog
   src: geerlingguy.mailhog

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 - name: composer
   src: geerlingguy.composer
-  version: 1.7.6
+  version: 1.9.0
 
 - name: ntp
   src: geerlingguy.ntp

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -4,7 +4,7 @@
 
 - name: ntp
   src: geerlingguy.ntp
-  version: 2.0.0
+  version: 2.2.0
 
 - name: logrotate
   src: nickhammond.logrotate


### PR DESCRIPTION
Manually update Ansible Galaxy roles that have new versions.
Fix #1252 .