### PR TITLE
Fixes #1319 - Improve how ssh_args are loaded

### DIFF
--- a/lib/trellis/plugins/callback/vars.py
+++ b/lib/trellis/plugins/callback/vars.py
@@ -3,6 +3,7 @@ __metaclass__ = type
 
 import re
 import sys
+import os
 
 from __main__ import cli
 from ansible.module_utils.six import iteritems
@@ -14,6 +15,7 @@ from ansible.plugins.callback import CallbackBase
 from ansible.template import Templar
 from ansible.utils.unsafe_proxy import wrap_var
 from ansible import context
+from ansible.plugins.loader import connection_loader
 
 
 class CallbackModule(CallbackBase):
@@ -94,6 +96,9 @@ class CallbackModule(CallbackBase):
             return True
 
     def v2_playbook_on_play_start(self, play):
+        play_context = PlayContext(play=play)
+        connection = connection_loader.get('ssh', play_context, os.devnull)
+
         env = play.get_variable_manager().get_vars(play=play).get('env', '')
         env_group = next((group for key,group in iteritems(play.get_variable_manager()._inventory.groups) if key == env), False)
         if env_group:
@@ -102,7 +107,7 @@ class CallbackModule(CallbackBase):
         for host in play.get_variable_manager()._inventory.list_hosts(play.hosts[0]):
             hostvars = play.get_variable_manager().get_vars(play=play, host=host)
             self.raw_vars(play, host, hostvars)
-            host.vars['ssh_args_default'] = PlayContext(play=play)._ssh_args.default
+            host.vars['ssh_args_default'] = connection.get_option('ssh_args')
             host.vars['cli_options'] = self.cli_options()
             host.vars['cli_ask_pass'] = self._options.get('ask_pass', False)
             host.vars['cli_ask_become_pass'] = self._options.get('become_ask_pass', False)


### PR DESCRIPTION
This refactors how `ssh_args` are loaded since the private method `_ssh_args` on `PlayContext` has been removed in Ansible 2.11.

Instead, we load the ssh plugin and get the option directly.