### PR TITLE
Remove `WPMU_PLUGIN_DIR` constant to `null` in `tmp_multisite_constants.php`

### DIFF
--- a/roles/deploy/files/tmp_multisite_constants.php
+++ b/roles/deploy/files/tmp_multisite_constants.php
@@ -2,6 +2,5 @@
 error_reporting(E_ALL & ~E_NOTICE);
 define('MULTISITE', false);
 define('SUBDOMAIN_INSTALL', false);
-define('WPMU_PLUGIN_DIR', null);
 define('WP_PLUGIN_DIR', null);
 define('WP_USE_THEMES', false);


### PR DESCRIPTION
(Variant A) This PR removes the line that sets the `WPMU_PLUGIN_DIR` constant to `null` in `tmp_multisite_constants.php` so the Ansible check that uses `wp core is-installed [...]` passes (failing since the WordPress `6.0` release).

Before merging, it may be good to think about possible issues that may arise with not setting the `WPMU_PLUGIN_DIR` constant to null in that (smoke) test during deployment. Can this result in passing deploys for multisite setups that would have issues, hence should not have passed this check?
Previous discussions (https://github.com/roots/trellis/issues/1385) indicate that this shouldn't be the case and that setting that constant to `null` isn't really required anymore with recent WordPress versions.

Fixes issue: https://github.com/roots/trellis/issues/1385