### PR TITLE
Add built-in fail2ban filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Add built-in fail2ban filters ([#1375](https://github.com/roots/trellis/pull/1375))
 * Support Ansible >= 2.10 (tested up to 5.4.0) ([#1373](https://github.com/roots/trellis/pull/1373))
 * Remove Python 2 support ([#1361](https://github.com/roots/trellis/pull/1361))
 

--- a/group_vars/all/security.yml
+++ b/group_vars/all/security.yml
@@ -1,3 +1,5 @@
+# Documentation: https://roots.io/trellis/docs/security/
+
 ferm_input_list:
   - type: dport_accept
     dport: [http, https]
@@ -10,7 +12,20 @@ ferm_input_list:
     seconds: 300
     hits: 20
 
-# Documentation: https://roots.io/trellis/docs/security/
+
+# Enable built-in fail2ban services or add your own custom ones
+fail2ban_services_custom:
+  - name: wordpress_xmlrpc
+    filter: wordpress-xmlrpc
+    enabled: "false"
+    port: http,https
+    logpath: "{{ www_root }}/**/logs/access.log"
+  - name: wordpress_wp_login
+    filter: wordpress-wp-login
+    enabled: "false"
+    port: http,https
+    logpath: "{{ www_root }}/**/logs/access.log"
+
 # If sshd_permit_root_login: false, admin_user must be in 'users' (`group_vars/all/users.yml`) with sudo group
 # and in 'vault_users' (`group_vars/staging/vault.yml`, `group_vars/production/vault.yml`)
 sshd_permit_root_login: true

--- a/roles/fail2ban/defaults/main.yml
+++ b/roles/fail2ban/defaults/main.yml
@@ -29,4 +29,3 @@ fail2ban_services_custom: []
 fail2ban_services: "{{ fail2ban_services_default + fail2ban_services_custom }}"
 
 fail2ban_filter_templates_path: fail2ban_filters
-fail2ban_filter_templates_pattern: "^({{ fail2ban_filter_templates_path | regex_escape }})/(.*)\\.j2$"

--- a/roles/fail2ban/tasks/main.yml
+++ b/roles/fail2ban/tasks/main.yml
@@ -21,6 +21,7 @@
 - name: build list of fail2ban filter templates
   find:
     paths:
+      - "{{ playbook_dir }}/roles/fail2ban/templates/filters"
       - "{{ fail2ban_filter_templates_path }}"
     pattern: "*.conf.j2"
   become: no
@@ -36,7 +37,7 @@
 - name: template fail2ban filters
   template:
     src: "{{ item }}"
-    dest: "/etc/fail2ban/filter.d/{{ item | regex_replace(fail2ban_filter_templates_pattern, '\\2') }}"
+    dest: "/etc/fail2ban/filter.d/{{ item | basename | regex_replace('.j2$', '') }}"
     mode: '0644'
   with_items: "{{ fail2ban_filter_templates.files | map(attribute='path') | list | sort(True) }}"
   notify: restart fail2ban

--- a/roles/fail2ban/templates/filters/wordpress-wp-login.conf.j2
+++ b/roles/fail2ban/templates/filters/wordpress-wp-login.conf.j2
@@ -1,0 +1,2 @@
+[Definition]
+failregex = ^<HOST> .* "POST .*wp-login\.php

--- a/roles/fail2ban/templates/filters/wordpress-xmlrpc.conf.j2
+++ b/roles/fail2ban/templates/filters/wordpress-xmlrpc.conf.j2
@@ -1,0 +1,2 @@
+[Definition]
+failregex = ^<HOST> .* "POST .*xmlrpc\.php


### PR DESCRIPTION
Trellis supported default fail2ban services previously but they were restricted to filters built into fail2ban itself (like `sshd`).

This adds filters defined by Trellis as well now by automatically creating the filter configuration files from templates.

Importantly, these filters will be _disabled_ by default. Any time a new filter is added, it will also be added to `fail2ban_services_custom` with enabled set to `false.`

This achieves a few goals:

1. makes it very easy to enable the built-in filters, which
2. brings more awareness to them by adding them to `group_vars/all/security.yml`
3. hopefully encourages more fail2ban filters to be created and used

There's two initial filters:
* wp-login
* xmlrpc

Which are both designed to prevent common DDoS attack vectors.