### PR TITLE
Support empty passwords for Composer authentication

### DIFF
--- a/group_vars/all/helpers.yml
+++ b/group_vars/all/helpers.yml
@@ -22,6 +22,6 @@ sites_use_ssl: "{{ wordpress_sites.values() | map(attribute='ssl') | selectattr(
 
 # For backward compatibility, to be removed in Trellis v2.
 site_packagist_org_authentications:
-  - { hostname: repo.packagist.com, username: token, password: "{{ vault_wordpress_sites[site].packagist_token | default('') }}" }
+  - { hostname: repo.packagist.com, username: token, password: "{{ vault_wordpress_sites[site].packagist_token | default('\"\"') }}" }
 site_composer_authentications: "{{ vault_wordpress_sites[site].composer_authentications | default([]) }}"
 composer_authentications: "{{ site_packagist_org_authentications + site_composer_authentications }}"

--- a/group_vars/all/helpers.yml
+++ b/group_vars/all/helpers.yml
@@ -20,8 +20,4 @@ ssl_stapling_enabled: "{{ item.value.ssl is defined and item.value.ssl.stapling_
 cron_enabled: "{{ site_env.disable_wp_cron and (not item.value.multisite.enabled | default(false) or (item.value.multisite.enabled | default(false) and item.value.multisite.cron | default(true))) }}"
 sites_use_ssl: "{{ wordpress_sites.values() | map(attribute='ssl') | selectattr('enabled') | list | count > 0 }}"
 
-# For backward compatibility, to be removed in Trellis v2.
-site_packagist_org_authentications:
-  - { hostname: repo.packagist.com, username: token, password: "{{ vault_wordpress_sites[site].packagist_token | default('\"\"') }}" }
-site_composer_authentications: "{{ vault_wordpress_sites[site].composer_authentications | default([]) }}"
-composer_authentications: "{{ site_packagist_org_authentications + site_composer_authentications }}"
+composer_authentications: "{{ vault_wordpress_sites[site].composer_authentications | default([]) }}"

--- a/roles/deploy/hooks/build-after.yml
+++ b/roles/deploy/hooks/build-after.yml
@@ -19,7 +19,6 @@
   when:
     - composer_authentication.hostname is defined and composer_authentication.hostname != ""
     - composer_authentication.username is defined and composer_authentication.username != ""
-    - composer_authentication.password is defined and composer_authentication.password != ""
   loop: "{{ composer_authentications | default([]) }}"
   loop_control:
     loop_var: composer_authentication


### PR DESCRIPTION
Fixes #1306

Some private repository servers don't require the password but Composer requires at least `""` as the value. Removing this extra validation allows `password: ""` to be set.