### PR TITLE
Bump vagrant_ansible_version

### DIFF
--- a/vagrant.default.yml
+++ b/vagrant.default.yml
@@ -4,7 +4,7 @@ vagrant_cpus: 1
 vagrant_memory: 1024 # in MB
 vagrant_box: 'bento/ubuntu-20.04'
 vagrant_box_version: '>= 201807.12.0'
-vagrant_ansible_version: '2.8.0'
+vagrant_ansible_version: '2.9.10'
 vagrant_skip_galaxy: false
 vagrant_mount_type: 'nfs'
 


### PR DESCRIPTION
This should usually match the max tested version but I forget to bump it 😞 

This will fix some issues with people using Vagrant's `ansible_local` provisioner with Ubuntu 20.04 as well