### PR TITLE
Disable `install_recommends` for php packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Fix #1354 - Disable `install_recommends` for php packages ([#1355](https://github.com/roots/trellis/pull/1355))
 * Update default ssh key paths (include ed25519 keys) ([#1348](https://github.com/roots/trellis/pull/1348))
 * Use trellis-cli for Vagrant galaxy install when available ([#1349](https://github.com/roots/trellis/pull/1349))
 * Fix #970 - Improve git clone failure error ([#1351](https://github.com/roots/trellis/pull/1351))

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -9,6 +9,7 @@
     name: "{{ item.key }}"
     state: "{{ item.value }}"
     cache_valid_time: "{{ apt_cache_valid_time }}"
+    install_recommends: no
   with_dict: "{{ php_extensions }}"
 
 - name: Start php fpm service


### PR DESCRIPTION
Fixes #1354 

php8.1-cli is being installed due to another package recommending it. Right now this breaks WordPress installation due to WP-CLI being incompatible.

However, 8.1 shouldn't be installed anyway when the `php_version` is set to `8.0`. This fixes the root cause by setting `install_recommends: no` which disables the feature in `apt`.

More background: https://github.com/oerdnj/deb.sury.org/wiki/Frequently-Asked-Questions#why-is-phpdefaultversion-cli-always-installed
and https://github.com/oerdnj/deb.sury.org/issues/1711