### PR TITLE
fix: set mjs as application/javascript in h5bp

### DIFF
--- a/roles/nginx/templates/h5bp/mime.types
+++ b/roles/nginx/templates/h5bp/mime.types
@@ -14,7 +14,7 @@ types {
 
     # Normalize to standard type.
     # https://tools.ietf.org/html/rfc4329#section-7.2
-    application/javascript                js;
+    application/javascript                js mjs;
 
 
   # Manifest files


### PR DESCRIPTION
Problem: nginx serves `mjs` as `application/octet-stream` and results in errors in the browser:

```
Failed to load module script: Expected a JavaScript module script but the server responded with a MIME type of "application/octet-stream".
```

This change sets `mjs` as `application/javascript` so that these files are served in accordance with the HTML specification.