### PR TITLE
File permissions: Use strings instead of octal numbers

### DIFF
--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -20,7 +20,7 @@ project_templates:
   - name: .env config
     src: roles/deploy/templates/env.j2
     dest: .env
-    mode: 0600
+    mode: '0600'
 
 # The shared_children is a list of all files/folders in your project that need to be linked to a path in `/shared`.
 # For example a sessions directory or an uploads folder. They are created if they don't exist, with the type
@@ -29,7 +29,7 @@ project_templates:
 # project_shared_children:
 #   - path: app/sessions
 #     src: sessions
-#     mode: 0755      // <- optional, use an octal number starting with 0 or quote it, defaults to `0755` if `directory` or `0644` if `file`
+#     mode: '0755'      // <- optional, use an octal number starting with 0 or quote it, defaults to `'0755'` if `directory` or `'0644'` if `file`
 #     type: directory // <- optional, defaults to `directory`, options: `directory` or `file`
 project_shared_children:
   - path: web/app/uploads

--- a/roles/deploy/tasks/build.yml
+++ b/roles/deploy/tasks/build.yml
@@ -17,7 +17,7 @@
   template:
     src: "{{ item.src }}"
     dest: "{{ deploy_helper.new_release_path }}/{{ item.dest }}"
-    mode: "{{ item.mode | default(0644) }}"
+    mode: "{{ item.mode | default('0644') }}"
   with_items: "{{ project.project_templates | default(project_templates) }}"
 
 - name: Check if project folders exist

--- a/roles/deploy/tasks/prepare.yml
+++ b/roles/deploy/tasks/prepare.yml
@@ -27,7 +27,7 @@
 - name: Create new release dir
   file:
     path: "{{ deploy_helper.new_release_path }}"
-    mode: 0755
+    mode: '0755'
     state: directory
 
 - name: Run git archive to populate new build dir
@@ -51,7 +51,7 @@
 - name: write unfinished file
   file:
     path: "{{ deploy_helper.new_release_path }}/{{ deploy_helper.unfinished_filename }}"
-    mode: 0744
+    mode: '0744'
     state: touch
 
 - name: Check if deploy_prepare_after scripts exist

--- a/roles/deploy/tasks/share.yml
+++ b/roles/deploy/tasks/share.yml
@@ -17,7 +17,7 @@
   file:
     path: "{{ deploy_helper.shared_path }}/{{ item.src }}"
     state: directory
-    mode: "{{ item.mode | default(0755) }}"
+    mode: "{{ item.mode | default('0755') }}"
   with_items: "{{ project.project_shared_children | default(project_shared_children) }}"
   when: item.type | default('directory') | lower == 'directory'
 
@@ -25,7 +25,7 @@
   file:
     path: "{{ deploy_helper.shared_path }}/{{ item.src | dirname }}"
     state: directory
-    mode: 0755
+    mode: '0755'
   with_items: "{{ project.project_shared_children | default(project_shared_children) }}"
   when: item.type | default('directory') | lower == 'file'
 
@@ -33,14 +33,14 @@
   file:
     path: "{{ deploy_helper.shared_path }}/{{ item.src }}"
     state: touch
-    mode: "{{ item.mode | default(0644) }}"
+    mode: "{{ item.mode | default('0644') }}"
   with_items: "{{ project.project_shared_children | default(project_shared_children) }}"
   when: item.type | default('directory') | lower == 'file'
 
 - name: Ensure parent directories for shared paths are present
   file:
     path: "{{ deploy_helper.new_release_path }}/{{ item.path | dirname }}"
-    mode: 0777
+    mode: '0777'
     state: directory
   with_items: "{{ project.project_shared_children | default(project_shared_children) }}"
 

--- a/roles/fail2ban/tasks/main.yml
+++ b/roles/fail2ban/tasks/main.yml
@@ -11,7 +11,7 @@
   template:
     src: "{{ item }}.j2"
     dest: /etc/fail2ban/{{ item }}
