### PR TITLE
Change MariaDB mirror source

### DIFF
--- a/roles/mariadb/defaults/main.yml
+++ b/roles/mariadb/defaults/main.yml
@@ -1,6 +1,6 @@
 mariadb_keyserver: "hkp://keyserver.ubuntu.com:80"
 mariadb_keyserver_id: "0xF1656F24C74CD1D8"
-mariadb_ppa: "deb http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.5/ubuntu {{ ansible_distribution_release }} main"
+mariadb_ppa: "deb http://mirrors.gigenet.com/mariadb/repo/10.5/ubuntu {{ ansible_distribution_release }} main"
 
 mariadb_client_package: mariadb-client
 mariadb_server_package: mariadb-server


### PR DESCRIPTION
Digitalocean has proven to be an unreliable mirror so let's switch to another one (from the official MariaDB site).