### PR TITLE
Improve ARM support - remove explicit arch deb options

### DIFF
--- a/roles/mariadb/defaults/main.yml
+++ b/roles/mariadb/defaults/main.yml
@@ -1,6 +1,6 @@
 mariadb_keyserver: "hkp://keyserver.ubuntu.com:80"
 mariadb_keyserver_id: "0xF1656F24C74CD1D8"
-mariadb_ppa: "deb [arch=amd64] http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.5/ubuntu {{ ansible_distribution_release }} main"
+mariadb_ppa: "deb http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.5/ubuntu {{ ansible_distribution_release }} main"
 
 mariadb_client_package: mariadb-client
 mariadb_server_package: mariadb-server

--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 nginx_keyserver: "https://nginx.org/keys/nginx_signing.key"
 nginx_keyserver_id: "ABF5BD827BD9BF62"
-nginx_ppa: "deb [arch=amd64] http://nginx.org/packages/mainline/ubuntu {{ ansible_distribution_release }} nginx"
+nginx_ppa: "deb http://nginx.org/packages/mainline/ubuntu {{ ansible_distribution_release }} nginx"
 nginx_package: nginx
 nginx_conf: nginx.conf.j2
 nginx_path: /etc/nginx


### PR DESCRIPTION
Apt defaults to the architecture supported by `dpkg`, which defaults to the actual architecture of the OS (as it should). Removing this explicit `arc=amd64` option just means we'll get the smart default which improves support for `arm64` (Apple M1 CPUs primarily).