### PR TITLE
Split `is-installed` check into a non-multisite and a mulitsite specific one

### DIFF
--- a/roles/deploy/hooks/finalize-before.yml
+++ b/roles/deploy/hooks/finalize-before.yml
@@ -1,16 +1,58 @@
 ---
+# Is installed check
+#   Non-multisite specific check
+- name: WordPress Installed (non-multisite)?
+  command: wp core is-installed --skip-plugins --skip-themes
+  args:
+    chdir: "{{ deploy_helper.new_release_path }}"
+  register: wp_installed_single
+  changed_when: false
+  failed_when: wp_installed_single.stderr | length > 0 or wp_installed_single.rc > 1
+  when:
+    - not project.multisite.enabled | default(false)
+
+#   Multisite specific check
 - name: Create file with multisite constants defined as false
   copy:
     src: "tmp_multisite_constants.php"
     dest: "{{ deploy_helper.shared_path }}/tmp_multisite_constants.php"
+  when:
+    - project.multisite.enabled | default(false)
 
-- name: WordPress Installed?
+- name: Set variables used in "WordPress Installed?" check
+  set_fact:
+    php_needle_warning: "Warning: strpos\\(\\): Empty needle in {{ deploy_helper.new_release_path }}/web/wp/wp-includes/link-template.php on line 3535"
+  when:
+    #- project.multisite.enabled | default(false)
+    - not project.multisite.enabled | default(false)
+
+- name: WordPress Installed (multisite)?
   command: wp core is-installed --skip-plugins --skip-themes --require={{ deploy_helper.shared_path }}/tmp_multisite_constants.php
   args:
     chdir: "{{ deploy_helper.new_release_path }}"
-  register: wp_installed
+  register: wp_installed_multisite
   changed_when: false
-  failed_when: wp_installed.stderr | default("") != "" or wp_installed.rc > 1
+  failed_when: (wp_installed_multisite.stderr | length > 0 and wp_installed_multisite.stderr is not match(php_needle_warning)) or wp_installed_multisite.rc > 1
+  when:
+    - project.multisite.enabled | default(false)
+#   /Multisite specific check
+
+#   Because variable is always registered, even with non-applying when-condition
+- name: Set "WordPress installed (non-multisite)?" result variable
+  set_fact:
+    wp_installed: "{{ wp_installed_single }}"
+  when:
+    - not project.multisite.enabled | default(false)
+
+- name: Set "WordPress installed (multisite)?" result variable
+  set_fact:
+    wp_installed: "{{ wp_installed_multisite }}"
+  when:
+    - project.multisite.enabled | default(false)
+# /Is installed check
+
+
+
 
 - name: Get WP theme template and stylesheet roots
   shell: >

--- a/roles/deploy/hooks/finalize-before.yml
+++ b/roles/deploy/hooks/finalize-before.yml
@@ -1,56 +1,46 @@
 ---
-# Is installed check
-#   Non-multisite specific check
 - name: WordPress Installed (non-multisite)?
-  command: wp core is-installed --skip-plugins --skip-themes
-  args:
-    chdir: "{{ deploy_helper.new_release_path }}"
-  register: wp_installed_single
-  changed_when: false
-  failed_when: wp_installed_single.stderr | length > 0 or wp_installed_single.rc > 1
-  when:
-    - not project.multisite.enabled | default(false)
+  block:
+    - name: "'wp core is-installed' command"
+      command: wp core is-installed --skip-plugins --skip-themes
+      args:
+        chdir: "{{ deploy_helper.new_release_path }}"
+      register: wp_installed_singlesite
+      changed_when: false
+      failed_when: wp_installed_singlesite.stderr | length > 0 or wp_installed_singlesite.rc > 1
 
-#   Multisite specific check
-- name: Create file with multisite constants defined as false
-  copy:
-    src: "tmp_multisite_constants.php"
-    dest: "{{ deploy_helper.shared_path }}/tmp_multisite_constants.php"
+    - name: Set "WordPress installed?" result variable (from non-multisite)
+      set_fact:
+        wp_installed: "{{ wp_installed_singlesite }}"
   when:
-    - project.multisite.enabled | default(false)
-
-- name: Set variables used in "WordPress Installed (multisite)?" check
-  set_fact:
-    php_needle_warning: "Warning: strpos\\(\\): Empty needle in {{ deploy_helper.new_release_path }}/web/wp/wp-includes/link-template.php on line 3535"
-  when:
+    #- not project.multisite.enabled | default(false)
     - project.multisite.enabled | default(false)
 
 - name: WordPress Installed (multisite)?
-  command: wp core is-installed --skip-plugins --skip-themes --require={{ deploy_helper.shared_path }}/tmp_multisite_constants.php
-  args:
-    chdir: "{{ deploy_helper.new_release_path }}"
-  register: wp_installed_multisite
-  changed_when: false
-  failed_when: (wp_installed_multisite.stderr | length > 0 and wp_installed_multisite.stderr is not match(php_needle_warning)) or wp_installed_multisite.rc > 1
-  when:
-    - project.multisite.enabled | default(false)
-#   /Multisite specific check
+  block:
+    - name: Create file with multisite constants defined as false
+      copy:
+        src: "tmp_multisite_constants.php"
+        dest: "{{ deploy_helper.shared_path }}/tmp_multisite_constants.php"
 