-    mode: 0644
+    mode: '0644'
   with_items:
     - jail.local
     - fail2ban.local
@@ -31,13 +31,13 @@
   file:
     path: /etc/fail2ban/filter.d/
     state: directory
-    mode: 0755
+    mode: '0755'
 
 - name: template fail2ban filters
   template:
     src: "{{ item }}"
     dest: "/etc/fail2ban/filter.d/{{ item | regex_replace(fail2ban_filter_templates_pattern, '\\2') }}"
-    mode: 0644
+    mode: '0644'
   with_items: "{{ fail2ban_filter_templates.files | map(attribute='path') | list | sort(True) }}"
   notify: restart fail2ban
 

--- a/roles/ferm/tasks/main.yml
+++ b/roles/ferm/tasks/main.yml
@@ -19,7 +19,7 @@
   file:
     path: "{{ item }}"
     state: directory
-    mode: 0750
+    mode: '0750'
   with_items:
     - /etc/ferm/ferm.d
     - /etc/ferm/filter-input.d
@@ -28,7 +28,7 @@
   template:
     src: "{{ item }}.j2"
     dest: /{{ item }}
-    mode: 0644
+    mode: '0644'
   with_items:
     - etc/default/ferm
     - etc/ferm/ferm.conf

--- a/roles/letsencrypt/tasks/certificates.yml
+++ b/roles/letsencrypt/tasks/certificates.yml
@@ -9,7 +9,7 @@
 - name: Ensure correct permissions on private keys
   file:
     path: "{{ letsencrypt_keys_dir }}/{{ item.key }}.key"
-    mode: 0600
+    mode: '0600'
   when: site_uses_letsencrypt
   with_dict: "{{ wordpress_sites }}"
 
@@ -39,7 +39,7 @@
   template:
     src: renew-certs.py
     dest: "{{ acme_tiny_data_directory }}/renew-certs.py"
-    mode: 0700
+    mode: '0700'
   tags: [wordpress, wordpress-setup, wordpress-setup-nginx, nginx-includes]
 
 - name: Generate the certificates

--- a/roles/letsencrypt/tasks/nginx.yml
+++ b/roles/letsencrypt/tasks/nginx.yml
@@ -3,7 +3,7 @@
   template:
     src: acme-challenge-location.conf.j2
     dest: "{{ nginx_path }}/acme-challenge-location.conf"
-    mode: 0644
+    mode: '0644'
 
 - name: Get list of hosts in current Nginx conf
   shell: |
@@ -18,7 +18,7 @@
   template:
     src: nginx-challenge-site.conf.j2
     dest: "{{ nginx_path }}/sites-available/letsencrypt-{{ item.key }}.conf"
-    mode: 0644
+    mode: '0644'
   register: challenge_site_confs
   when:
     - site_uses_letsencrypt
@@ -44,7 +44,7 @@
   file:
     path: "{{ acme_tiny_challenges_directory }}/ping.txt"
     state: touch
-    mode: 0644
+    mode: '0644'
 
 - name: Test Acme Challenges
   test_challenges:

--- a/roles/letsencrypt/tasks/setup.yml
+++ b/roles/letsencrypt/tasks/setup.yml
@@ -28,12 +28,12 @@
     state: directory
   with_items:
     - path: "{{ acme_tiny_data_directory }}"
-      mode: 0700
+      mode: '0700'
     - path: "{{ acme_tiny_data_directory }}/csrs"
     - path: "{{ acme_tiny_software_directory }}"
     - path: "{{ acme_tiny_challenges_directory }}"
     - path: "{{ letsencrypt_certs_dir }}"
-      mode: 0700
+      mode: '0700'
 
 - name: Clone acme-tiny repository
   git:
@@ -46,14 +46,14 @@
   copy:
     src: "{{ letsencrypt_account_key_source_file }}"
     dest: "{{ letsencrypt_account_key }}"
-    mode: 0700
+    mode: '0700'
   when: letsencrypt_account_key_source_file is defined
 
 - name: Copy Lets Encrypt account key source contents
   copy:
     content: "{{ letsencrypt_account_key_source_content | trim }}"
     dest: "{{ letsencrypt_account_key }}"
