### PR TITLE
Remove deprecated PHP option track_errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Fix #1263 - Remove deprecated PHP option `track_errors` ([#1264](https://github.com/roots/trellis/pull/1264))
 * Validate that `letsencrypt_contact_emails` is a list ([#1250](https://github.com/roots/trellis/pull/1250))
 * Add config for PHP CLI ([#1261](https://github.com/roots/trellis/pull/1261))
 

--- a/group_vars/development/php.yml
+++ b/group_vars/development/php.yml
@@ -1,7 +1,6 @@
 php_error_reporting: 'E_ALL'
 php_display_errors: 'On'
 php_display_startup_errors: 'On'
-php_track_errors: 'On'
 php_mysqlnd_collect_memory_statistics: 'On'
 php_opcache_enable: 0
 

--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -32,7 +32,6 @@ php_session_save_path: /tmp
 php_session_cookie_httponly: 'On'
 php_session_cookie_secure: 'Off'
 php_upload_max_filesize: 25M
-php_track_errors: 'Off'
 php_timezone: '{{ ntp_timezone }}'
 php_output_buffering: 'Off'
 

--- a/roles/php/templates/php-cli.ini.j2
+++ b/roles/php/templates/php-cli.ini.j2
@@ -3,7 +3,6 @@
 [PHP]
 error_reporting = {{ php_error_reporting }}
 sendmail_path = {{ php_sendmail_path }}
-track_errors = {{ php_track_errors }}
 expose_php = Off
 date.timezone = {{ php_timezone }}
 

--- a/roles/php/templates/php-fpm.ini.j2
+++ b/roles/php/templates/php-fpm.ini.j2
@@ -13,7 +13,6 @@ sendmail_path = {{ php_sendmail_path }}
 session.save_path = {{ php_session_save_path }}
 session.cookie_httponly = {{ php_session_cookie_httponly }}
 session.cookie_secure = {{ php_session_cookie_secure }}
-track_errors = {{ php_track_errors }}
 upload_max_filesize = {{ php_upload_max_filesize }}
 expose_php = Off
 date.timezone = {{ php_timezone }}


### PR DESCRIPTION
`track_errors` was deprecated as of PHP 7.2 so we're removing it entirely.

Fixes https://github.com/roots/trellis/issues/1263 which was caused by https://github.com/roots/trellis/pull/1261