### PR TITLE
Add php-intl extension

### DIFF
--- a/roles/php/vars/7.4.yml
+++ b/roles/php/vars/7.4.yml
@@ -4,6 +4,7 @@ php_extensions_default:
   php7.4-dev: "{{ apt_package_state }}"
   php7.4-fpm: "{{ apt_package_state }}"
   php7.4-gd: "{{ apt_package_state }}"
+  php7.4-intl: "{{ apt_package_state }}"
   php7.4-mbstring: "{{ apt_package_state }}"
   php7.4-mysql: "{{ apt_package_state }}"
   php7.4-xml: "{{ apt_package_state }}"

--- a/roles/php/vars/8.0.yml
+++ b/roles/php/vars/8.0.yml
@@ -4,6 +4,7 @@ php_extensions_default:
   php8.0-dev: "{{ apt_package_state }}"
   php8.0-fpm: "{{ apt_package_state }}"
   php8.0-gd: "{{ apt_package_state }}"
+  php8.0-intl: "{{ apt_package_state }}"
   php8.0-mbstring: "{{ apt_package_state }}"
   php8.0-mysql: "{{ apt_package_state }}"
   php8.0-xml: "{{ apt_package_state }}"


### PR DESCRIPTION
Per the WordPress Hosting Team recommendation: https://make.wordpress.org/hosting/2021/05/20/why-hosters-should-install-the-php-intl-extension/