### PR TITLE
Run composer check-platform-reqs during deploy

### DIFF
--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -51,6 +51,8 @@ update_db_on_deploy: true
 
 # Most scripts are used in development instead of remote servers. Use with caution.
 composer_no_scripts: true
+# Whether to run `composer check-platform-reqs`.
+composer_platform_requirements_check: true
 # Whether to autoload classes from classmap only.
 composer_classmap_authoritative: true
 

--- a/roles/deploy/hooks/build-after.yml
+++ b/roles/deploy/hooks/build-after.yml
@@ -25,6 +25,12 @@
     loop_var: composer_authentication
     label: "{{ composer_authentication.hostname }}"
 
+- name: Run composer check
+  composer:
+    command: check-platform-reqs
+    working_dir: "{{ deploy_helper.new_release_path }}"
+  when: composer_platform_requirements_check
+
 - name: Install Composer dependencies
   composer:
     no_scripts: "{{ composer_no_scripts }}"


### PR DESCRIPTION
Fixes #1244

Runs `composer check-platform-reqs` before installing composer dependencies to verify that platform requirements (i.e. php and php extensions) are fulfilled by the PHP process currently running. This could potentially prevent some "white page of death" errors before a deploy.

Ref https://getcomposer.org/doc/07-runtime.md#platform-check