### PR TITLE
Fix shared folder permissions

### DIFF
--- a/roles/deploy/tasks/share.yml
+++ b/roles/deploy/tasks/share.yml
@@ -40,7 +40,7 @@
 - name: Ensure parent directories for shared paths are present
   file:
     path: "{{ deploy_helper.new_release_path }}/{{ item.path | dirname }}"
-    mode: '0777'
+    mode: '0755'
     state: directory
   with_items: "{{ project.project_shared_children | default(project_shared_children) }}"
 


### PR DESCRIPTION
Fixes #1400

This should match a related task for shared paths in https://github.com/roots/trellis/blob/5411c18bc8963710f4f5423ac5819cfb1f0dbbea/roles/deploy/tasks/share.yml#L28