### PR TITLE
Improve support for adding public keys for deploys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Improve support for adding public SSH keys ([#1344](https://github.com/roots/trellis/pull/1344))
 * Fix #1319 - Improve how ssh_args are loaded ([#1337](https://github.com/roots/trellis/pull/1337))
 * Fix #1331 - Improve passlib instructions([#1336](https://github.com/roots/trellis/pull/1336))
 

--- a/lib/trellis/utils/output.py
+++ b/lib/trellis/utils/output.py
@@ -55,7 +55,7 @@ def replace_item_with_key(obj, result):
     )
 
     if should_replace:
-        if 'key' in result._result[item]:
+        if type(result._result[item]) is dict and 'key' in result._result[item]:
             result._result[item] = result._result[item]['key']
         elif type(result._result[item]) is dict:
             subitem = '_ansible_item_label' if '_ansible_item_label' in result._result[item] else 'item'

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -49,13 +49,19 @@
     validate: "/usr/sbin/visudo -cf %s"
   when: web_sudoers[0] is defined
 
-- name: Add SSH keys
+- name: Add user SSH keys
   authorized_key:
     user: "{{ item.0.name }}"
     key: "{{ item.1 }}"
   with_subelements:
     - "{{ users | default([]) }}"
     - keys
+
+- name: Add deploy SSH keys
+  authorized_key:
+    user: "{{ web_user }}"
+    key: "{{ lookup('file', item) }}"
+  with_fileglob: 'public_keys/*.pub'
 
 - name: Check whether Ansible can connect as admin_user
   command: ansible {{ inventory_hostname }} -m ping -u {{ admin_user }} {{ cli_options | default('') }}


### PR DESCRIPTION
Adding a deploy specific SSH public key to a Trellis server is a common task to enable CI/CD deploys (such as GitHub Actions).

This creates a standard folder (`public_keys`) for them. Any public SSH keys in that folder (ending in `.pub`) will be automatically added to the `web_user` as an authorized key.