-    mode: 0700
+    mode: '0700'
   when: letsencrypt_account_key_source_content is defined
 
 - name: Generate a new account key

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -29,7 +29,7 @@
       dest: /etc/mysql/conf.d
       owner: root
       group: root
-      mode: 0644
+      mode: '0644'
     when: mysql_binary_logging_disabled | bool
     notify: restart mysql server
 
@@ -53,7 +53,7 @@
       dest: ~/.my.cnf
       owner: root
       group: root
-      mode: 0600
+      mode: '0600'
 
   - name: Delete anonymous MySQL server users
     mysql_user:

--- a/roles/memcached/tasks/main.yml
+++ b/roles/memcached/tasks/main.yml
@@ -10,7 +10,7 @@
   template:
     src: memcached.conf.j2
     dest: /etc/memcached.conf
-    mode: 0644
+    mode: '0644'
   notify: restart memcached
 
 - name: Set the max open file descriptors

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -19,14 +19,14 @@
   file:
     path: "{{ nginx_path }}/{{ item }}"
     state: directory
-    mode: 0755
+    mode: '0755'
   with_items:
     - sites-available
     - sites-enabled
 
 - name: Create SSL directory
   file:
-    mode: 0700
+    mode: '0700'
     path: "{{ nginx_path }}/ssl"
     state: directory
 
@@ -43,14 +43,14 @@
   copy:
     src: templates/h5bp
     dest: "{{ nginx_path }}"
-    mode: 0755
+    mode: '0755'
   notify: reload nginx
 
 - name: Create nginx.conf
   template:
     src: "{{ nginx_conf }}"
     dest: "{{ nginx_path }}/nginx.conf"
-    mode: 0644
+    mode: '0644'
   notify: reload nginx
   tags: nginx-includes
 

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -49,11 +49,11 @@
   template:
     src: php-fpm.ini.j2
     dest: /etc/php/7.4/fpm/php.ini
-    mode: 0644
+    mode: '0644'
   notify: reload php-fpm
 
 - name: Copy PHP CLI configuration file
   template:
     src: php-cli.ini.j2
     dest: /etc/php/7.4/cli/php.ini
-    mode: 0644
+    mode: '0644'

--- a/roles/rollback/tasks/main.yml
+++ b/roles/rollback/tasks/main.yml
@@ -30,4 +30,4 @@
   file:
     path: "{{ current_release_readlink_result.stdout }}/DEPLOY_UNFINISHED"
     state: touch
-    mode: 0644
+    mode: '0644'

--- a/roles/sshd/tasks/main.yml
+++ b/roles/sshd/tasks/main.yml
@@ -11,7 +11,7 @@
   template:
     src: "{{ sshd_config }}"
     dest: /etc/ssh/sshd_config
-    mode: 0600
+    mode: '0600'
     validate: '/usr/sbin/sshd -T -f %s'
   notify: restart ssh
 
@@ -19,7 +19,7 @@
   template:
     src: "{{ ssh_config }}"
     dest: /etc/ssh/ssh_config
-    mode: 0644
+    mode: '0644'
 
 - name: Remove Diffie-Hellman moduli of size < 2000
   lineinfile:

--- a/roles/ssmtp/tasks/main.yml
+++ b/roles/ssmtp/tasks/main.yml
@@ -9,10 +9,10 @@
   template:
     src: ssmtp.conf.j2
     dest: /etc/ssmtp/ssmtp.conf
-    mode: 0644
+    mode: '0644'
 
 - name: ssmtp revaliases configuration
   template:
     src: revaliases.j2
     dest: /etc/ssmtp/revaliases
-    mode: 0644
+    mode: '0644'

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -43,7 +43,7 @@
   template:
     src: sudoers.d.j2
     dest: "/etc/sudoers.d/{{ web_user }}-services"
-    mode: 0440
+    mode: '0440'
     owner: root
     group: root
     validate: "/usr/sbin/visudo -cf %s"

