### PR TITLE
chore(github): fix typos in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -48,7 +48,7 @@ body:
       label: Steps To Reproduce
       description: |
         Non-reproducible issues may be immediately closed as not actionable.
-        Please provide reproduction steps as details as possible.
+        Please provide reproduction steps as detailed as possible.
       value: |
         1.
         1.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,7 +8,7 @@ body:
     attributes:
       value: |
         This form is for suggesting an idea for Trellis.
-        If want to ask a question is looking for support, [Roots Discourse](https://discourse.roots.io/) is the best place for getting support.
+        If you have a question or you're looking for support, please visit [Roots Discourse](https://discourse.roots.io/).
 
   - type: checkboxes
     id: terms


### PR DESCRIPTION
This fixes a couple of typos in the issue templates. These mirror the corrections made for the new issues templates added in roots/.github#8 (I copied Trellis’ to use more generically over there).
