### PR TITLE
Fix display output in logs

### DIFF
--- a/lib/trellis/utils/output.py
+++ b/lib/trellis/utils/output.py
@@ -102,17 +102,17 @@ def display(obj, result):
     hr = '-' * int(wrap_width*.67)
 
     if obj.task_failed and first:
-        display(system(obj.vagrant_version), 'bright gray')
-        display(hr, 'bright gray')
+        display(system(obj.vagrant_version), 'bright gray', screen_only=True)
+        display(hr, 'bright gray', screen_only=True)
 
     if msg == '':
         if obj.task_failed and not first:
-            display(hr, 'bright gray')
+            display(hr, 'bright gray', screen_only=True)
         else:
             return
     else:
         if not first:
-            display(hr, 'bright gray')
+            display(hr, 'bright gray', screen_only=True)
         display(msg, 'red' if obj.task_failed else 'bright purple')
 
 def display_host(obj, result):


### PR DESCRIPTION
Background: https://github.com/roots/trellis/pull/1235#issuecomment-729621213

Ansible bases the log level based on colour (yeah, it's dumb) when logging is enabled. `bright gray` was a valid log level mapping.

Instead of trying to pick some other colur supported in both contexts, we can just set `screen_only` to skip these messages which are meant for STDOUT anyway.

cc @strarsis 