### PR TITLE
Using variable for location instead of hard-coded

### DIFF
--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -32,7 +32,7 @@ project_templates:
 #     mode: '0755'      // <- optional, use an octal number starting with 0 or quote it, defaults to `'0755'` if `directory` or `'0644'` if `file`
 #     type: directory // <- optional, defaults to `directory`, options: `directory` or `file`
 project_shared_children:
-  - path: web/app/uploads
+  - path: "{{ location_path }}/app/uploads"
     src: uploads
 
 # The project_environment is a list of environment variables that can be used in hooks
@@ -58,6 +58,7 @@ composer_classmap_authoritative: true
 project: "{{ wordpress_sites[site] }}"
 project_root: "{{ www_root }}/{{ site }}"
 project_local_path: "{{ (lookup('env', 'USER') == 'vagrant') | ternary(project_root + '/' + project_current_path, project.local_path) }}"
+location_path: "{{ project.location_path | default('web') }}"
 
 
 # Deploy hooks

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -15,7 +15,7 @@ server {
   {% endblock %}
 
   {% block server_basic -%}
-  root  {{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/web;
+  root  {{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/{{ item.value.location_path | default('web') }};
   index index.php index.htm index.html;
   add_header Fastcgi-Cache $upstream_cache_status;
 


### PR DESCRIPTION
Currently `web` is hard-coded location path for nginx. This is true for bedrock. For sites which are not bedrock specific, it will be helpful to keep it configurable.
I know trellis only supports wordpress, but I am using this for even setting up laravel projects where the location path is `public` instead of `web`. I manually have to modify the nginx config, whenever I run ansible playbook for server.yml.