### PR TITLE
Fix ansible incompatibility with `Failed connection to remote repo`

### DIFF
--- a/roles/deploy/tasks/update.yml
+++ b/roles/deploy/tasks/update.yml
@@ -41,7 +41,7 @@
       > https://roots.io/trellis/docs/ssh-keys/#cloning-remote-repo-using-ssh-agent-forwarding
 
       Error:
-      {{ git_clone.stderr }}
+      {{ git_clone.msg | default(git_clone.stderr) }}
   when: git_clone is failed
 
 - name: Remove untracked files from project folder


### PR DESCRIPTION
Newer versions of `ansible.builtin.git` puts error message in `msg` instead of `stderr`.