### PR TITLE
Fix #970 - Improve git clone failure error

### DIFF
--- a/roles/deploy/tasks/update.yml
+++ b/roles/deploy/tasks/update.yml
@@ -39,6 +39,9 @@
       More info:
       > https://roots.io/trellis/docs/deploys/#ssh-keys
       > https://roots.io/trellis/docs/ssh-keys/#cloning-remote-repo-using-ssh-agent-forwarding
+
+      Error:
+      {{ git_clone.stderr }}
   when: git_clone is failed
 
 - name: Remove untracked files from project folder


### PR DESCRIPTION
Outputs the original stderr message as well in case of failure.