### PR TITLE
Update to PHP 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Trellis will configure a server with the following and more:
 
 - Ubuntu 20.04 Focal LTS
 - Nginx (with optional FastCGI micro-caching)
-- PHP 7.4
+- PHP 8.0
 - MariaDB (a drop-in MySQL replacement)
 - SSL support (scores an A+ on the [Qualys SSL Labs Test](https://www.ssllabs.com/ssltest/))
 - Let's Encrypt for free SSL certificates

--- a/dev.yml
+++ b/dev.yml
@@ -6,7 +6,7 @@
   roles:
     - { role: python_interpreter, tags: [always] }
 
-- name: "WordPress Server: Install LEMP Stack with PHP 7.4 and MariaDB MySQL"
+- name: "WordPress Server: Install LEMP Stack with PHP 8.0 and MariaDB MySQL"
   hosts: web:&development
   become: yes
   remote_user: vagrant

--- a/group_vars/all/users.yml
+++ b/group_vars/all/users.yml
@@ -19,4 +19,4 @@ users:
 web_user: web
 web_group: www-data
 web_sudoers:
-  - "/usr/sbin/service php7.4-fpm *"
+  - "/usr/sbin/service php8.0-fpm *"

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -9,7 +9,7 @@
 
 - name: reload php-fpm
   service:
-    name: php7.4-fpm
+    name: php8.0-fpm
     state: reloaded
 
 - import_tasks: reload_nginx.yml

--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -34,6 +34,6 @@
   when: wp_installed.rc == 0
 
 - name: Reload php-fpm
-  shell: sudo service php7.4-fpm reload
+  shell: sudo service php8.0-fpm reload
   args:
     warn: false

--- a/roles/memcached/defaults/main.yml
+++ b/roles/memcached/defaults/main.yml
@@ -8,7 +8,7 @@ memcached_port_udp: 0
 
 memcached_packages_default:
   memcached: "{{ apt_package_state }}"
-  php7.4-memcached: "{{ apt_package_state }}"
+  php8.0-memcached: "{{ apt_package_state }}"
 
 memcached_packages_custom: {}
 memcached_packages: "{{ memcached_packages_default | combine(memcached_packages_custom) }}"

--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -2,18 +2,18 @@ disable_default_pool: true
 memcached_sessions: false
 
 php_extensions_default:
-  php7.4-cli: "{{ apt_package_state }}"
-  php7.4-common: "{{ apt_package_state }}"
-  php7.4-curl: "{{ apt_package_state }}"
-  php7.4-dev: "{{ apt_package_state }}"
-  php7.4-fpm: "{{ apt_package_state }}"
-  php7.4-gd: "{{ apt_package_state }}"
-  php7.4-mbstring: "{{ apt_package_state }}"
-  php7.4-mysql: "{{ apt_package_state }}"
-  php7.4-opcache: "{{ apt_package_state }}"
-  php7.4-xml: "{{ apt_package_state }}"
-  php7.4-xmlrpc: "{{ apt_package_state }}"
-  php7.4-zip: "{{ apt_package_state }}"
+  php8.0-cli: "{{ apt_package_state }}"
+  php8.0-common: "{{ apt_package_state }}"
+  php8.0-curl: "{{ apt_package_state }}"
+  php8.0-dev: "{{ apt_package_state }}"
+  php8.0-fpm: "{{ apt_package_state }}"
+  php8.0-gd: "{{ apt_package_state }}"
+  php8.0-mbstring: "{{ apt_package_state }}"
+  php8.0-mysql: "{{ apt_package_state }}"
+  php8.0-opcache: "{{ apt_package_state }}"
+  php8.0-xml: "{{ apt_package_state }}"
+  php8.0-xmlrpc: "{{ apt_package_state }}"
+  php8.0-zip: "{{ apt_package_state }}"
 
 php_extensions_custom: {}
 php_extensions: "{{ php_extensions_default | combine(php_extensions_custom) }}"

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -20,7 +20,7 @@
 - name: Check for existing php7.4-fpm service
   stat:
     path: /etc/init.d/php7.4-fpm
-  register: php73_status
+  register: php74_status
 
 - name: Stop php7.4-fpm service if it exists
   service:

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -1,21 +1,35 @@
 ---
-- name: Add PHP 7.4 PPA
+- name: Add PHP 8.0 PPA
   apt_repository:
     repo: "ppa:ondrej/php"
     update_cache: yes
 
-- name: Install PHP 7.4
+- name: Install PHP 8.0
   apt:
     name: "{{ item.key }}"
     state: "{{ item.value }}"
     cache_valid_time: "{{ apt_cache_valid_time }}"
   with_dict: "{{ php_extensions }}"
 
-- name: Start php7.4-fpm service
+- name: Start php8.0-fpm service
   service:
-    name: php7.4-fpm
+    name: php8.0-fpm
     state: started
     enabled: true
+
+- name: Check for existing php7.4-fpm service
+  stat:
+    path: /etc/init.d/php7.4-fpm
+  register: php73_status
+
+- name: Stop php7.4-fpm service if it exists
+  service:
+    name: php7.4-fpm
+    state: stopped
+    enabled: false
+  register: service_stopped
+  when: php74_status.stat.exists
+  notify: reload php-fpm
 
 - name: Check for existing php7.3-fpm service
   stat:
@@ -48,12 +62,12 @@
 - name: Copy PHP-FPM configuration file
   template:
     src: php-fpm.ini.j2
-    dest: /etc/php/7.4/fpm/php.ini
+    dest: /etc/php/8.0/fpm/php.ini
     mode: '0644'
   notify: reload php-fpm
 
 - name: Copy PHP CLI configuration file
   template:
     src: php-cli.ini.j2
-    dest: /etc/php/7.4/cli/php.ini
+    dest: /etc/php/8.0/cli/php.ini
     mode: '0644'

--- a/roles/wordpress-setup/tasks/main.yml
+++ b/roles/wordpress-setup/tasks/main.yml
@@ -26,14 +26,14 @@
 - name: Create WordPress php-fpm configuration file
   template:
     src: php-fpm.conf.j2
-    dest: /etc/php/7.4/fpm/pool.d/wordpress.conf
+    dest: /etc/php/8.0/fpm/pool.d/wordpress.conf
     mode: '0644'
   notify: reload php-fpm
 
 - name: Disable default PHP-FPM pool
-  command: mv /etc/php/7.4/fpm/pool.d/www.conf /etc/php/7.4/fpm/pool.d/www.disabled
+  command: mv /etc/php/8.0/fpm/pool.d/www.conf /etc/php/8.0/fpm/pool.d/www.disabled
   args:
-    creates: /etc/php/7.4/fpm/pool.d/www.disabled
+    creates: /etc/php/8.0/fpm/pool.d/www.disabled
   when: disable_default_pool | default(true)
   notify: reload php-fpm
 

--- a/roles/xdebug/defaults/main.yml
+++ b/roles/xdebug/defaults/main.yml
@@ -1,4 +1,4 @@
-php_xdebug_package: php7.4-xdebug
+php_xdebug_package: php8.0-xdebug
 
 # XDebug Generic
 xdebug_output_dir: /tmp

--- a/roles/xdebug/tasks/main.yml
+++ b/roles/xdebug/tasks/main.yml
@@ -8,18 +8,18 @@
 - name: Template the Xdebug configuration file
   template:
     src: xdebug.ini.j2
-    dest: /etc/php/7.4/mods-available/xdebug.ini
+    dest: /etc/php/8.0/mods-available/xdebug.ini
     mode: '0644'
   notify: reload php-fpm
 
 - name: Ensure 20-xdebug.ini is present
   file:
-    src: /etc/php/7.4/mods-available/xdebug.ini
-    dest: /etc/php/7.4/fpm/conf.d/20-xdebug.ini
+    src: /etc/php/8.0/mods-available/xdebug.ini
+    dest: /etc/php/8.0/fpm/conf.d/20-xdebug.ini
     state: link
   notify: reload php-fpm
 
 - name: Disable Xdebug CLI
   file:
-    path: /etc/php/7.4/cli/conf.d/20-xdebug.ini
+    path: /etc/php/8.0/cli/conf.d/20-xdebug.ini
     state: absent

--- a/server.yml
+++ b/server.yml
@@ -16,7 +16,7 @@
   roles:
     - { role: python_interpreter, tags: [always] }
 
-- name: WordPress Server - Install LEMP Stack with PHP 7.4 and MariaDB MySQL
+- name: WordPress Server - Install LEMP Stack with PHP 8.0 and MariaDB MySQL
   hosts: web:&{{ env }}
   become: yes
   roles:

--- a/xdebug-tunnel.yml
+++ b/xdebug-tunnel.yml
@@ -15,5 +15,5 @@
   handlers:
     - name: reload php-fpm
       service:
-        name: php7.4-fpm
+        name: php8.0-fpm
         state: reloaded


### PR DESCRIPTION
This adds support for PHP 8.0, which requires WordPress 5.6+.