### PR TITLE
Revert "Default to proper box for M1 macs"

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,13 +19,7 @@ trellis_config = Trellis::Config.new(root_path: ANSIBLE_PATH)
 Vagrant.require_version '>= 2.1.0', '< 2.2.19'
 
 Vagrant.configure('2') do |config|
-  vagrant_box = if Vagrant::Util::Platform.darwin? && `uname -m`.chomp == "arm64"
-    'jeffnoxon/ubuntu-20.04-arm64'
-  else
-    vconfig.fetch('vagrant_box')
-  end
-
-  config.vm.box = vagrant_box
+  config.vm.box = vconfig.fetch('vagrant_box')
   config.vm.box_version = vconfig.fetch('vagrant_box_version')
   config.ssh.forward_agent = true
   config.vm.post_up_message = post_up_message


### PR DESCRIPTION
Reverts roots/trellis#1346

This may not work in some situations since executing `uname -m` from within Vagrant might return `x86_64` if it's running under Rosetta