### PR TITLE
Remove explicit permission for site directory

### DIFF
--- a/roles/wordpress-install/tasks/directories.yml
+++ b/roles/wordpress-install/tasks/directories.yml
@@ -22,7 +22,6 @@
     path: "{{ www_root }}/{{ item.key }}"
     owner: "{{ web_user }}"
     group: "{{ web_group }}"
-    mode: '0755'
     state: directory
     recurse: yes
   with_dict: "{{ wordpress_sites }}"


### PR DESCRIPTION
Fixes #1311

The `mode` option was set in https://github.com/roots/trellis/pull/1270 for linting purposes. However, this can result in the permissions changing on local site files causing them to appear as changed in Git.

Since this directory is guaranteed to exist, we don't need to set `mode`. The purpose of this task is just to set the owner + group recursively.