### PR TITLE
Remove ssl_dhparam and Diffie-Hellman group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### HEAD
+* Remove Nginx `ssl_dhparam` directive and Diffie-Hellman params group ([#1326](https://github.com/roots/trellis/pull/1326))
+
 ### 1.10.0: November 28th, 2021
 * Default to PHP 8.0 ([#1322](https://github.com/roots/trellis/pull/1322))
 * Add GitHub SSH ed25519 key to known hosts ([#1324](https://github.com/roots/trellis/pull/1324))

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -30,15 +30,6 @@
     path: "{{ nginx_path }}/ssl"
     state: directory
 
-- name: Generate strong unique Diffie-Hellman group.
-  command: openssl dhparam -out dhparams.pem 2048
-  args:
-    chdir: "{{ nginx_path }}/ssl"
-    creates: "{{ nginx_path }}/ssl/dhparams.pem"
-  when: sites_use_ssl | bool
-  notify: reload nginx
-  tags: [diffie-hellman, letsencrypt, wordpress, wordpress-setup, nginx-includes, nginx-sites]
-
 - name: Copy h5bp configs
   copy:
     src: templates/h5bp

--- a/roles/wordpress-setup/templates/ssl.no-default.conf.j2
+++ b/roles/wordpress-setup/templates/ssl.no-default.conf.j2
@@ -12,7 +12,6 @@ server {
   listen 443 ssl default_server deferred;
 
   include h5bp/directive-only/ssl.conf;
-  ssl_dhparam /etc/nginx/ssl/dhparams.pem;
 
   ssl_certificate         {{ nginx_path }}/ssl/no_default.cert;
   ssl_trusted_certificate {{ nginx_path }}/ssl/no_default.cert;

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -75,7 +75,6 @@ server {
   include h5bp/directive-only/ssl-stapling.conf;
   {% endif -%}
 
-  ssl_dhparam /etc/nginx/ssl/dhparams.pem;
   ssl_buffer_size 1400; # 1400 bytes to fit in one MTU
 
   {% if item.value.ssl.provider | default('manual') != 'self-signed' -%}


### PR DESCRIPTION
This was needed to prevent Logjam attacks but those only applied to DHE cyphers which haven't been supported in Trellis for 2 years.