### PR TITLE
Simplify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,17 +78,9 @@ Full documentation is available at [https://docs.roots.io/trellis/master/install
 
 ## Requirements
 
-Make sure all dependencies have been installed before moving on:
-
-- [Virtualbox](https://www.virtualbox.org/wiki/Downloads) >= 4.3.10
-- [Vagrant](https://www.vagrantup.com/downloads.html) >= 2.1.0
-- **Recommended**: [trellis-cli](https://github.com/roots/trellis-cli)
-
-**Windows user?** [Read the Windows getting started docs](https://docs.roots.io/getting-started/windows/#working-with-trellis) for slightly different installation instructions.
+See the full [installation](https://docs.roots.io/trellis/master/installation/#installation) docs for requirements and our [getting started pages](https://docs.roots.io/getting-started) for more OS specific instructions.
 
 ## Installation
-
-### Using trellis-cli
 
 Create a new project:
 
@@ -96,42 +88,7 @@ Create a new project:
 $ trellis new example.com
 ```
 
-### Manual
-
-The recommended directory structure for a Trellis project looks like:
-
-```bash
-example.com/      # → Root folder for the project
-├── trellis/      # → Your clone of this repository
-└── site/         # → A Bedrock-based WordPress site
-    └── web/
-        ├── app/  # → WordPress content directory (themes, plugins, etc.)
-        └── wp/   # → WordPress core (don't touch!)
-```
-
-See a complete working example in the [roots-example-project.com repo](https://github.com/roots/roots-example-project.com).
-
-1. Create a new project directory:
-
-```bash
-$ mkdir example.com && cd example.com
-```
-
-2. Install Trellis:
-
-```bash
-$ git clone --depth=1 git@github.com:roots/trellis.git && rm -rf trellis/.git
-```
-
-3. Install Bedrock into the `site` directory:
-
-```bash
-$ composer create-project roots/bedrock site
-```
-
 ## Local development setup
-
-### Using trellis-cli
 
 1. Review the automatically created site in `group_vars/development/wordpress_sites.yml`
 2. Customize settings if necessary
@@ -142,12 +99,6 @@ Start the Vagrant virtual machine:
 $ trellis up
 ```
 
-### Manual
-
-1. Configure your WordPress sites in `group_vars/development/wordpress_sites.yml` and in `group_vars/development/vault.yml`
-2. Ensure you're in the trellis directory: `cd trellis`
-3. Run `vagrant up`
-
 [Read the local development docs](https://docs.roots.io/trellis/master/local-development/#wordpress-installation) for more information.
 
 ## Remote server setup (staging/production)
@@ -157,14 +108,6 @@ A base Ubuntu 18.04 (Bionic) or Ubuntu 20.04 (Focal LTS) server is required for 
 1. Configure your WordPress sites in `group_vars/<environment>/wordpress_sites.yml` and in `group_vars/<environment>/vault.yml` (see the [Vault docs](https://docs.roots.io/trellis/master/vault/) for how to encrypt files containing passwords)
 2. Add your server IP/hostnames to `hosts/<environment>`
 3. Specify public SSH keys for `users` in `group_vars/all/users.yml` (see the [SSH Keys docs](https://docs.roots.io/trellis/master/ssh-keys/))
-
-### Using trellis-cli
-
-Initialize Trellis (Virtualenv) environment:
-
-```bash
-$ trellis init
-```
 
 Provision the server:
 
@@ -178,24 +121,12 @@ Or take advantage of its [Digital Ocean](https://roots.io/r/digitalocean) suppor
 $ trellis droplet create production
 ```
 
-### Manual
-
-For remote servers, installing Ansible locally is an additional requirement. See the [docs](https://docs.roots.io/trellis/master/remote-server-setup/#requirements) for more information.
-
-Provision the server:
-
-```bash
-$ ansible-playbook server.yml -e env=<environment>
-```
-
 [Read the remote server docs](https://docs.roots.io/trellis/master/remote-server-setup/) for more information.
 
 ## Deploying to remote servers
 
 1. Add the `repo` (Git URL) of your Bedrock WordPress project in the corresponding `group_vars/<environment>/wordpress_sites.yml` file
 2. Set the `branch` you want to deploy (defaults to `master`)
-
-### Using trellis-cli
 
 Deploy a site:
 
@@ -209,21 +140,16 @@ Rollback a deploy:
 $ trellis rollback <environment> <site>
 ```
 
-### Manual
-
-Deploy a site:
-
-```bash
-$ ./bin/deploy.sh <environment> <site>
-```
-
-Rollback a deploy:
-
-```bash
-$ ansible-playbook rollback.yml -e "site=<site> env=<environment>"
-```
-
 [Read the deploys docs](https://roots.io/docs/trellis/master/deployments/) for more information.
+
+## Migrating existing projects to trellis-cli:
+
+Assuming you're using the standard project structure, you just need to make the
+project trellis-cli compatible by initializing it:
+
+```bash
+$ trellis init
+```
 
 ## Contributing
 


### PR DESCRIPTION
This removes the "manual" docs from the README and focuses on the trellis-cli workflow. This README isn't meant to be the full documentation anyway.