### PR TITLE
Improve handling of WP-CLI failed verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Fix #1285 - Improve handling of WP-CLI failed verification ([#1295](https://github.com/roots/trellis/pull/1295))
 * Fix #1284 - Update logrotate postrotate Nginx command ([#1293](https://github.com/roots/trellis/pull/1293))
 * Replace php-gd with php-imagick ([#1292](https://github.com/roots/trellis/pull/1292))
 * Improve handling of PHP versions and support PHP 8.0 (default is still 7.4) ([#1284](https://github.com/roots/trellis/pull/1284))

--- a/roles/wp-cli/tasks/main.yml
+++ b/roles/wp-cli/tasks/main.yml
@@ -21,9 +21,22 @@
     dest: /tmp/wp-cli.pgp.gpg
     mode: '0744'
 
-- name: Verify WP-CLI Phar Signature
-  command: gpg2 --lock-never --no-default-keyring --keyring /tmp/wp-cli.pgp.gpg --verify /tmp/wp-cli-{{ wp_cli_version }}.phar.asc /tmp/wp-cli-{{ wp_cli_version }}.phar
-  changed_when: false
+- name: Verify WP-CLI
+  block:
+    - name: Check GPG signature
+      command: gpg2 --lock-never --no-default-keyring --keyring /tmp/wp-cli.pgp.gpg --verify /tmp/wp-cli-{{ wp_cli_version }}.phar.asc /tmp/wp-cli-{{ wp_cli_version }}.phar
+      changed_when: false
+  rescue:
+    - name: Delete invalid WP-CLI Phar file
+      file:
+        path: "{{ item }}"
+        state: absent
+      with_items:
+        - "/tmp/wp-cli-{{ wp_cli_version }}.phar"
+        - "/tmp/wp-cli-{{ wp_cli_version }}.phar.asc"
+    - name: Fail verification
+      fail:
+        msg: "WP-CLI Phar signature could not be verified. Please try again."
 
 - name: Install WP-CLI
   command: rsync -c --chmod=0755 --info=name /tmp/wp-cli-{{ wp_cli_version }}.phar {{ wp_cli_bin_path }}


### PR DESCRIPTION
Fixes #1295

Sometimes gpg signature verification for WP-CLI could fail due to network reasons (the downloaded phar or asc files were corrupt). In those cases the playbook will be a "stuck" state unless the files are manually deleted from the server.

This improves error handling by deleting both the phar and asc files which will allow Ansible to re-download them next time.