### PR TITLE
default to python3

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -9,6 +9,7 @@ nocows = 1
 roles_path = vendor/roles
 vars_plugins = ~/.ansible/plugins/vars:/usr/share/ansible/plugins/vars:lib/trellis/plugins/vars
 pipelining = True
+interpreter_python = /usr/bin/python3
 
 [ssh_connection]
 ssh_args = -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s


### PR DESCRIPTION
Set ansible to use python3 interpreter by default now that python2 isn't supported anymore.

fixes #1371