### PR TITLE
Manual config of ansible_ssh_extra_args should always take precedence

### DIFF
--- a/roles/connection/tasks/main.yml
+++ b/roles/connection/tasks/main.yml
@@ -12,7 +12,7 @@
   register: preferred_host_key_algorithms
   when:
     - dynamic_host_key_algorithms | default(true)
-    - not (not ansible_ssh_extra_args)
+    - not ansible_ssh_extra_args
     - not (ansible_host_known or ssh_config_host_known)
 
 - name: Check whether Ansible can connect as {{ dynamic_user | default(true) | ternary('root', web_user) }}


### PR DESCRIPTION
It appears that a lint fix inadvertently reversed the logic such that ansible_ssh_extra_args is overridden in cases where the host is not known (in my case, this was happening in a CI environment).

In my case, this was occurring in a CI environment. I had set `ansible_ssh_extra_args='-o StrictHostKeyChecking=no'`, but it was being overridden and causing the ssh-agent to fail it's connection due to a host lookup.

The change was introduced here: https://github.com/roots/trellis/commit/34689c23b82e1b5b58526c7dff03b34dcff65589

You can see in the diff that the logic was flipped. Given the commit message, I assume that this was a mistake.