### PR TITLE
Update `wp_cli_version` to 2.5.0

### DIFF
--- a/roles/wp-cli/defaults/main.yml
+++ b/roles/wp-cli/defaults/main.yml
@@ -1,5 +1,5 @@
 gpg2_package: gnupg2
-wp_cli_version: 2.4.0
+wp_cli_version: 2.5.0
 wp_cli_bin_path: /usr/bin/wp
 wp_cli_phar_url: "https://github.com/wp-cli/wp-cli/releases/download/v{{ wp_cli_version }}/wp-cli-{{ wp_cli_version }}.phar"
 wp_cli_phar_asc_url: "https://github.com/wp-cli/wp-cli/releases/download/v{{ wp_cli_version }}/wp-cli-{{ wp_cli_version }}.phar.asc"


### PR DESCRIPTION
https://make.wordpress.org/cli/2021/05/19/wp-cli-v2-5-0-release-notes/