### PR TITLE
Disable HSTS includeSubdomains by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* [BREAKING] Disable HSTS `includeSubdomains` by default ([#1409](https://github.com/roots/trellis/pull/1409))
 * Fix #905, #831 - Update hb5p Nginx configs ([#1406](https://github.com/roots/trellis/pull/1406))
 
 ### 1.16.0: July 18th, 2022

--- a/roles/wordpress-setup/defaults/main.yml
+++ b/roles/wordpress-setup/defaults/main.yml
@@ -18,7 +18,7 @@ nginx_sites_confs:
 
 # HSTS defaults
 nginx_hsts_max_age: 31536000
-nginx_hsts_include_subdomains: true
+nginx_hsts_include_subdomains: false
 nginx_hsts_preload: false
 
 # HSTS helpers


### PR DESCRIPTION
Ref #741

This changes the default for HSTS' `includeSubdomains` value from `true` to `false`. Previously a user visiting a WordPress site would result in HSTS being enabled in their browser for _all_ subdomains of the site's domain. Now HSTS will only apply to the hostnames activately managed by Trellis in the `wordpress_sites.yml` config.

This is a safer default since subdomains can frequently exist without SSL.

**Note**: this is a **breaking change** for anyone who never disabled this manually. Provisioning this change will result in subdomains being excluded from HSTS. If you want this behaviour, and we recommend it where possible, you'll need to manually opt back into it:

Per site:
```yaml
# group_vars/production/wordpress_sites.yml (example)

example.com:
  # rest of site config
  ssl:
    enabled: true
    hsts_include_subdomains: true
```

Globally:
```yaml
# group_vars/production/main.yml

nginx_hsts_include_subdomains: true
```

Docs update: https://github.com/roots/docs/pull/417