### PR TITLE
Exempt from `is-installed` check the DB error dump PHP warning for not yet set up multisite sites

### DIFF
--- a/roles/deploy/files/tmp_multisite_constants.php
+++ b/roles/deploy/files/tmp_multisite_constants.php
@@ -1,7 +1,0 @@
-<?php
-error_reporting(E_ALL & ~E_NOTICE);
-define('MULTISITE', false);
-define('SUBDOMAIN_INSTALL', false);
-define('WPMU_PLUGIN_DIR', null);
-define('WP_PLUGIN_DIR', null);
-define('WP_USE_THEMES', false);

--- a/roles/deploy/hooks/finalize-before.yml
+++ b/roles/deploy/hooks/finalize-before.yml
@@ -1,4 +1,9 @@
 ---
+- name: Clean up unused, temporary PHP file with multisite constants that had been used for WordPress Installed check.
+  file:
+    state: absent
+    path: "{{ deploy_helper.shared_path }}/tmp_multisite_constants.php"
+
 - name: WordPress Installed (non-multisite)?
   block:
     - name: "Invoke 'wp core is-installed' command"

--- a/roles/deploy/hooks/finalize-before.yml
+++ b/roles/deploy/hooks/finalize-before.yml
@@ -1,5 +1,5 @@
 ---
-- name: Clean up unused, temporary PHP file with multisite constants that had been used for WordPress Installed check.
+- name: Clean up unused, temporary PHP file with multisite constants that had been used for WordPress Installed checks.
   file:
     state: absent
     path: "{{ deploy_helper.shared_path }}/tmp_multisite_constants.php"

--- a/roles/deploy/hooks/finalize-before.yml
+++ b/roles/deploy/hooks/finalize-before.yml
@@ -17,22 +17,17 @@
 
 - name: WordPress Installed (multisite)?
   block:
-    - name: Create file with multisite constants defined as false
-      copy:
-        src: "tmp_multisite_constants.php"
-        dest: "{{ deploy_helper.shared_path }}/tmp_multisite_constants.php"
-
     - name: Set variables used in "WordPress Installed (multisite)?" check
       set_fact:
-        php_needle_warning: "Warning: strpos\\(\\): Empty needle in {{ deploy_helper.new_release_path }}/web/wp/wp-includes/link-template.php"
+        multisite_non_setup_db_error: "WordPress database error Table '{{ site_env.db_name }}.wp_blogs' doesn't exist"
 
     - name: "Invoke 'wp core is-installed' command"
-      command: wp core is-installed --skip-plugins --skip-themes --require={{ deploy_helper.shared_path }}/tmp_multisite_constants.php
+      command: wp core is-installed --skip-plugins --skip-themes
       args:
         chdir: "{{ deploy_helper.new_release_path }}"
       register: wp_installed_multisite
       changed_when: false
-      failed_when: (wp_installed_multisite.stderr | length > 0 and wp_installed_multisite.stderr is not match(php_needle_warning)) or wp_installed_multisite.rc > 1
+      failed_when: (wp_installed_multisite.stderr | length > 0 and wp_installed_multisite.stderr is not match(multisite_non_setup_db_error)) or wp_installed_multisite.rc > 1
 
     - name: Set "WordPress installed?" result variable (from multisite)
       set_fact:


### PR DESCRIPTION
This PR changes the [recently added `stderr` exemption](https://github.com/roots/trellis/pull/1388) of a specific PHP warning from the WP CLI `wp core is-installed` command for multisite sites to the DB error dump that occurs with not yet set up multisite sites.

This eliminates the need for letting the WP CLI require a temporary PHP file with constants that disable the multisite feature, which itself caused fatal PHP errors in recent WordPress/Bedrock/Trellis setups where those multisite constants where redefined in the Bedrock application config.

Initial deployment of multisite sites will successfully complete and allow finalization of the site setup (by using the WP CLI, web GUI setup process, importing a database dump/transfer uploads/data files, etc).

- As an improvement the [Trellis Multisite documentation](https://docs.roots.io/trellis/master/multisite/#:~:text=After%20provisioning%20your%20remote%20server%20and%20deploying%20your%20sites) could be updated so that it includes the web GUI URL for the site setup (if someone prefers or needs that over the WP CLI approach): `http://<a canonical host or domain_current_site>/wp/wp-admin/install.php` as frontend request redirection to the setup web GUI page may not work until the site setup is completed.
- ~~Should Ansible clean up an existing `tmp_multisite_constants.php` file? It would be useless anyway and its purpose become forgotten on existing Trellis systems.~~ (added: https://github.com/roots/trellis/pull/1391/files#diff-da02775cb0a887a7b8c5f5183fffe57a8840d53f47065f919dff77ad2accd4a0R2-R6)