### PR TITLE
Require Vagrant < 2.2.19

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,7 @@ ensure_plugins(vconfig.fetch('vagrant_plugins')) if vconfig.fetch('vagrant_insta
 
 trellis_config = Trellis::Config.new(root_path: ANSIBLE_PATH)
 
-Vagrant.require_version '>= 2.1.0'
+Vagrant.require_version '>= 2.1.0', '< 2.2.19'
 
 Vagrant.configure('2') do |config|
   config.vm.box = vconfig.fetch('vagrant_box')


### PR DESCRIPTION
2.2.19 has a bug affecting macOS Big Sur and should be avoided.