### PR TITLE
Improve handling of PHP versions

### DIFF
--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -1,8 +1,9 @@
-composer_keep_updated: true
 apt_cache_valid_time: 3600
 apt_package_state: present
 apt_security_package_state: latest
 apt_dev_package_state: latest
+composer_keep_updated: true
+php_version: "7.4"
 ntp_timezone: Etc/UTC
 ntp_manage_config: true
 www_root: /srv/www

--- a/group_vars/all/users.yml
+++ b/group_vars/all/users.yml
@@ -19,4 +19,4 @@ users:
 web_user: web
 web_group: www-data
 web_sudoers:
-  - "/usr/sbin/service php7.4-fpm *"
+  - "/usr/sbin/service php{{ php_version }}-fpm *"

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -9,7 +9,7 @@
 
 - name: reload php-fpm
   service:
-    name: php7.4-fpm
+    name: php{{ php_version }}-fpm
     state: reloaded
 
 - import_tasks: reload_nginx.yml

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -34,6 +34,18 @@
   when: item.value.site_hosts | rejectattr('canonical', 'defined') | list | count
   tags: [letsencrypt, wordpress]
 
+- name: Import PHP version specific vars
+  include_vars: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - '{{ php_version }}.yml'
+        - '7.4.yml'
+      paths:
+        - "{{ playbook_dir }}/roles/php/vars/"
+
+  tags: [php, memcached]
+
 - name: Verify dict format for apt package component variables
   fail:
     msg: "{{ lookup('template', 'package_vars_wrong_format_msg.j2') }}"

--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -34,6 +34,6 @@
   when: wp_installed.rc == 0
 
 - name: Reload php-fpm
-  shell: sudo service php7.4-fpm reload
+  shell: sudo service php{{ php_version }}-fpm reload
   args:
     warn: false

--- a/roles/memcached/defaults/main.yml
+++ b/roles/memcached/defaults/main.yml
@@ -8,7 +8,6 @@ memcached_port_udp: 0
 
 memcached_packages_default:
   memcached: "{{ apt_package_state }}"
-  php7.4-memcached: "{{ apt_package_state }}"
 
 memcached_packages_custom: {}
-memcached_packages: "{{ memcached_packages_default | combine(memcached_packages_custom) }}"
+memcached_packages: "{{ memcached_packages_default | combine(php_memcached_packages, memcached_packages_custom) }}"

--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -1,20 +1,6 @@
 disable_default_pool: true
 memcached_sessions: false
 
-php_extensions_default:
-  php7.4-cli: "{{ apt_package_state }}"
-  php7.4-common: "{{ apt_package_state }}"
-  php7.4-curl: "{{ apt_package_state }}"
-  php7.4-dev: "{{ apt_package_state }}"
-  php7.4-fpm: "{{ apt_package_state }}"
-  php7.4-gd: "{{ apt_package_state }}"
-  php7.4-mbstring: "{{ apt_package_state }}"
-  php7.4-mysql: "{{ apt_package_state }}"
-  php7.4-opcache: "{{ apt_package_state }}"
-  php7.4-xml: "{{ apt_package_state }}"
-  php7.4-xmlrpc: "{{ apt_package_state }}"
-  php7.4-zip: "{{ apt_package_state }}"
-
 php_extensions_custom: {}
 php_extensions: "{{ php_extensions_default | combine(php_extensions_custom) }}"
 

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -1,59 +1,48 @@
 ---
-- name: Add PHP 7.4 PPA
+- name: Add PHP PPA
   apt_repository:
     repo: "ppa:ondrej/php"
     update_cache: yes
 
-- name: Install PHP 7.4
+- name: Install PHP and extensions
   apt:
     name: "{{ item.key }}"
     state: "{{ item.value }}"
     cache_valid_time: "{{ apt_cache_valid_time }}"
   with_dict: "{{ php_extensions }}"
 
-- name: Start php7.4-fpm service
+- name: Start php fpm service
   service:
-    name: php7.4-fpm
+    name: "php{{ php_version }}-fpm"
     state: started
     enabled: true
 
-- name: Check for existing php7.3-fpm service
-  stat:
-    path: /etc/init.d/php7.3-fpm
-  register: php73_status
+- name: Find existing php fpm services
+  find:
+    paths: /etc/init.d
+    patterns: "^php((?!{{ php_version }})(\\d\\.\\d))-fpm$"
+    use_regex: true
+  register: old_php_fpm_services
 
-- name: Stop php7.3-fpm service if it exists
+- name: Stop old php-fpm services
   service:
-    name: php7.3-fpm
+    name: "{{ item.path | basename }}"
     state: stopped
     enabled: false
-  register: service_stopped
-  when: php73_status.stat.exists
-  notify: reload php-fpm
-
-- name: Check for existing php7.2-fpm service
-  stat:
-    path: /etc/init.d/php7.2-fpm
-  register: php72_status
-
-- name: Stop php7.2-fpm service if it exists
-  service:
-    name: php7.2-fpm
-    state: stopped
-    enabled: false
-  register: service_stopped
-  when: php72_status.stat.exists
+  loop: "{{ old_php_fpm_services.files }}"
+  loop_control:
+    label: "{{ item.path | basename }}"
   notify: reload php-fpm
 
 - name: Copy PHP-FPM configuration file
   template:
     src: php-fpm.ini.j2
