### PR TITLE
feat: ✨ test for ACME file over SSL, + more logging

### DIFF
--- a/roles/letsencrypt/library/test_challenges.py
+++ b/roles/letsencrypt/library/test_challenges.py
@@ -4,10 +4,10 @@
 import socket
 
 try:
-    from httplib import HTTPConnection, HTTPException
+    from httplib import HTTPConnection, HTTPSConnection, HTTPException
 except ImportError:
     # Python 3
-    from http.client import HTTPConnection, HTTPException
+    from http.client import HTTPConnection, HTTPSConnection, HTTPException
 
 DOCUMENTATION = '''
 ---
@@ -22,6 +22,12 @@ options:
     required: true
     default: null
     type: list
+  ssl:
+    description:
+      - If true, will check on SSL port as well.
+    required: false
+    default: false
+    type: bool
   file:
     description:
       - The dummy filename in the URL to test.
@@ -45,21 +51,49 @@ EXAMPLES = '''
       - www.mydomain.com
 '''
 
-def get_status(host, path, file):
+def get_connection(host, port):
+    if port == 80:
+        conn = HTTPConnection(host, port)
+    elif port == 443:
+        conn = HTTPSConnection(host, port)
+    return conn
+
+def get_status(host, port, path, file):
+    uri = '{0}:{1}/{2}/{3}'.format(host,port,path,file)
+    request = {
+        'hostname': host,
+        'uri': uri,
+    }
+
     try:
-        conn = HTTPConnection(host)
+        conn = get_connection(host, port)
         conn.request('HEAD', '/{0}/{1}'.format(path, file))
         res = conn.getresponse()
-    except (HTTPException, socket.timeout, socket.error):
-        return 0
+    except (HTTPException, socket.timeout, socket.error) as e:
+        results = {
+            'headers': None,
+            'reason': None,
+            'status': -1, # a flag indicating failure.
+        }
+        exception = {
+            'exception': str(e),
+        }
+        return {**request, **results, **exception}
+
     else:
-        return res.status
+        results = {
+            'status': res.status,
+            'headers': res.getheaders(),
+            'reason': res.reason,
+        }
+        return {**request, **results}
 
 def main():
     module = AnsibleModule(
         argument_spec = dict(
             file  = dict(default='ping.txt'),
             hosts = dict(required=True, type='list'),
+            ssl = dict(default=False, type='bool'),
             path  = dict(default='.well-known/acme-challenge')
         )
     )
@@ -67,21 +101,35 @@ def main():
     hosts = module.params['hosts']
     path = module.params['path']
     file = module.params['file']
+    ssl = module.params['ssl']
 
     failed_hosts = []
 
     for host in hosts:
-        status = get_status(host, path, file)
+        result = get_status(host, 80, path, file)
+        status = result['status']
+
+        if int(status) != 200 and bool(ssl) == True:
+            failed_hosts.append(result)
+            # Try again, this time over SSL
+            result = get_status(host, 443, path, file)
+            status = result['status']
+
         if int(status) != 200:
-            failed_hosts.append(host)
+            failed_hosts.append(result)
 
     rc = int(len(failed_hosts) > 0)
 
-    module.exit_json(
+    module_result = dict(
         changed=False,
         rc=rc,
         failed_hosts=failed_hosts
     )
+
+    if (rc != 0):
+        module.fail_json(msg='Failed to fetch the ACME test file', **module_result)
+    else:
+        module.exit_json(**module_result)
 
 from ansible.module_utils.basic import *
 main()

--- a/roles/letsencrypt/tasks/nginx.yml
+++ b/roles/letsencrypt/tasks/nginx.yml
@@ -49,6 +49,7 @@
 - name: Test Acme Challenges
   test_challenges:
     hosts: "{{ site_hosts }}"
+    ssl: true
   register: letsencrypt_test_challenges
   ignore_errors: true
   when: site_uses_letsencrypt
@@ -56,11 +57,20 @@
 
 - name: Notify of challenge failures
   fail:
-    msg: >
-      Could not access the challenge file for the hosts/domains: {{ item.failed_hosts | join(', ') }}.
+    msg: |
+      Could not access the challenge file for the hosts/domains:
+      {{ item.failed_hosts | join(', ', attribute='hostname') }}
+
+      Details:
+      {% for failed in item.failed_hosts %}
+      {{ failed.status }} {{ failed.uri }}
+      {% endfor %}
+
       Let's Encrypt requires every domain/host be publicly accessible.
-      Make sure that a valid DNS record exists for {{ item.failed_hosts | join(', ') }} and that they point to this server's IP.
-      If you don't want these domains in your SSL certificate, then remove them from `site_hosts`.
-      See https://roots.io/trellis/docs/ssl for more details.
+      Make sure that a valid DNS record exists for each host and that
+      they point to this server's IP.
+
+      If you don't want these domains in your SSL certificate, then
+      remove them from `site_hosts`. See https://roots.io/trellis/docs/ssl for more details.
   when: item is not skipped and item is failed
   with_items: "{{ letsencrypt_test_challenges.results }}"


### PR DESCRIPTION
Resolves #1340 

Consider this a rough initial PR, ready for review/discussion. I'm happy to make changes as needed.

Things to consider:

* is it really necessary to have the `ssl` config option (maybe we just recognize a potential 301 HTTP->HTTPS redirect and follow it?
* I haven't renamed `get_status` function, but now that it returns more than just the HTTP status, perhaps I should

## Example output

Below is an example where I've just changed the filename to force what happens when the file is inaccessible 

```
TASK [letsencrypt : Test Acme Challenges] **************************************
System info:
  Ansible 2.10.11; Darwin
  Trellis 1.8.0: February 12th, 2021
---------------------------------------------------
Failed to test ACME file
failed: [example.com] (item=example.com) => {"ansible_loop_var": "item", "changed": false, "failed_hosts": [{"headers": [["Date", "Thu, 23 Dec 2021 22:57:40 GMT"], ["Connection", "keep-alive"], ["Cache-Control", "max-age=3600"], ["Expires", "Thu, 23 Dec 2021 23:57:40 GMT"], ["Location", "https://example.com/.well-known/acme-challenge/missing.txt"], ["Vary", "Accept-Encoding"], ["Server", "cloudflare"], ["CF-RAY", "6c2530b19d5e62d3-SYD"]], "hostname": "example.com", "reason": "Moved Permanently", "status": 301, "uri": "example.com:80/.well-known/acme-challenge/missing.txt"}, {"headers": [["Date", "Thu, 23 Dec 2021 22:57:40 GMT"], ["Content-Type", "text/html; charset=utf-8"], ["Connection", "keep-alive"], ["X-Content-Type-Options", "nosniff"], ["X-XSS-Protection", "1; mode=block"], ["Content-Security-Policy", "frame-ancestors 'self'"], ["X-Frame-Options", "SAMEORIGIN"], ["CF-Cache-Status", "DYNAMIC"], ["Expect-CT", "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\""], ["Server", "cloudflare"], ["CF-RAY", "6c2530b1c800559f-SYD"]], "hostname": "example.com", "reason": "Not Found", "status": 404, "uri": "example.com:443/.well-known/acme-challenge/missing.txt"}], "item": {"key": "example.com", "value": {"admin_email": "user@example.org", "branch": "main", "cache": {"enabled": false}, "deploy_keep_releases": 10, "local_path": "../site", "multisite": {"enabled": false}, "repo": "git@github.com:example/wp-bedrock.git", "site_hosts": [{"canonical": "example.com", "redirects": []}], "ssl": {"enabled": true, "provider": "letsencrypt"}}}, "rc": 1}
...ignoring

TASK [letsencrypt : Notify of challenge failures] ******************************
System info:
  Ansible 2.10.11; Darwin
  Trellis 1.8.0: February 12th, 2021
---------------------------------------------------
Could not access the challenge file for the hosts/domains:
example.com, example.com

Details:
301 example.com:80/.well-known/acme-challenge/missing.txt
404 example.com:443/.well-known/acme-challenge/missing.txt

Let's Encrypt requires every domain/host be publicly accessible.
Make sure that a valid DNS record exists for each host and that
they point to this server's IP.

If you don't want these domains in your SSL certificate, then
remove them from `site_hosts`. See https://roots.io/trellis/docs/ssl for more
details.
failed: [example.com] (item=example.com) => {"ansible_loop_var": "item", "changed": false, "item": {"ansible_loop_var": "item", "changed": false, "failed": true, "failed_hosts": [{"headers": [["Date", "Thu, 23 Dec 2021 22:57:40 GMT"], ["Connection", "keep-alive"], ["Cache-Control", "max-age=3600"], ["Expires", "Thu, 23 Dec 2021 23:57:40 GMT"], ["Location", "https://example.com/.well-known/acme-challenge/missing.txt"], ["Vary", "Accept-Encoding"], ["Server", "cloudflare"], ["CF-RAY", "6c2530b19d5e6243"]], "hostname": "example.com", "reason": "Moved Permanently", "status": 301, "uri": "example.com:80/.well-known/acme-challenge/missing.txt"}, {"headers": [["Date", "Thu, 23 Dec 2021 22:57:40 GMT"], ["Content-Type", "text/html; charset=utf-8"], ["Connection", "keep-alive"], ["X-Content-Type-Options", "nosniff"], ["X-XSS-Protection", "1; mode=block"], ["Content-Security-Policy", "frame-ancestors 'self'"], ["X-Frame-Options", "SAMEORIGIN"], ["CF-Cache-Status", "DYNAMIC"], ["Expect-CT", "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\""], ["Server", "cloudflare"], ["CF-RAY", "6c2530b1c800559e"]], "hostname": "example.com", "reason": "Not Found", "status": 404, "uri": "example.com:443/.well-known/acme-challenge/missing.txt"}], "invocation": {"module_args": {"file": "ping.txt", "hosts": ["example.com"], "path": ".well-known/acme-challenge", "ssl": true}}, "item": {"key": "example.com", "value": {"admin_email": "user@example.org", "branch": "main", "cache": {"enabled": false}, "deploy_keep_releases": 10, "local_path": "../site", "multisite": {"enabled": false}, "repo": "git@github.com:example/wp-bedrock.git", "site_hosts": [{"canonical": "example.com", "redirects": []}], "ssl": {"enabled": true, "provider": "letsencrypt"}}}, "msg": "Failed to test ACME file", "rc": 1}}
```


Below is an example where `example.com` (some good host) has a typo like `example.comuu` (extra 'uu') so we see the "-1" status in the details and the "Name or service not known" in the JSON holding the full details.

```
TASK [letsencrypt : Test Acme Challenges] **************************************
System info:
  Ansible 2.10.11; Darwin
  Trellis 1.8.0: February 12th, 2021
---------------------------------------------------
Failed to test ACME file
failed: [example.com] (item=example.com) => {"ansible_loop_var": "item", "changed": false, "failed_hosts": [{"exception": "[Errno -2] Name or service not known", "headers": null, "hostname": "example.comuu", "reason": null, "status": -1, "uri": "example.comuu:80/.well-known/acme-challenge/ping.txt"}, {"exception": "[Errno -2] Name or service not known", "headers": null, "hostname": "example.comuu", "reason": null, "status": -1, "uri": "example.comuu:443/.well-known/acme-challenge/ping.txt"}], "item": {"key": "example.com", "value": {"admin_email": "user@example.org", "branch": "main", "cache": {"enabled": false}, "deploy_keep_releases": 10, "local_path": "../site", "multisite": {"enabled": false}, "repo": "git@github.com:example/wp-bedrock.git", "site_hosts": [{"canonical": "example.com", "redirects": []}], "ssl": {"enabled": true, "provider": "letsencrypt"}}}, "rc": 1}
...ignoring

TASK [letsencrypt : Notify of challenge failures] ******************************
System info:
  Ansible 2.10.11; Darwin
  Trellis 1.8.0: February 12th, 2021
---------------------------------------------------
Could not access the challenge file for the hosts/domains:
example.comuu, example.comuu

Details:
-1 example.comuu:80/.well-known/acme-challenge/ping.txt
-1 example.comuu:443/.well-known/acme-challenge/ping.txt

Let's Encrypt requires every domain/host be publicly accessible.
Make sure that a valid DNS record exists for each host and that
they point to this server's IP.

If you don't want these domains in your SSL certificate, then
remove them from `site_hosts`. See https://roots.io/trellis/docs/ssl for more
details.
failed: [example.com] (item=example.com) => {"ansible_loop_var": "item", "changed": false, "item": {"ansible_loop_var": "item", "changed": false, "failed": true, "failed_hosts": [{"exception": "[Errno -2] Name or service not known", "headers": null, "hostname": "example.comuu", "reason": null, "status": -1, "uri": "example.comuu:80/.well-known/acme-challenge/ping.txt"}, {"exception": "[Errno -2] Name or service not known", "headers": null, "hostname": "example.comuu", "reason": null, "status": -1, "uri": "example.comuu:443/.well-known/acme-challenge/ping.txt"}], "invocation": {"module_args": {"file": "ping.txt", "hosts": ["example.com"], "path": ".well-known/acme-challenge", "ssl": true}}, "item": {"key": "example.com", "value": {"admin_email": "user@example.org", "branch": "main", "cache": {"enabled": false}, "deploy_keep_releases": 10, "local_path": "../site", "multisite": {"enabled": false}, "repo": "git@github.com:example/wp-bedrock.git", "site_hosts": [{"canonical": "example.com", "redirects": []}], "ssl": {"enabled": true, "provider": "letsencrypt"}}}, "msg": "Failed to test ACME file", "rc": 1}}
```
