### PR TITLE
Set default for ansible_ssh_extra_args

### DIFF
--- a/roles/connection/tasks/main.yml
+++ b/roles/connection/tasks/main.yml
@@ -12,7 +12,7 @@
   register: preferred_host_key_algorithms
   when:
     - dynamic_host_key_algorithms | default(true)
-    - not ansible_ssh_extra_args
+    - not ansible_ssh_extra_args | default(None)
     - not (ansible_host_known or ssh_config_host_known)
 
 - name: Check whether Ansible can connect as {{ dynamic_user | default(true) | ternary('root', web_user) }}


### PR DESCRIPTION
ansible-base in 2.10.16 changed how SSH option defaults worked breaking this. Just ensuring it has a proper default instead of undefined solves the issue.