### PR TITLE
Remove PHP version from messages

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -6,7 +6,7 @@
   roles:
     - { role: python_interpreter, tags: [always] }
 
-- name: "WordPress Server: Install LEMP Stack with PHP 7.4 and MariaDB MySQL"
+- name: "WordPress Server: Install LEMP Stack with PHP and MariaDB MySQL"
   hosts: web:&development
   become: yes
   remote_user: vagrant

--- a/server.yml
+++ b/server.yml
@@ -16,7 +16,7 @@
   roles:
     - { role: python_interpreter, tags: [always] }
 
-- name: WordPress Server - Install LEMP Stack with PHP 7.4 and MariaDB MySQL
+- name: WordPress Server - Install LEMP Stack with PHP and MariaDB MySQL
   hosts: web:&{{ env }}
   become: yes
   roles:


### PR DESCRIPTION
This PR removes the PHP versions from the messages.

Complements https://github.com/roots/trellis/pull/1284 (see https://github.com/roots/trellis/pull/1284#issuecomment-852086830).