### PR TITLE
Improve composer authentications password default

### DIFF
--- a/group_vars/all/helpers.yml
+++ b/group_vars/all/helpers.yml
@@ -20,8 +20,4 @@ ssl_stapling_enabled: "{{ item.value.ssl is defined and item.value.ssl.stapling_
 cron_enabled: "{{ site_env.disable_wp_cron and (not item.value.multisite.enabled | default(false) or (item.value.multisite.enabled | default(false) and item.value.multisite.cron | default(true))) }}"
 sites_use_ssl: "{{ wordpress_sites.values() | map(attribute='ssl') | selectattr('enabled') | list | count > 0 }}"
 
-# For backward compatibility, to be removed in Trellis v2.
-site_packagist_org_authentications:
-  - { hostname: repo.packagist.com, username: token, password: "{{ vault_wordpress_sites[site].packagist_token | default('') }}" }
-site_composer_authentications: "{{ vault_wordpress_sites[site].composer_authentications | default([]) }}"
-composer_authentications: "{{ site_packagist_org_authentications + site_composer_authentications }}"
+composer_authentications: "{{ vault_wordpress_sites[site].composer_authentications | default([]) }}"

--- a/roles/deploy/hooks/build-after.yml
+++ b/roles/deploy/hooks/build-after.yml
@@ -12,14 +12,13 @@
 - name: Setup composer authentications
   composer:
     command: config
-    arguments: --auth http-basic.{{ composer_authentication.hostname }} {{ composer_authentication.username }} {{ composer_authentication.password }}
+    arguments: --auth http-basic.{{ composer_authentication.hostname }} {{ composer_authentication.username }} {{ composer_authentication.password | default("") | quote }}
     working_dir: "{{ deploy_helper.new_release_path }}"
   no_log: true
   changed_when: false
   when:
     - composer_authentication.hostname is defined and composer_authentication.hostname != ""
     - composer_authentication.username is defined and composer_authentication.username != ""
-    - composer_authentication.password is defined and composer_authentication.password != ""
   loop: "{{ composer_authentications | default([]) }}"
   loop_control:
     loop_var: composer_authentication

--- a/roles/deploy/hooks/build-after.yml
+++ b/roles/deploy/hooks/build-after.yml
@@ -12,7 +12,7 @@
 - name: Setup composer authentications
   composer:
     command: config
-    arguments: --auth http-basic.{{ composer_authentication.hostname }} {{ composer_authentication.username }} {{ composer_authentication.password | default("") | quote }}
+    arguments: --auth http-basic.{{ composer_authentication.hostname | quote }} {{ composer_authentication.username | quote }} {{ composer_authentication.password | default("") | quote }}
     working_dir: "{{ deploy_helper.new_release_path }}"
   no_log: true
   changed_when: false

--- a/roles/wordpress-install/tasks/composer-authentications.yml
+++ b/roles/wordpress-install/tasks/composer-authentications.yml
@@ -2,14 +2,13 @@
 - name: "Setup composer authentications - {{ site }}"
   composer:
     command: config
-    arguments: --auth http-basic.{{ composer_authentication.hostname }} {{ composer_authentication.username }} {{ composer_authentication.password }}
+    arguments: --auth http-basic.{{ composer_authentication.hostname }} {{ composer_authentication.username }} {{ composer_authentication.password | default("") | quote }}
     working_dir: "{{ working_dir }}"
   no_log: true
   changed_when: false
   when:
-    - not (not composer_authentication.hostname)
-    - not (not composer_authentication.username)
-    - not (not composer_authentication.password)
+    - composer_authentication.hostname is defined and composer_authentication.hostname != ""
+    - composer_authentication.username is defined and composer_authentication.username != ""
   loop: "{{ composer_authentications | default([]) }}"
   loop_control:
     loop_var: composer_authentication

--- a/roles/wordpress-install/tasks/composer-authentications.yml
+++ b/roles/wordpress-install/tasks/composer-authentications.yml
@@ -2,7 +2,7 @@
 - name: "Setup composer authentications - {{ site }}"
   composer:
     command: config
-    arguments: --auth http-basic.{{ composer_authentication.hostname }} {{ composer_authentication.username }} {{ composer_authentication.password | default("") | quote }}
+    arguments: --auth http-basic.{{ composer_authentication.hostname | quote }} {{ composer_authentication.username | quote }} {{ composer_authentication.password | default("") | quote }}
     working_dir: "{{ working_dir }}"
   no_log: true
   changed_when: false


### PR DESCRIPTION
Removes the validation to enforce `password` and sets the default to `""` which is quoted to ensure `composer` is properly passed `""` as the last argument value.