### PR TITLE
Composer Authentication: Add support for `bearer`, `gitlab-oauth`, `gitlab-token`, `github-oauth` and `bitbucket-oauth` principles

### DIFF
--- a/group_vars/all/helpers.yml
+++ b/group_vars/all/helpers.yml
@@ -21,3 +21,7 @@ cron_enabled: "{{ site_env.disable_wp_cron and (not item.value.multisite.enabled
 sites_use_ssl: "{{ wordpress_sites.values() | map(attribute='ssl') | selectattr('enabled') | list | count > 0 }}"
 
 composer_authentications: "{{ vault_wordpress_sites[site].composer_authentications | default([]) }}"
+# Default `type` is `http-basic`.
+composer_authentications_using_basic_auth: "{{ composer_authentications | rejectattr('type', 'defined') | union( composer_authentications | selectattr('type', 'defined') | selectattr('type', 'equalto', 'http-basic') ) }}"
+composer_authentications_using_bitbucket_oauth: "{{ composer_authentications | selectattr('type', 'defined') | selectattr('type', 'equalto', 'bitbucket-oauth') }}"
+composer_authentications_using_other_token: "{{ composer_authentications | selectattr('type', 'defined') | rejectattr('type', 'equalto', 'http-basic') | rejectattr('type', 'equalto', 'bitbucket-oauth') }}"

--- a/roles/deploy/hooks/build-after.yml
+++ b/roles/deploy/hooks/build-after.yml
@@ -9,20 +9,48 @@
     msg: "Unable to find a `composer.json` file in the root of '{{ deploy_helper.new_release_path }}'. Make sure your repo has a `composer.json` file in its root or edit `repo_subtree_path` for '{{ site }}' in `wordpress_sites.yml` so it points to the directory with a `composer.json` file."
   when: not composer_json.stat.exists
 
-- name: Setup composer authentications
+- name: Setup composer authentications (HTTP Basic)
   composer:
     command: config
-    arguments: --auth http-basic.{{ composer_authentication.hostname | quote }} {{ composer_authentication.username | quote }} {{ composer_authentication.password | default("") | quote }}
+    arguments: --auth http-basic.{{ item.hostname | quote }} {{ item.username | quote }} {{ item.password | default("") | quote }}
     working_dir: "{{ deploy_helper.new_release_path }}"
   no_log: true
   changed_when: false
   when:
-    - composer_authentication.hostname is defined and composer_authentication.hostname != ""
-    - composer_authentication.username is defined and composer_authentication.username != ""
-  loop: "{{ composer_authentications | default([]) }}"
+    - item.hostname is defined and item.hostname != ""
+    - item.username is defined and item.username != ""
+  loop: "{{ composer_authentications_using_basic_auth }}"
   loop_control:
-    loop_var: composer_authentication
-    label: "{{ composer_authentication.hostname }}"
+    label: "{{ item.type | default('default-type') }}.{{ item.hostname }}"
+
+- name: Setup composer authentications (BitBucket OAuth)
+  composer:
+    command: config
+    arguments: --auth bitbucket-oauth.{{ item.hostname | quote }} {{ item.consumer_key | quote }} {{ item.consumer_secret | quote }}
+    working_dir: "{{ deploy_helper.new_release_path }}"
+  no_log: true
+  changed_when: false
+  when:
+    - item.hostname is defined and item.hostname != ""
+    - item.consumer_key is defined and item.consumer_key != ""
+    - item.consumer_secret is defined and item.consumer_secret != ""
+  loop: "{{ composer_authentications_using_bitbucket_oauth }}"
+  loop_control:
+    label: "{{ item.type }}.{{ item.hostname }}"
+
+- name: Setup composer authentications (Other Tokens)
+  composer:
+    command: config
+    arguments: --auth {{ item.type | quote }}.{{ item.hostname | quote }} {{ item.token | quote }}
+    working_dir: "{{ deploy_helper.new_release_path }}"
+  no_log: true
+  changed_when: false
+  when:
+    - item.hostname is defined and item.hostname != ""
+    - item.token is defined and item.token != ""
+  loop: "{{ composer_authentications_using_other_token }}"
+  loop_control:
+    label: "{{ item.type }}.{{ item.hostname }}"
 
 - name: Run composer check
   composer:

--- a/roles/wordpress-install/tasks/composer-authentications.yml
+++ b/roles/wordpress-install/tasks/composer-authentications.yml
@@ -1,15 +1,43 @@
 ---
-- name: "Setup composer authentications - {{ site }}"
+- name: "Setup composer authentications (HTTP Basic) - {{ site }}"
   composer:
     command: config
-    arguments: --auth http-basic.{{ composer_authentication.hostname | quote }} {{ composer_authentication.username | quote }} {{ composer_authentication.password | default("") | quote }}
+    arguments: --auth http-basic.{{ item.hostname | quote }} {{ item.username | quote }} {{ item.password | default("") | quote }}
     working_dir: "{{ working_dir }}"
   no_log: true
   changed_when: false
   when:
-    - composer_authentication.hostname is defined and composer_authentication.hostname != ""
-    - composer_authentication.username is defined and composer_authentication.username != ""
-  loop: "{{ composer_authentications | default([]) }}"
+    - item.hostname is defined and item.hostname != ""
+    - item.username is defined and item.username != ""
+  loop: "{{ composer_authentications_using_basic_auth }}"
   loop_control:
