### PR TITLE
Limit ansible version range in `>=2.10.0,<6`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ansible>=2.10.0
+ansible>=2.10.0,<6
 passlib


### PR DESCRIPTION
See: https://github.com/roots/trellis/issues/1393