-    dest: /etc/php/7.4/fpm/php.ini
+    dest: /etc/php/{{ php_version }}/fpm/php.ini
     mode: '0644'
   notify: reload php-fpm
 
 - name: Copy PHP CLI configuration file
   template:
     src: php-cli.ini.j2
-    dest: /etc/php/7.4/cli/php.ini
+    dest: /etc/php/{{ php_version }}/cli/php.ini
     mode: '0644'

--- a/roles/php/vars/7.4.yml
+++ b/roles/php/vars/7.4.yml
@@ -1,0 +1,16 @@
+php_extensions_default:
+  php7.4-cli: "{{ apt_package_state }}"
+  php7.4-curl: "{{ apt_package_state }}"
+  php7.4-dev: "{{ apt_package_state }}"
+  php7.4-fpm: "{{ apt_package_state }}"
+  php7.4-gd: "{{ apt_package_state }}"
+  php7.4-mbstring: "{{ apt_package_state }}"
+  php7.4-mysql: "{{ apt_package_state }}"
+  php7.4-xml: "{{ apt_package_state }}"
+  php7.4-xmlrpc: "{{ apt_package_state }}"
+  php7.4-zip: "{{ apt_package_state }}"
+
+php_memcached_packages:
+  php7.4-memcached: "{{ apt_package_state }}"
+
+php_xdebug_package: php7.4-xdebug

--- a/roles/php/vars/8.0.yml
+++ b/roles/php/vars/8.0.yml
@@ -1,0 +1,16 @@
+php_extensions_default:
+  php8.0-cli: "{{ apt_package_state }}"
+  php8.0-curl: "{{ apt_package_state }}"
+  php8.0-dev: "{{ apt_package_state }}"
+  php8.0-fpm: "{{ apt_package_state }}"
+  php8.0-gd: "{{ apt_package_state }}"
+  php8.0-mbstring: "{{ apt_package_state }}"
+  php8.0-mysql: "{{ apt_package_state }}"
+  php8.0-xml: "{{ apt_package_state }}"
+  php8.0-xmlrpc: "{{ apt_package_state }}"
+  php8.0-zip: "{{ apt_package_state }}"
+
+php_memcached_packages:
+  php8.0-memcached: "{{ apt_package_state }}"
+
+php_xdebug_package: php8.0-xdebug

--- a/roles/wordpress-setup/tasks/main.yml
+++ b/roles/wordpress-setup/tasks/main.yml
@@ -26,14 +26,14 @@
 - name: Create WordPress php-fpm configuration file
   template:
     src: php-fpm.conf.j2
-    dest: /etc/php/7.4/fpm/pool.d/wordpress.conf
+    dest: /etc/php/{{ php_version }}/fpm/pool.d/wordpress.conf
     mode: '0644'
   notify: reload php-fpm
 
 - name: Disable default PHP-FPM pool
-  command: mv /etc/php/7.4/fpm/pool.d/www.conf /etc/php/7.4/fpm/pool.d/www.disabled
+  command: mv /etc/php/{{ php_version }}/fpm/pool.d/www.conf /etc/php/{{ php_version }}/fpm/pool.d/www.disabled
   args:
-    creates: /etc/php/7.4/fpm/pool.d/www.disabled
+    creates: /etc/php/{{ php_version }}/fpm/pool.d/www.disabled
   when: disable_default_pool | default(true)
   notify: reload php-fpm
 

--- a/roles/xdebug/defaults/main.yml
+++ b/roles/xdebug/defaults/main.yml
@@ -1,5 +1,3 @@
-php_xdebug_package: php7.4-xdebug
-
 # XDebug Generic
 xdebug_output_dir: /tmp
 xdebug_trigger_value:

--- a/roles/xdebug/tasks/main.yml
+++ b/roles/xdebug/tasks/main.yml
@@ -8,18 +8,18 @@
 - name: Template the Xdebug configuration file
   template:
     src: xdebug.ini.j2
-    dest: /etc/php/7.4/mods-available/xdebug.ini
+    dest: /etc/php/{{ php_version }}/mods-available/xdebug.ini
     mode: '0644'
   notify: reload php-fpm
 
 - name: Ensure 20-xdebug.ini is present
   file:
-    src: /etc/php/7.4/mods-available/xdebug.ini
-    dest: /etc/php/7.4/fpm/conf.d/20-xdebug.ini
+    src: /etc/php/{{ php_version }}/mods-available/xdebug.ini
+    dest: /etc/php/{{ php_version }}/fpm/conf.d/20-xdebug.ini
     state: link
   notify: reload php-fpm
 
 - name: Disable Xdebug CLI
   file:
-    path: /etc/php/7.4/cli/conf.d/20-xdebug.ini
+    path: /etc/php/{{ php_version }}/cli/conf.d/20-xdebug.ini
     state: absent

--- a/xdebug-tunnel.yml
+++ b/xdebug-tunnel.yml
@@ -15,5 +15,5 @@
   handlers:
     - name: reload php-fpm
       service:
-        name: php7.4-fpm
+        name: php{{ php_version }}-fpm
         state: reloaded


### PR DESCRIPTION
Refactors how PHP and its extensions are installed per version. Previously all version references were hardcoded and updating to a new version (ie from `7.4` to `8.0`) meant replacing a bunch of version numbers across lots of files which made it difficult to use a different version than Trellis' default.

Now to switch to another PHP version that Trellis supports, only the `php_version` variable needs to be changed. And to support a new version, only a single version specific vars file needs to be created (example: `roles/php/vars/8.0.yml`).