### PR TITLE
Add ansible-base to requirements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ workflows:
           matrix:
             parameters:
               python-version: ["3.7.8", "2.7"]
-              ansible-version: ["~=2.9.0", "~=2.8.0"]
+              ansible-version: ["~=2.10.0"]
       - syntax-check-with-requirements-txt:
           name: syntax-check-python-<<matrix.python-version>>-requirements-txt
           matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### 1.11.0: December 10th, 2021
+* Bump minimum ansible version to `2.10.0` and add `ansible-base` to requirements ([#1334](https://github.com/roots/trellis/pull/1334))
 * Fix Ansible `2.10.16` - set default for `ansible_ssh_extra_args` ([#1333](https://github.com/roots/trellis/pull/1333))
 * Set max supported Vagrant version to `< 2.2.19` ([#1332](https://github.com/roots/trellis/pull/1332))
 * Bump `vagrant_ansible_version` to `2.10.7` ([#1329](https://github.com/roots/trellis/pull/1329))

--- a/lib/trellis/plugins/vars/version.py
+++ b/lib/trellis/plugins/vars/version.py
@@ -14,8 +14,8 @@ except ImportError:
     from ansible.utils.display import Display
     display = Display()
 
-version_requirement = '2.8.0'
-version_tested_max = '2.10.7'
+version_requirement = '2.10.0'
+version_tested_max = '2.10.16'
 python3_required_version = '2.5.3'
 
 if version_info[0] == 3 and not ge(LooseVersion(__version__), LooseVersion(python3_required_version)):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-ansible>=2.8.0,<3.0
+ansible>=2.10.0,<3.0
+ansible-base>=2.10,<=2.10.16
 passlib


### PR DESCRIPTION
The Ansible ecosystem has changed how their versions and packages work causing the main `ansible` package versions to no longer determine the version of `ansible-playbook`. Instead, the new `ansible-base` package is what matters.

Background: https://blog.while-true-do.io/ansible-release-3-0-0/

For example, installing `ansible==2.10.7` would result in `ansible-playbook==2.10.16` which was confusing.

By adding `ansible-base` to our `requirements.txt`, we'll get more consistent and predictable version constraints.

Installing `ansible-base==2.10.16` would result in `ansible-playbook==2.10.16` as you'd expect.