### PR TITLE
Ensure correct PHP version is set

### DIFF
--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -12,6 +12,11 @@
     install_recommends: no
   with_dict: "{{ php_extensions }}"
 
+- name: Ensure correct PHP version selected
+  community.general.alternatives:
+    name: php
+    path: /usr/bin/php{{ php_version }}
+
 - name: Start php fpm service
   service:
     name: "php{{ php_version }}-fpm"


### PR DESCRIPTION
Background: https://github.com/roots/trellis/issues/1354

https://github.com/roots/trellis/pull/1355 fixed half of this problem, but there's still situations where php-cli ends up defaulting to 8.1.

This ensures the correct version of PHP is always set based on `php_version` by using the `update-alternatives` command.