--- a/roles/wordpress-install/tasks/directories.yml
+++ b/roles/wordpress-install/tasks/directories.yml
@@ -4,7 +4,7 @@
     path: "{{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/web"
     owner: "{{ web_user }}"
     group: "{{ web_group }}"
-    mode: 0755
+    mode: '0755'
     state: directory
   with_dict: "{{ wordpress_sites }}"
 
@@ -13,7 +13,7 @@
     path: "{{ www_root }}/{{ item.key }}/shared"
     owner: "{{ web_user }}"
     group: "{{ web_group }}"
-    mode: 0755
+    mode: '0755'
     state: directory
   with_dict: "{{ wordpress_sites }}"
 
@@ -22,7 +22,7 @@
     path: "{{ www_root }}/{{ item.key }}"
     owner: "{{ web_user }}"
     group: "{{ web_group }}"
-    mode: 0755
+    mode: '0755'
     state: directory
     recurse: yes
   with_dict: "{{ wordpress_sites }}"

--- a/roles/wordpress-install/tasks/dotenv.yml
+++ b/roles/wordpress-install/tasks/dotenv.yml
@@ -3,7 +3,7 @@
   template:
     src: "env.j2"
     dest: "/tmp/{{ item.key }}.env"
-    mode: 0644
+    mode: '0644'
     owner: "{{ web_user }}"
     group: "{{ web_group }}"
   with_dict: "{{ wordpress_sites }}"

--- a/roles/wordpress-setup/tasks/main.yml
+++ b/roles/wordpress-setup/tasks/main.yml
@@ -11,7 +11,7 @@
     path: "{{ www_root }}"
     owner: "{{ web_user }}"
     group: "{{ web_group }}"
-    mode: 0755
+    mode: '0755'
     state: directory
 
 - name: Create logs folder of sites
@@ -19,7 +19,7 @@
     path: "{{ www_root }}/{{ item.key }}/logs"
     owner: "{{ web_user }}"
     group: "{{ web_group }}"
-    mode: 0755
+    mode: '0755'
     state: directory
   with_dict: "{{ wordpress_sites }}"
 
@@ -27,7 +27,7 @@
   template:
     src: php-fpm.conf.j2
     dest: /etc/php/7.4/fpm/pool.d/wordpress.conf
-    mode: 0644
+    mode: '0644'
   notify: reload php-fpm
 
 - name: Disable default PHP-FPM pool

--- a/roles/wordpress-setup/tasks/nginx-client-cert.yml
+++ b/roles/wordpress-setup/tasks/nginx-client-cert.yml
@@ -3,6 +3,6 @@
   get_url:
     url: "{{ item.value.ssl.client_cert_url }}"
     dest: "{{ nginx_ssl_path }}/client-{{ (item.value.ssl.client_cert_url | hash('md5'))[:7] }}.crt"
-    mode: 0640
+    mode: '0640'
   with_dict: "{{ wordpress_sites }}"
   when: ssl_enabled and item.value.ssl.client_cert_url is defined

--- a/roles/wordpress-setup/tasks/nginx-includes.yml
+++ b/roles/wordpress-setup/tasks/nginx-includes.yml
@@ -13,7 +13,7 @@
   file:
     path: "{{ nginx_path }}/includes.d/{{ item }}"
     state: directory
-    mode: 0755
+    mode: '0755'
   with_items: "{{ nginx_includes_templates.files | map(attribute='path') |
                   map('regex_replace', nginx_includes_pattern, '\\2') |
                   map('dirname') | unique | list | sort
@@ -24,7 +24,7 @@
   template:
     src: "{{ item }}"
     dest: "{{ nginx_path }}/includes.d/{{ item | regex_replace(nginx_includes_pattern, '\\2') }}"
-    mode: 0644
+    mode: '0644'
   with_items: "{{ nginx_includes_templates.files | map(attribute='path') | list | sort(True) }}"
   notify: reload nginx
 

