### PR TITLE
Update default Vagrant IP to `192.168.56.5`

### DIFF
--- a/hosts/development
+++ b/hosts/development
@@ -35,7 +35,7 @@
 # into the Vagrantfile's `config.vm.provision` section.
 
 [development]
-192.168.50.5 ansible_connection=local
+192.168.56.5 ansible_connection=local
 
 [web]
-192.168.50.5 ansible_connection=local
+192.168.56.5 ansible_connection=local

--- a/vagrant.default.yml
+++ b/vagrant.default.yml
@@ -1,5 +1,5 @@
 ---
-vagrant_ip: '192.168.50.5'
+vagrant_ip: '192.168.56.5'
 vagrant_cpus: 1
 vagrant_memory: 1024 # in MB
 vagrant_box: 'bento/ubuntu-20.04'


### PR DESCRIPTION
Changes the default `vagrant_ip` from `192.168.50.5` to `192.168.56.5` (note the subtle change from `50` -> `56`).

A recent change in VirtualBox means that only IP addresses in the 192.168.56.0/21 range are allowed.

Vagrant is now validating that the IP is within this range as well (https://github.com/hashicorp/vagrant/pull/12564).