### PR TITLE
Remove redundant ansible_connection=local and comments

### DIFF
--- a/hosts/development
+++ b/hosts/development
@@ -1,4 +1,4 @@
-# Add each host to the [staging] group and to a "type" group such as [web] or [db].
+# Add each host to the [development] group and to a "type" group such as [web] or [db].
 # List each machine only once per [group], even if it will host multiple sites.
 
 [development]

--- a/hosts/development
+++ b/hosts/development
@@ -1,41 +1,8 @@
-# This file is only used for Windows hosts.
-#
-# Windows
-# -------------------------------------------------------------
-# If you want to run `dev.yml` manually you can SSH into the VM
-# to the directory with the `dev.yml` playbook and run:
-
-# `ansible-playbook dev.yml`
-#
-# Non-Windows
-# -------------------------------------------------------------
-# If you want to run `dev.yml` manually via the `ansible-playbook`
-# command (vs. `vagrant up` or `vagrant provision`), you might be
-# inclined to define your development host information in this file.
-# We recommend instead that you use the `-i` (inventory) option with
-# your `ansible-playbook` command to specify the custom inventory file
-# Vagrant has created for the VM. Vagrant's custom inventory
-# includes necessary non-standard SSH connection information.
-#
-# Here is an example command:
-#
-# `ansible-playbook dev.yml -i .vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory`
-#
-# The `.vagrant` directory above is usually in the same directory as
-# your `Vagrantfile`. If not, you will need to adjust this path in the
-# command.
-#
-# Why run `dev.yml` manually?
-# -------------------------------------------------------------
-# One reason you may want to run `dev.yml` via the `ansible-playbook`
-# command is for the convenience of adding Ansible options via the
-# command line (e.g., `--tags`, `--skip-tags`, or `-vvvv`). In contrast,
-# the commands `vagrant up` and `vagrant provision` would only run the
-# `dev.yml` playbook with such options if you were edit the options
-# into the Vagrantfile's `config.vm.provision` section.
+# Add each host to the [staging] group and to a "type" group such as [web] or [db].
+# List each machine only once per [group], even if it will host multiple sites.
 
 [development]
-192.168.56.5 ansible_connection=local
+192.168.56.5
 
 [web]
-192.168.56.5 ansible_connection=local
+192.168.56.5


### PR DESCRIPTION
Before WSL became an option for Windows users we had many scripts and workarounds for successful provision and deploys. Now that WSL is the recommended usage for Trellis we can remove the development host comments and default settings.

With `ansible_connection=local` in the hosts file, this forced a local connection all the time. So when `ansible-playbook dev.yml -e env=development` was ran it would try to run this against the users local machine.

This change allows users to not only provision via running a `vagrant up && vagrant reload --provision` but also by the more intuitive method as we do with production and staging envs: `ansible-playbook dev.yml -e env=development`

This will remove the need for documentation that differs between production,staging and development environments. And restores normal ansible usage for development provisions. The user will still have to run an initial `vagrant up`, but then should they wish to make changes locally thereafter such as with specific tags they can do that.

This was added here, and was used alongside the now deleted `windows.sh` script: https://github.com/roots/trellis/commit/550ef595026c73c471e7bdf2dbdd0bde20050534

When Vagrant is provisioning the local flag is always passed here: https://github.com/roots/trellis/blob/master/Vagrantfile#L113

This also opens scope for us to implement a DRY approach for the `server.yml` and `dev.yml` files. Allowing us to use a singular `server.yml`, which I could potentially chain onto this PR if you feel it's worth while