### PR TITLE
Add default for composer_authentications

### DIFF
--- a/roles/deploy/hooks/build-after.yml
+++ b/roles/deploy/hooks/build-after.yml
@@ -20,7 +20,7 @@
     - composer_authentication.hostname is defined and composer_authentication.hostname != ""
     - composer_authentication.username is defined and composer_authentication.username != ""
     - composer_authentication.password is defined and composer_authentication.password != ""
-  loop: "{{ composer_authentications }}"
+  loop: "{{ composer_authentications | default([]) }}"
   loop_control:
     loop_var: composer_authentication
     label: "{{ composer_authentication.hostname }}"

--- a/roles/wordpress-install/tasks/composer-authentications.yml
+++ b/roles/wordpress-install/tasks/composer-authentications.yml
@@ -10,7 +10,7 @@
     - not (not composer_authentication.hostname)
     - not (not composer_authentication.username)
     - not (not composer_authentication.password)
-  loop: "{{ composer_authentications }}"
+  loop: "{{ composer_authentications | default([]) }}"
   loop_control:
     loop_var: composer_authentication
     label: "{{ composer_authentication.hostname }}"


### PR DESCRIPTION
This was a frequent cause of Trellis projects breaking during upgrades from before `composer_authentications` existed. Because the process involves copying over existing `group_vars`, the default variable wouldn't exist and these tasks would fail.

This solves it by supplying a local default where it's used.