### PR TITLE
Fix Ansible 6 support - remove broken and unused cli import

### DIFF
--- a/lib/trellis/plugins/callback/vars.py
+++ b/lib/trellis/plugins/callback/vars.py
@@ -2,12 +2,10 @@ import re
 import sys
 import os
 
-from __main__ import cli
 from ansible.module_utils.six import iteritems
 from ansible.errors import AnsibleError
 from ansible.parsing.yaml.objects import AnsibleMapping, AnsibleSequence, AnsibleUnicode
 from ansible.playbook.play_context import PlayContext
-from ansible.playbook.task import Task
 from ansible.plugins.callback import CallbackBase
 from ansible.template import Templar
 from ansible.utils.unsafe_proxy import wrap_var

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ansible>=2.10.0,<6
+ansible>=2.10.0
 passlib


### PR DESCRIPTION
Fixes #1393 to properly support Ansible 6 (and ansible-core >= 2.13.1)

Importing `cli` from `__main__` no longer works as of ansible 2.13.1. This import is no longer used anyway (as of https://github.com/roots/trellis/pull/1166) so the fix is to remove it.

cc @codepuncher