### PR TITLE
Add integration test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,51 @@
+name: Integration
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: mkdir $HOME/.ssh
+      - name: Remove and cleanup mysql
+        run: |
+          sudo apt-get remove --purge mysql*
+          sudo apt-get autoremove
+          sudo apt-get autoclean
+          sudo rm -rf /etc/apparmor.d/abstractions/mysql /etc/apparmor.d/cache/usr.sbin.mysqld /etc/mysql /var/lib/mysql /var/log/mysql* /var/log/upstart/mysql.log* /var/run/mysqld ~/.mysql_history
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - uses: roots/setup-trellis-cli@v1
+        with:
+          ansible-vault-password: 'fake'
+          auto-init: false
+          galaxy-install: false
+          trellis-directory: '.'
+      - name: Create new Trellis project
+        run: trellis new --name example.com --host www.example.com --trellis-version ${{ github.sha }} ./example.com
+      - name: Update configs
+        run: |
+          sudo echo "127.0.0.1 www.example.com example.com" | sudo tee -a /etc/hosts
+          rm hosts/production && echo -e "[production]\nlocalhost ansible_connection=local\n[web]\nlocalhost ansible_connection=local\n" > hosts/production
+          sed --in-place '/repo_subtree_path: site/d' group_vars/production/wordpress_sites.yml
+        working-directory: example.com/trellis
+      - name: Provision
+        run: trellis provision --extra-vars web_user=runner production
+        working-directory: example.com
+      - name: Deploy
+        run: trellis deploy --extra-vars "web_user=runner project_git_repo=https://github.com/roots/bedrock.git" production
+        working-directory: example.com
+      - name: Install WordPress
+        run: |
+          wp core install --url="http://example.com" --title="Example.com" --admin_user="admin" --admin_password="password" --admin_email="admin@example.com"
+        working-directory: /srv/www/example.com/current
+      - name: Verify install
+        run: curl -s http://www.example.com | grep "<title>Example"


### PR DESCRIPTION
Uses trellis-cli to create a new Trellis project from the current SHA. The project is provisioned and deployed all using trellis-cli.

Finally the site is verified that WordPress was actually installed and working.

The steps are a little more complex than someone provisioning a normal remote server for a few reasons:

1. GitHub's Ubuntu image has a lot of software installed by default including mysql-server which needs to be purged completely.
2. there's a few workarounds to force Ansible to use a local connection since we aren't actually SSHing into a remote server.