### PR TITLE
Extend failed connection to remote repo msg

### DIFF
--- a/roles/deploy/tasks/update.yml
+++ b/roles/deploy/tasks/update.yml
@@ -35,7 +35,7 @@
 - name: Failed connection to remote repo
   fail:
     msg: |
-      Git repo {{ project.repo }} cannot be accessed. Please verify the repository exists and you have SSH forwarding set up correctly.
+      Git repo {{ project.repo }} on branch {{ project_version }} cannot be accessed. Please verify the repository/branch are correct and you have SSH forwarding set up correctly.
       More info:
       > https://roots.io/trellis/docs/deploys/#ssh-keys
       > https://roots.io/trellis/docs/ssh-keys/#cloning-remote-repo-using-ssh-agent-forwarding


### PR DESCRIPTION
Due to no_log for git clone on deploy you are unable to see the exact
output error message, adding the branch being used to the fail message
may help when incorrect branch name is used.