### PR TITLE
Add HTTPS site to integration tests

### DIFF
--- a/.github/actions/setup-step-ca/action.yml
+++ b/.github/actions/setup-step-ca/action.yml
@@ -1,0 +1,42 @@
+name: Setup Step CA ACME server
+description: Installs and runs an ACME compatible server via step-ca
+inputs:
+  path:
+    description: 'step-ca path'
+    required: false
+    default: /root/.step
+runs:
+  using: composite
+  steps:
+    - name: Set STEP_CA_PATH env
+      run: echo STEP_CA_PATH=${{ inputs.path }} >> $GITHUB_ENV
+      shell: bash
+    - name: Download packages
+      run: |
+        wget -q https://dl.step.sm/gh-release/cli/docs-ca-install/v0.18.1/step-cli_0.18.1_amd64.deb
+        wget -q https://dl.step.sm/gh-release/certificates/docs-ca-install/v0.18.1/step-ca_0.18.1_amd64.deb
+      shell: bash
+    - name: Install packages
+      run: |
+        sudo dpkg -i step-cli_0.18.1_amd64.deb
+        sudo dpkg -i step-ca_0.18.1_amd64.deb
+      shell: bash
+    - name: Create password file
+      run: |
+        sudo mkdir $STEP_CA_PATH && sudo touch $STEP_CA_PATH/password.txt
+        echo $(openssl rand -hex 12) | sudo tee $STEP_CA_PATH/password.txt
+      shell: bash
+    - name: Initialize
+      run: |
+        sudo step ca init --name trellis-local-ca --dns 127.0.0.1 --address :8443 --provisioner admin --password-file $STEP_CA_PATH/password.txt --provisioner-password-file $STEP_CA_PATH/password.txt
+        sudo step ca provisioner add acme --type ACME
+      shell: bash
+    - name: Install certificate to system
+      run: |
+        sudo step certificate install $STEP_CA_PATH/certs/root_ca.crt
+      shell: bash
+    - name: Run service
+      run: |
+        sudo cp .github/files/step-ca.service /etc/systemd/system/step-ca.service
+        sudo systemctl start step-ca
+      shell: bash

--- a/.github/files/inventory
+++ b/.github/files/inventory
@@ -1,0 +1,4 @@
+[production]
+localhost ansible_connection=local
+[web]
+localhost ansible_connection=local

--- a/.github/files/step-ca.service
+++ b/.github/files/step-ca.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=step-ca service
+After=network.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=1
+Environment=STEPPATH=/root/.step
+WorkingDirectory=/root/.step
+ExecStart=/usr/bin/step-ca config/ca.json --password-file password.txt
+
+[Install]
+WantedBy=multi-user.target

--- a/.github/files/vault.yml
+++ b/.github/files/vault.yml
@@ -1,0 +1,36 @@
+# Documentation: https://roots.io/trellis/docs/vault/
+vault_mysql_root_password: productionpw
+
+# Documentation: https://roots.io/trellis/docs/security/
+vault_users:
+  - name: "{{ admin_user }}"
+    password: example_password
+    salt: "generateme"
+
+# Variables to accompany `group_vars/production/wordpress_sites.yml`
+# Note: the site name (`example.com`) must match up with the site name in the above file.
+vault_wordpress_sites:
+  example.com:
+    env:
+      db_password: example_dbpassword
+      # Generate your keys here: https://roots.io/salts.html
+      auth_key: "generateme"
+      secure_auth_key: "generateme"
+      logged_in_key: "generateme"
+      nonce_key: "generateme"
+      auth_salt: "generateme"
+      secure_auth_salt: "generateme"
+      logged_in_salt: "generateme"
+      nonce_salt: "generateme"
+  example-https.com:
+    env:
+      db_password: example_dbpassword
+      # Generate your keys here: https://roots.io/salts.html
+      auth_key: "generateme"
+      secure_auth_key: "generateme"
+      logged_in_key: "generateme"
+      nonce_key: "generateme"
+      auth_salt: "generateme"
+      secure_auth_salt: "generateme"
+      logged_in_salt: "generateme"
+      nonce_salt: "generateme"

