### PR TITLE
Vagrant: use python3

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -117,23 +117,11 @@ Vagrant.configure('2') do |config|
   provisioner = local_provisioning? ? :ansible_local : :ansible
   provisioning_path = local_provisioning? ? ANSIBLE_PATH_ON_VM : ANSIBLE_PATH
 
-  # Fix for https://github.com/hashicorp/vagrant/issues/10914
-  if local_provisioning?
-    config.vm.provision 'shell', inline: <<~SHELL
-      sudo apt-get update -y -qq &&
-      sudo dpkg-reconfigure libc6 &&
-      export DEBIAN_FRONTEND=noninteractive &&
-      sudo -E apt-get -q --option \"Dpkg::Options::=--force-confold\" --assume-yes install libssl1.1
-    SHELL
-  end
-
   config.vm.provision provisioner do |ansible|
     if local_provisioning?
+      ansible.extra_vars = { ansible_python_interpreter: vconfig.fetch('vagrant_ansible_python_interpreter') }
       ansible.install_mode = 'pip'
-      if Vagrant::VERSION >= '2.2.5'
-        # Fix for https://github.com/hashicorp/vagrant/issues/10950
-        ansible.pip_install_cmd = 'curl https://bootstrap.pypa.io/get-pip.py | sudo python'
-      end
+      ansible.pip_install_cmd = 'sudo apt-get install -y -qq python3-distutils && curl https://bootstrap.pypa.io/get-pip.py | sudo python3'
       ansible.provisioning_path = provisioning_path
       ansible.version = vconfig.fetch('vagrant_ansible_version')
     end

--- a/vagrant.default.yml
+++ b/vagrant.default.yml
@@ -3,8 +3,9 @@ vagrant_ip: '192.168.50.5'
 vagrant_cpus: 1
 vagrant_memory: 1024 # in MB
 vagrant_box: 'bento/ubuntu-20.04'
-vagrant_box_version: '>= 201807.12.0'
+vagrant_box_version: '>= 202012.23.0'
 vagrant_ansible_version: '2.9.10'
+vagrant_ansible_python_interpreter: '/usr/bin/python3'
 vagrant_skip_galaxy: false
 vagrant_mount_type: 'nfs'
 


### PR DESCRIPTION
Fixes #1267

Pip doesn't support Python2 anymore so we're defaulting Vagrant to python3.

This defines a new config option `vagrant_ansible_python_interpreter` which defaults to `/usr/bin/python3`.