-    loop_var: composer_authentication
-    label: "{{ composer_authentication.hostname }}"
+    label: "{{ item.type | default('default-type') }}.{{ item.hostname }}"
+
+- name: "Setup composer authentications (BitBucket OAuth) - {{ site }}"
+  composer:
+    command: config
+    arguments: --auth bitbucket-oauth.{{ item.hostname | quote }} {{ item.consumer_key | quote }} {{ item.consumer_secret | quote }}
+    working_dir: "{{ working_dir }}"
+  no_log: true
+  changed_when: false
+  when:
+    - item.hostname is defined and item.hostname != ""
+    - item.consumer_key is defined and item.consumer_key != ""
+    - item.consumer_secret is defined and item.consumer_secret != ""
+  loop: "{{ composer_authentications_using_bitbucket_oauth }}"
+  loop_control:
+    label: "{{ item.type }}.{{ item.hostname }}"
+
+- name: "Setup composer authentications (Other Tokens) - {{ site }}"
+  composer:
+    command: config
+    arguments: --auth {{ item.type | quote }}.{{ item.hostname | quote }} {{ item.token | quote }}
+    working_dir: "{{ working_dir }}"
+  no_log: true
+  changed_when: false
+  when:
+    - item.hostname is defined and item.hostname != ""
+    - item.token is defined and item.token != ""
+  loop: "{{ composer_authentications_using_other_token }}"
+  loop_control:
+    label: "{{ item.type }}.{{ item.hostname }}"


### PR DESCRIPTION
Add support for `bearer` `gitlab-oauth`, `gitlab-token`, `github-oauth` and `bitbucket-oauth` principles

|Principle (`type`)|Supported?|
|---|---| 
|`http-basic`| :white_check_mark: old feature|
|Inline `http-basic`| :x: use `http-basic` instead|
|HTTP Bearer (`bearer`)| :white_check_mark:|
|Custom header| :x: composer doesn't support setting it in non-interactive mode|
|`gitlab-oauth`| :white_check_mark:|
|`gitlab-token`| :white_check_mark:|
|`github-oauth`| :white_check_mark:|
|`bitbucket-oauth`| :white_check_mark:|

---

### ~~Breaking Changes~~ 

> **Note**
> Breaking changes have been removed. See: https://github.com/roots/trellis/pull/1413#issuecomment-1228352480

~~This PR contains a breaking change. `type` is now required in [`composer_authentications`](https://github.com/roots/trellis/blob/8104b1d7ce1527b255103f3362b1f26b33d13fc2/group_vars/all/helpers.yml#L23).~~

~~For example:~~

```yml
---
composer_authentications:
  - { type: http-basic, hostname: http-basic.com, username: http-basic-username, password: http-basic-password }
  - { type: http-basic, hostname: second.http-basic.com/without-password, username:  second-http-basic-username }

  - { type: bearer, hostname: bearer.com, token: bearer-token }
  - { type: bearer, hostname: second.bearer.com/abc/def, token:  second-bearer-token }

  - { type: gitlab-oauth, hostname: gitlab.com, token: gitlab-com-oauth-token }
  - { type: gitlab-oauth, hostname: gitlab.oauth.org, token: gitlab-oauth-org-token }

  - { type: gitlab-token, hostname: gitlab.com, token: gitlab-com-token-token }
  - { type: gitlab-token, hostname: gitlab.token.org, token: gitlab-token-org-token }

  - { type: github-oauth, hostname: github.com, token: githubcomtoken }
  - { type: github-oauth, hostname: you.most.likely.set.this.to.github-com.example, token: youmostlikelysetthistogithubcomexampletoken }

  - { type: bitbucket-oauth, hostname: bitbucket.org, consumer_key: bitbucket-org-consumer-key, consumer_secret: bitbucket-org-consumer-secret }
  - { type: bitbucket-oauth, hostname: private-bitbucket.com, consumer_key: private-bitbucket-com-consumer-key, consumer_secret: private-bitbucket-com-consumer-secret }
```

~~The above example results in the following `auth.json`:~~

```json
{
    "http-basic": {
        "http-basic.com": {
            "username": "http-basic-username",
            "password": "http-basic-password"
        },
        "second.http-basic.com/without-password": {
            "username": "second-http-basic-username",
            "password": ""
        }
    },
    "bitbucket-oauth": {
        "bitbucket.org": {
            "consumer-key": "bitbucket-org-consumer-key",
            "consumer-secret": "bitbucket-org-consumer-secret"
        },
        "private-bitbucket.com": {
            "consumer-key": "private-bitbucket-com-consumer-key",
            "consumer-secret": "private-bitbucket-com-consumer-secret"
        }
    },
    "bearer": {
        "bearer.com": "bearer-token",
        "second.bearer.com/abc/def": "second-bearer-token"
    },
    "gitlab-oauth": {
        "gitlab.com": "gitlab-com-oauth-token",
        "gitlab.oauth.org": "gitlab-oauth-org-token"
    },
    "gitlab-token": {
        "gitlab.com": "gitlab-com-token-token",
        "gitlab.token.org": "gitlab-token-org-token"
    },
    "github-oauth": {
        "github.com": "githubcomtoken",
        "you.most.likely.set.this.to.github-com.example": "youmostlikelysetthistogithubcomexampletoken"
    }
}

```

---

`github-oauth` was supported in v0.9.3 but removed in v0.9.6

- https://github.com/roots/trellis/pull/402
- https://github.com/roots/trellis/commit/625ca3f1417476a29dc8bef85ba2d92044c0883e
- https://github.com/roots/trellis/pull/491

---

See also:
- https://getcomposer.org/doc/articles/authentication-for-private-packages.md#manually-editing-global-authentication-credentials
- https://discourse.roots.io/t/composer-trellis-bedrock-private-composer-repositories/22831
- https://discourse.roots.io/t/gitlab-private-repo-as-composer-package/20592
- https://discourse.roots.io/t/private-or-commercial-wordpress-plugins-as-composer-dependencies/13247

