### PR TITLE
Do not disallow up to date Vagrant vers. on Linux

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,8 +16,12 @@ ensure_plugins(vconfig.fetch('vagrant_plugins')) if vconfig.fetch('vagrant_insta
 
 trellis_config = Trellis::Config.new(root_path: ANSIBLE_PATH)
 
-Vagrant.require_version '>= 2.1.0', '< 2.2.19'
-
+if Vagrant::Util::Platform.darwin?
+  Vagrant.require_version '>= 2.1.0', '< 2.2.19'
+else
+  Vagrant.require_version '>= 2.1.0'
+end
+  
 Vagrant.configure('2') do |config|
   config.vm.box = vconfig.fetch('vagrant_box')
   config.vm.box_version = vconfig.fetch('vagrant_box_version')


### PR DESCRIPTION
When this version restriction was introduced, I found out from the changelog or an issue that this was specifically because of a mac OS issue.

I have successfully ran later Vagrant versions that ship with Open SUSE Tumbleweed (Not sure), Ubuntu 21.10 and Ubuntu 22.04. AFAIK there is no reason to shut Linux users out of up-to-date Vagrant versions.