### PR TITLE
Update default ssh key paths

### DIFF
--- a/group_vars/all/users.yml
+++ b/group_vars/all/users.yml
@@ -7,13 +7,15 @@ users:
     groups:
       - "{{ web_group }}"
     keys:
-      - "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
+      - "{{ lookup('file', '~/.ssh/id_rsa.pub', errors='ignore') }}"
+      - "{{ lookup('file', '~/.ssh/id_ed25519.pub', errors='ignore') }}"
       # - https://github.com/username.keys
   - name: "{{ admin_user }}"
     groups:
       - sudo
     keys:
-      - "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
+      - "{{ lookup('file', '~/.ssh/id_rsa.pub', errors='ignore') }}"
+      - "{{ lookup('file', '~/.ssh/id_ed25519.pub', errors='ignore') }}"
       # - https://github.com/username.keys
 
 web_user: web


### PR DESCRIPTION
Adds id_ed25519 in addition to the existing id_rsa entry and sets `errors='ignore'` to both. If that local path doesn't exist, Ansible will still show a helpful warning but won't fail.


```plain
TASK [users : Add SSH keys] ****************************************************
[WARNING]: Unable to find '~/.ssh/id_rsa.pub' in expected paths (use -vvvvv to
see paths)
```