### PR TITLE
Migrate to Xdebug v3

### DIFF
--- a/group_vars/development/php.yml
+++ b/group_vars/development/php.yml
@@ -5,5 +5,6 @@ php_track_errors: 'On'
 php_mysqlnd_collect_memory_statistics: 'On'
 php_opcache_enable: 0
 
-xdebug_remote_enable: 1
-xdebug_remote_connect_back: 1
+xdebug_mode: 'debug'
+xdebug_start_with_request: 'yes'
+xdebug_discover_client_host: 1

--- a/roles/xdebug-tunnel/defaults/main.yml
+++ b/roles/xdebug-tunnel/defaults/main.yml
@@ -1,6 +1,6 @@
-xdebug_tunnel_remote_port: 9000
+xdebug_tunnel_remote_port: 9003
 xdebug_tunnel_host: localhost
-xdebug_tunnel_local_port: 9000
+xdebug_tunnel_local_port: 9003
 xdebug_tunnel_control_socket: /tmp/trellis-xdebug-{{ xdebug_tunnel_inventory_host }}
 xdebug_tunnel_control_identity: "{{ ansible_user_id }}"
 

--- a/roles/xdebug/defaults/main.yml
+++ b/roles/xdebug/defaults/main.yml
@@ -1,14 +1,17 @@
 php_xdebug_package: php7.4-xdebug
 
+# XDebug Generic
+xdebug_output_dir: /tmp
+xdebug_trigger_value:
+
 # XDebug Remote Debugging
-xdebug_remote_enable: 0
-xdebug_remote_connect_back: 0
-xdebug_remote_autostart: 0
-xdebug_remote_host: localhost
-xdebug_remote_port: 9000
-xdebug_remote_log: /tmp/xdebug.log
+xdebug_mode: 'off'
+xdebug_start_with_request: 'no'
+xdebug_discover_client_host: 0
+xdebug_client_host: localhost
+xdebug_client_port: 9003
+xdebug_log: /tmp/xdebug.log
 xdebug_idekey: XDEBUG
-xdebug_extended_info: 1
 xdebug_max_nesting_level: 200
 
 # XDebug Display Settings
@@ -21,24 +24,13 @@ xdebug_var_display_max_depth: 3
 
 # XDebug Function/Stack Traces
 xdebug_collect_assignments: 0
-xdebug_collect_includes: 1
-xdebug_collect_params: 0
 xdebug_collect_return: 0
-xdebug_collect_vars: 0
 xdebug_show_exception_trace: 0
 xdebug_show_local_vars: 0
-xdebug_show_mem_delta: 0
-xdebug_trace_enable_trigger: 0
-xdebug_trace_enable_trigger_value:
 xdebug_trace_format: 0
 xdebug_trace_options: 0
-xdebug_trace_output_dir: /tmp
 xdebug_trace_output_name: trace.%c
 
 # XDebug Profiler
 xdebug_profiler_append: 0
-xdebug_profiler_enable: 0
-xdebug_profiler_enable_trigger: 0
-xdebug_profiler_enable_trigger_value:
-xdebug_profiler_output_dir: /tmp
 xdebug_profiler_output_name: cachegrind.out.%p

--- a/roles/xdebug/tasks/main.yml
+++ b/roles/xdebug/tasks/main.yml
@@ -19,13 +19,13 @@
       state: link
     notify: reload php-fpm
 
-  when: xdebug_remote_enable | bool
+  when: xdebug_mode is not match("off")
 
 - name: Disable Xdebug
   file:
     path: /etc/php/7.4/fpm/conf.d/20-xdebug.ini
     state: absent
-  when: not xdebug_remote_enable | bool
+  when: xdebug_mode is match("off")
   notify: reload php-fpm
 
 - name: Disable Xdebug CLI

--- a/roles/xdebug/tasks/main.yml
+++ b/roles/xdebug/tasks/main.yml
@@ -19,15 +19,6 @@
       state: link
     notify: reload php-fpm
 
-  when: xdebug_mode is not match("off")
-
-- name: Disable Xdebug
-  file:
-    path: /etc/php/7.4/fpm/conf.d/20-xdebug.ini
-    state: absent
-  when: xdebug_mode is match("off")
-  notify: reload php-fpm
-
 - name: Disable Xdebug CLI
   file:
     path: /etc/php/7.4/cli/conf.d/20-xdebug.ini