--- a/.github/files/wordpress_sites.yml
+++ b/.github/files/wordpress_sites.yml
@@ -1,0 +1,34 @@
+letsencrypt_contact_emails:
+  - admin@example.com
+
+wordpress_sites:
+  example.com:
+    site_hosts:
+      - canonical: example.com
+        redirects:
+          - www.example.com
+    local_path: ../site
+    repo: git@github.com:roots/bedrock.git
+    branch: master
+    multisite:
+      enabled: false
+    ssl:
+      enabled: false
+      provider: letsencrypt
+    cache:
+      enabled: true
+  example-https.com:
+    site_hosts:
+      - canonical: example-https.com
+        redirects:
+          - www.example-https.com
+    local_path: ../site
+    repo: git@github.com:roots/bedrock.git
+    branch: master
+    multisite:
+      enabled: false
+    ssl:
+      enabled: true
+      provider: letsencrypt
+    cache:
+      enabled: false

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.9'
+      - uses: ./.github/actions/setup-step-ca
       - uses: roots/setup-trellis-cli@v1
         with:
           ansible-vault-password: 'fake'
@@ -36,19 +37,29 @@ jobs:
         run: trellis new --name example.com --host www.example.com --trellis-version ${{ github.sha }} ./example.com
       - name: Update configs
         run: |
-          sudo echo "127.0.0.1 www.example.com example.com" | sudo tee -a /etc/hosts
-          rm hosts/production && echo -e "[production]\nlocalhost ansible_connection=local\n[web]\nlocalhost ansible_connection=local\n" > hosts/production
-          sed --in-place '/repo_subtree_path: site/d' group_vars/production/wordpress_sites.yml
+          sudo echo "127.0.0.1 www.example.com example.com www.example-https.com example-https.com" | sudo tee -a /etc/hosts
+          cp ../../.github/files/inventory hosts/production
+          cp ../../.github/files/wordpress_sites.yml group_vars/production/wordpress_sites.yml
+          cp ../../.github/files/vault.yml group_vars/production/vault.yml
         working-directory: example.com/trellis
       - name: Provision
-        run: trellis provision --extra-vars web_user=runner production
+        run: trellis provision --extra-vars "web_user=runner letsencrypt_ca=https://127.0.0.1:8443/acme/acme" production
         working-directory: example.com
-      - name: Deploy
-        run: trellis deploy --extra-vars "web_user=runner project_git_repo=https://github.com/roots/bedrock.git" production
+      - name: Deploy non-https site
+        run: trellis deploy --extra-vars "web_user=runner project_git_repo=https://github.com/roots/bedrock.git" production example.com
         working-directory: example.com
       - name: Install WordPress
         run: |
           wp core install --url="http://example.com" --title="Example.com" --admin_user="admin" --admin_password="password" --admin_email="admin@example.com"
         working-directory: /srv/www/example.com/current
       - name: Verify install
-        run: curl -s http://www.example.com | grep "<title>Example"
+        run: curl -s http://example.com | grep "<title>Example"
+      - name: Deploy https site
+        run: trellis deploy --extra-vars "web_user=runner project_git_repo=https://github.com/roots/bedrock.git" production example-https.com
+        working-directory: example.com
+      - name: Install WordPress
+        run: |
+          wp core install --url="http://example-https.com" --title="Example HTTPS" --admin_user="admin" --admin_password="password" --admin_email="admin@example.com"
+        working-directory: /srv/www/example-https.com/current
+      - name: Verify install
+        run: curl -s https://example-https.com | grep "<title>Example HTTPS"


### PR DESCRIPTION
Previously the integration test just had a single non-https example site. This adds a second example site but with `ssl` set to `letsencrypt`.

Because of Let's Encrypts rate limiting, neither the production or staging server are recommended for CI/CD. To get around that, this uses the [step-ca](https://smallstep.com/docs/step-ca) server which can act as an ACME server. This means Trellis goes through the same certificate flow as usual, just with a different ca directory.