### PR TITLE
Create mysql my.cnf credentials file earlier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Create mysql my.cnf credentials file earlier ([#1360](https://github.com/roots/trellis/pull/1360))
 * Remove bin scripts (trellis-cli should be used instead) ([#1352](https://github.com/roots/trellis/pull/1352))
 * Update `wp_cli_version` to `2.6.0` ([#1358](https://github.com/roots/trellis/pull/1358))
 * Deploy hook build example: Update Sage build command ([#1356](https://github.com/roots/trellis/pull/1356))

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -33,6 +33,14 @@
     when: mysql_binary_logging_disabled | bool
     notify: restart mysql server
 
+  - name: Copy .my.cnf file with root password credentials.
+    template:
+      src: my.cnf.j2
+      dest: ~/.my.cnf
+      owner: root
+      group: root
+      mode: '0600'
+
   - name: Set root user password
     mysql_user:
       name: root
@@ -46,14 +54,6 @@
       - 127.0.0.1
       - ::1
       - localhost
-
-  - name: Copy .my.cnf file with root password credentials.
-    template:
-      src: my.cnf.j2
-      dest: ~/.my.cnf
-      owner: root
-      group: root
-      mode: '0600'
 
   - name: Delete anonymous MySQL server users
     mysql_user:


### PR DESCRIPTION
In some situations the "Set root user password" task might fail because it tries to connect with no root password. Moving the my.cnf credentials file task above it fixes that situation and also just makes more sense in general.

This was discovered during https://github.com/roots/trellis/pull/1359 trying to get Trellis provisioning on GitHub actions.