### PR TITLE
Updating geerlingguy.ntp role from Ansible Galaxy to latest (2.3.1)

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -4,7 +4,7 @@
 
 - name: ntp
   src: geerlingguy.ntp
-  version: 2.2.0
+  version: 2.3.1
 
 - name: logrotate
   src: nickhammond.logrotate


### PR DESCRIPTION
Ran into an issue provisioning a Ubuntu 20.04 box, turns out there's a known issue where your timesync service is disabled while Ansible is also looking for it.

Vendor issue: https://github.com/geerlingguy/ansible-role-ntp/issues/87
Hotfix PR: https://github.com/geerlingguy/ansible-role-ntp/pull/110

I've tested the latest version of ntp and was able to provision without issue, but more testing may be needed for others.