--- a/roles/wordpress-setup/tasks/nginx.yml
+++ b/roles/wordpress-setup/tasks/nginx.yml
@@ -3,7 +3,7 @@
   copy:
     src: "{{ item.value.ssl.cert }}"
     dest: "{{ nginx_ssl_path }}/{{ item.value.ssl.cert | basename }}"
-    mode: 0640
+    mode: '0640'
   with_dict: "{{ wordpress_sites }}"
   when: ssl_enabled and item.value.ssl.cert is defined
   notify: reload nginx
@@ -12,7 +12,7 @@
   copy:
     src: "{{ item.value.ssl.key }}"
     dest: "{{ nginx_ssl_path }}/{{ item.value.ssl.key | basename }}"
-    mode: 0600
+    mode: '0600'
   with_dict: "{{ wordpress_sites }}"
   when: ssl_enabled and item.value.ssl.key is defined
   notify: reload nginx
@@ -23,7 +23,7 @@
   template:
     src: "{{ item.src }}"
     dest: "{{ nginx_path }}/sites-available/{{ item.src | basename | regex_replace('.j2$', '') }}"
-    mode: 0644
+    mode: '0644'
   with_items: "{{ nginx_sites_confs }}"
   when: item.enabled | default(true)
   notify: reload nginx
@@ -53,14 +53,14 @@
   template:
     src: "{{ playbook_dir }}/roles/letsencrypt/templates/acme-challenge-location.conf.j2"
     dest: "{{ nginx_path }}/acme-challenge-location.conf"
-    mode: 0644
+    mode: '0644'
   notify: reload nginx
 
 - name: Create WordPress configuration for Nginx
   template:
     src: "{{ item.value.nginx_wordpress_site_conf | default(nginx_wordpress_site_conf) }}"
     dest: "{{ nginx_path }}/sites-available/{{ item.key }}.conf"
-    mode: 0644
+    mode: '0644'
   with_dict: "{{ wordpress_sites }}"
   notify: reload nginx
   tags: nginx-includes

--- a/roles/wordpress-setup/tasks/self-signed-certificate.yml
+++ b/roles/wordpress-setup/tasks/self-signed-certificate.yml
@@ -3,13 +3,13 @@
   file:
     path: "{{ nginx_ssl_path }}/self-signed-openssl-configs/"
     state: directory
-    mode: 0755
+    mode: '0755'
 
 - name: Template openssl configs
   template:
     src: self-signed-openssl-config.j2
     dest: "{{ nginx_ssl_path }}/self-signed-openssl-configs/{{ item.key }}.cnf"
-    mode: 0644
+    mode: '0644'
   with_dict: "{{ wordpress_sites | combine(ssl_default_site) }}"
   when:
     - sites_use_ssl | bool

--- a/roles/wp-cli/tasks/main.yml
+++ b/roles/wp-cli/tasks/main.yml
@@ -19,7 +19,7 @@
   copy:
     src: "{{ wp_cli_pgp_public_key }}"
     dest: /tmp/wp-cli.pgp.gpg
-    mode: 0744
+    mode: '0744'
 
 - name: Verify WP-CLI Phar Signature
   command: gpg2 --lock-never --no-default-keyring --keyring /tmp/wp-cli.pgp.gpg --verify /tmp/wp-cli-{{ wp_cli_version }}.phar.asc /tmp/wp-cli-{{ wp_cli_version }}.phar

--- a/roles/xdebug/tasks/main.yml
+++ b/roles/xdebug/tasks/main.yml
@@ -9,7 +9,7 @@
   template:
     src: xdebug.ini.j2
     dest: /etc/php/7.4/mods-available/xdebug.ini
-    mode: 0644
+    mode: '0644'
   notify: reload php-fpm
 
 - name: Ensure 20-xdebug.ini is present


### PR DESCRIPTION
Follow up #1270
Fix: https://discourse.roots.io/t/mode-must-be-in-octal-or-symbolic-form/20038

See: https://github.com/ansible/ansible/issues/31952#issuecomment-338042101