### PR TITLE
simple bug and common issue with all 2.2.19

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,7 @@ ensure_plugins(vconfig.fetch('vagrant_plugins')) if vconfig.fetch('vagrant_insta
 
 trellis_config = Trellis::Config.new(root_path: ANSIBLE_PATH)
 
-Vagrant.require_version '>= 2.1.0', '< 2.2.19'
+Vagrant.require_version '>= 2.1.0', '<= 2.2.19'
 
 Vagrant.configure('2') do |config|
   config.vm.box = vconfig.fetch('vagrant_box')


### PR DESCRIPTION
there should be less than equals so at least it supports vagrant 2.2.19

Vagrant failed to initialize at a very early stage:

This Vagrant environment has specified that it requires the Vagrant
version to satisfy the following version requirements:

  >= 2.1.0, < 2.2.19

You are running Vagrant 2.2.19, which does not satisfy
these requirements. Please change your Vagrant version or update
the Vagrantfile to allow this Vagrant version. However, be warned
that if the Vagrantfile has specified another version, it probably has
good reason to do so, and changing that may cause the environment to
not function properly.
exit status 1