### PR TITLE
Change MariaDB PPA link

### DIFF
--- a/roles/mariadb/defaults/main.yml
+++ b/roles/mariadb/defaults/main.yml
@@ -1,6 +1,6 @@
 mariadb_keyserver: "hkp://keyserver.ubuntu.com:80"
 mariadb_keyserver_id: "0xF1656F24C74CD1D8"
-mariadb_ppa: "deb http://mirrors.gigenet.com/mariadb/repo/10.5/ubuntu {{ ansible_distribution_release }} main"
+mariadb_ppa: "deb http://mariadb.mirror.globo.tech/repo/10.5/ubuntu {{ ansible_distribution_release }} main"
 
 mariadb_client_package: mariadb-client
 mariadb_server_package: mariadb-server


### PR DESCRIPTION
**Problem:** As described in [https://github.com/roots/trellis/issues/1321#issuecomment-1134316507](https://github.com/roots/trellis/issues/1321#issuecomment-1134316507) provisioning fails with the message `Failed to update apt cache: E:The repository 'http://mirrors.gigenet.com/mariadb/repo/10.5/ubuntu focal Release' does not have a Release file. fatal: [default]: FAILED! => {"changed": false}`. 

**Solution:** This change replaces the currently used broken mirror (http://mirrors.gigenet.com/mariadb/repo/10.5/ubuntu) with a working one (http://mariadb.mirror.globo.tech/repo/10.5/ubuntu).