### PR TITLE
Add exception for the PHP `strpos()` empty needle warning

### DIFF
--- a/roles/deploy/hooks/finalize-before.yml
+++ b/roles/deploy/hooks/finalize-before.yml
@@ -4,13 +4,19 @@
     src: "tmp_multisite_constants.php"
     dest: "{{ deploy_helper.shared_path }}/tmp_multisite_constants.php"
 
+
+- name: Set variables used in "WordPress Installed?" check
+  set_fact:
+    php_needle_warning: "Warning: strpos\\(\\): Empty needle in {{ deploy_helper.new_release_path }}/web/wp/wp-includes/link-template.php on line 3535"
+
 - name: WordPress Installed?
   command: wp core is-installed --skip-plugins --skip-themes --require={{ deploy_helper.shared_path }}/tmp_multisite_constants.php
   args:
     chdir: "{{ deploy_helper.new_release_path }}"
   register: wp_installed
   changed_when: false
-  failed_when: wp_installed.stderr | default("") != "" or wp_installed.rc > 1
+  failed_when: (wp_installed.stderr | length > 0 and wp_installed.stderr is not match(php_needle_warning)) or wp_installed.rc > 1
+
 
 - name: Get WP theme template and stylesheet roots
   shell: >


### PR DESCRIPTION
Variant B (ignore PHP `strpos()` empty needle warning caused by `WPMU_PLUGIN_DIR` constant being `null`).
As an alternative to PR https://github.com/roots/trellis/pull/1386

The `Is WordPress installed?` check will pass if this particular PHP warning occurs (all other PHP warnings still cause it to fail, as in the original behavior).