-#   Because variable is always registered, even with non-applying when-condition
-- name: Set "WordPress installed (non-multisite)?" result variable
-  set_fact:
-    wp_installed: "{{ wp_installed_single }}"
+    - name: Set variables used in "WordPress Installed (multisite)?" check
+      set_fact:
+        php_needle_warning: "Warning: strpos\\(\\): Empty needle in {{ deploy_helper.new_release_path }}/web/wp/wp-includes/link-template.php on line 3535"
+
+    - name: "'wp core is-installed' command"
+      command: wp core is-installed --skip-plugins --skip-themes --require={{ deploy_helper.shared_path }}/tmp_multisite_constants.php
+      args:
+        chdir: "{{ deploy_helper.new_release_path }}"
+      register: wp_installed_multisite
+      changed_when: false
+      failed_when: (wp_installed_multisite.stderr | length > 0 and wp_installed_multisite.stderr is not match(php_needle_warning)) or wp_installed_multisite.rc > 1
+
+    - name: Set "WordPress installed?" result variable (from multisite)
+      set_fact:
+        wp_installed: "{{ wp_installed_multisite }}"
   when:
+    #- project.multisite.enabled | default(false)
     - not project.multisite.enabled | default(false)
-
-- name: Set "WordPress installed (multisite)?" result variable
-  set_fact:
-    wp_installed: "{{ wp_installed_multisite }}"
-  when:
-    - project.multisite.enabled | default(false)
-# /Is installed check
-
-
 
 
 - name: Get WP theme template and stylesheet roots

--- a/roles/deploy/hooks/finalize-before.yml
+++ b/roles/deploy/hooks/finalize-before.yml
@@ -24,7 +24,7 @@
 
     - name: Set variables used in "WordPress Installed (multisite)?" check
       set_fact:
-        php_needle_warning: "Warning: strpos\\(\\): Empty needle in {{ deploy_helper.new_release_path }}/web/wp/wp-includes/link-template.php on line 3535"
+        php_needle_warning: "Warning: strpos\\(\\): Empty needle in {{ deploy_helper.new_release_path }}/web/wp/wp-includes/link-template.php"
 
     - name: "'wp core is-installed' command"
       command: wp core is-installed --skip-plugins --skip-themes --require={{ deploy_helper.shared_path }}/tmp_multisite_constants.php

--- a/roles/deploy/hooks/finalize-before.yml
+++ b/roles/deploy/hooks/finalize-before.yml
@@ -1,7 +1,7 @@
 ---
 - name: WordPress Installed (non-multisite)?
   block:
-    - name: "'wp core is-installed' command"
+    - name: "Invoke 'wp core is-installed' command"
       command: wp core is-installed --skip-plugins --skip-themes
       args:
         chdir: "{{ deploy_helper.new_release_path }}"
@@ -26,7 +26,7 @@
       set_fact:
         php_needle_warning: "Warning: strpos\\(\\): Empty needle in {{ deploy_helper.new_release_path }}/web/wp/wp-includes/link-template.php"
 
-    - name: "'wp core is-installed' command"
+    - name: "Invoke 'wp core is-installed' command"
       command: wp core is-installed --skip-plugins --skip-themes --require={{ deploy_helper.shared_path }}/tmp_multisite_constants.php
       args:
         chdir: "{{ deploy_helper.new_release_path }}"

--- a/roles/deploy/hooks/finalize-before.yml
+++ b/roles/deploy/hooks/finalize-before.yml
@@ -13,8 +13,7 @@
       set_fact:
         wp_installed: "{{ wp_installed_singlesite }}"
   when:
-    #- not project.multisite.enabled | default(false)
-    - project.multisite.enabled | default(false)
+    - not project.multisite.enabled | default(false)
 
 - name: WordPress Installed (multisite)?
   block:
@@ -39,8 +38,7 @@
       set_fact:
         wp_installed: "{{ wp_installed_multisite }}"
   when:
-    #- project.multisite.enabled | default(false)
-    - not project.multisite.enabled | default(false)
+    - project.multisite.enabled | default(false)
 
 
 - name: Get WP theme template and stylesheet roots

--- a/roles/deploy/hooks/finalize-before.yml
+++ b/roles/deploy/hooks/finalize-before.yml
@@ -19,12 +19,11 @@
   when:
     - project.multisite.enabled | default(false)
 
-- name: Set variables used in "WordPress Installed?" check
+- name: Set variables used in "WordPress Installed (multisite)?" check
   set_fact:
     php_needle_warning: "Warning: strpos\\(\\): Empty needle in {{ deploy_helper.new_release_path }}/web/wp/wp-includes/link-template.php on line 3535"
   when:
-    #- project.multisite.enabled | default(false)
-    - not project.multisite.enabled | default(false)
+    - project.multisite.enabled | default(false)
 
 - name: WordPress Installed (multisite)?
   command: wp core is-installed --skip-plugins --skip-themes --require={{ deploy_helper.shared_path }}/tmp_multisite_constants.php


### PR DESCRIPTION
(Variant C) This PR splits the `WordPress installed?` check into two conditional ones, 
one for non-multisites and one for multisites.
The temporary PHP file for setting some constants to `null`/`false` is then only created/ensured for multisites.
The `wp core is-installed` invocation also is then different for non-multisites and multisites, 
and the PHP warning for `strpos()` empty needle for a `null` `WPMU_PLUGIN_DIR` constant (used in the multisite check) 
is ignored (as in the variant B PR https://github.com/roots/trellis/pull/1387).

Variant A PR: https://github.com/roots/trellis/pull/1386
Variant B PR: https://github.com/roots/trellis/pull/1387
Variant C PR: (This PR)

@swalkinshaw: IMHO this approach is the best one as it simplifies the check for non-multisite (single) sites, 
while allowing the PHP warning for multisites sites.