### PR TITLE
Add php-bcmath extension

### DIFF
--- a/roles/php/vars/7.4.yml
+++ b/roles/php/vars/7.4.yml
@@ -1,4 +1,5 @@
 php_extensions_default:
+  php7.4-bcmath: "{{ apt_package_state }}"
   php7.4-cli: "{{ apt_package_state }}"
   php7.4-curl: "{{ apt_package_state }}"
   php7.4-dev: "{{ apt_package_state }}"

--- a/roles/php/vars/8.0.yml
+++ b/roles/php/vars/8.0.yml
@@ -1,4 +1,5 @@
 php_extensions_default:
+  php8.0-bcmath: "{{ apt_package_state }}"
   php8.0-cli: "{{ apt_package_state }}"
   php8.0-curl: "{{ apt_package_state }}"
   php8.0-dev: "{{ apt_package_state }}"


### PR DESCRIPTION
This commit was missing from #1292. It adds the PHP bc_math extension. Thanks, @strarsis!