--- a/roles/xdebug/templates/xdebug.ini.j2
+++ b/roles/xdebug/templates/xdebug.ini.j2
@@ -3,16 +3,18 @@
 [XDebug]
 zend_extension=xdebug.so
 
+; Generic
+xdebug.output_dir={{ xdebug_output_dir }}
+xdebug.trigger_value={{ xdebug_trigger_value }}
+
 ; Remote Debugging
-xdebug.remote_enable={{ xdebug_remote_enable }}
-xdebug.remote_connect_back={{ xdebug_remote_connect_back }}
-xdebug.remote_autostart={{ xdebug_remote_autostart }}
-xdebug.remote_host={{ xdebug_remote_host }}
-xdebug.remote_port={{ xdebug_remote_port }}
-xdebug.remote_handler=dbgp
-xdebug.remote_log={{ xdebug_remote_log }}
+xdebug.mode={{ xdebug_mode }}
+xdebug.start_with_request={{ xdebug_start_with_request }}
+xdebug.discover_client_host={{ xdebug_discover_client_host }}
+xdebug.client_host={{ xdebug_client_host }}
+xdebug.client_port={{ xdebug_client_port }}
+xdebug.log={{ xdebug_log }}
 xdebug.idekey={{ xdebug_idekey }}
-xdebug.extended_info={{ xdebug_extended_info }}
 xdebug.max_nesting_level={{ xdebug_max_nesting_level }}
 
 ; Display Settings
@@ -25,24 +27,13 @@ xdebug.var_display_max_depth={{ xdebug_var_display_max_depth }}
 
 ; Function/Stack Traces
 xdebug.collect_assignments={{ xdebug_collect_assignments }}
-xdebug.collect_includes={{ xdebug_collect_includes }}
-xdebug.collect_params={{ xdebug_collect_params }}
 xdebug.collect_return={{ xdebug_collect_return }}
-xdebug.collect_vars={{ xdebug_collect_vars }}
 xdebug.show_exception_trace={{ xdebug_show_exception_trace }}
 xdebug.show_local_vars={{ xdebug_show_local_vars }}
-xdebug.show_mem_delta={{ xdebug_show_mem_delta }}
-xdebug.trace_enable_trigger={{ xdebug_trace_enable_trigger }}
-xdebug.trace_enable_trigger_value={{ xdebug_trace_enable_trigger_value }}
 xdebug.trace_format={{ xdebug_trace_format }}
 xdebug.trace_options={{ xdebug_trace_options }}
-xdebug.trace_output_dir={{ xdebug_trace_output_dir }}
 xdebug.trace_output_name={{ xdebug_trace_output_name }}
 
 ; Profiler
 xdebug.profiler_append={{ xdebug_profiler_append }}
-xdebug.profiler_enable={{ xdebug_profiler_enable }}
-xdebug.profiler_enable_trigger={{ xdebug_profiler_enable_trigger }}
-xdebug.profiler_enable_trigger_value={{ xdebug_profiler_enable_trigger_value }}
-xdebug.profiler_output_dir={{ xdebug_profiler_output_dir }}
 xdebug.profiler_output_name={{ xdebug_profiler_output_name }}


### PR DESCRIPTION
This PR will migrate the Xdebug config to work with Xdebug v3 that [was released in november 2020](https://xdebug.org/announcements/2020-11-25).

It's a pretty naive migration where I simply went thru the [upgrade guide](https://xdebug.org/docs/upgrade_guide) and removed the config options that's been deprecated and updated those that have been changed.

Though there is one significant change:

With Xdebug v3 they've changed the default connection port from `9000` to `9003`. I decided to follow the defaults and this means the new port to connect with trellis+xdebug will be `9003`.

I would love some help with this one. I'm not in any way experienced in configuring Xdebug. The changes made here does work well with the php debugger in VScode. But I haven't tested it with other IDE's. So if someone with more experience in configuring Xdebug can take a look I would warmly welcome some feedback.

## Considerations

- Does this migration in any way affect the xdebug-tunnel role? I've never used it, but maybe changes need to happen there as well?

Fixes #1255 
