### PR TITLE
Support Ansible >= 2.10

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -42,6 +42,8 @@ jobs:
           cp ../../.github/files/wordpress_sites.yml group_vars/production/wordpress_sites.yml
           cp ../../.github/files/vault.yml group_vars/production/vault.yml
         working-directory: example.com/trellis
+      - run: trellis exec ansible-playbook --version
+        working-directory: example.com/trellis
       - name: Provision
         run: trellis provision --extra-vars "web_user=runner letsencrypt_ca=https://127.0.0.1:8443/acme/acme" production
         working-directory: example.com

--- a/lib/trellis/plugins/vars/version.py
+++ b/lib/trellis/plugins/vars/version.py
@@ -11,7 +11,7 @@ except ImportError:
     display = Display()
 
 version_requirement = '2.10.0'
-version_tested_max = '2.10.16'
+version_tested_max = '5.4.0'
 
 if python_version_tuple()[0] == '2':
     raise AnsibleError(('Trellis no longer supports Python 2 (you are using version {}).'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-ansible>=2.10.0,<3.0
-ansible-base>=2.10,<=2.10.16
+ansible>=2.10.0
 passlib


### PR DESCRIPTION
This removes the upper version constraint and supports Ansible versions up to 5.4.0 (ansible-core 2.12)