### PR TITLE
Enable pipelining for local connections

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -8,8 +8,8 @@ inventory = hosts
 nocows = 1
 roles_path = vendor/roles
 vars_plugins = ~/.ansible/plugins/vars:/usr/share/ansible/plugins/vars:lib/trellis/plugins/vars
+pipelining = True
 
 [ssh_connection]
 ssh_args = -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s
-pipelining = True
 retries = 1


### PR DESCRIPTION
Enabling pipelining for SSH connections only means that `become`/ `become_user` behaves differently for vagrant, than it does VMs over SSH. Moving this config to the defaults makes both vagrant and VMs behave the same. We may see some local speed improvements on local provisions as a result.

There are no issues this fixes, however, this ensures closer environment parity.

To replicate the potential future issue this fixes you can do the following:

- Create a new ubuntu user without sudo privileges in dev.yml
- Create a task that is ran by that user using become_user

This task will fail stating that Ansible does not have permission to edit necessary temporary files, which directs you to enable pipelining or ACL. As outlined here: https://docs.ansible.com/ansible/latest/user_guide/become.html#risks-of-becoming-an-unprivileged-user

Perform the same tasks in server.yml over SSH and the tasks will pass