### PR TITLE
Fix backwards compat for ssl.no-default conf

### DIFF
--- a/roles/wordpress-setup/defaults/main.yml
+++ b/roles/wordpress-setup/defaults/main.yml
@@ -4,6 +4,8 @@ nginx_ssl_path: "{{ nginx_path }}/ssl"
 
 nginx_sites_confs:
   - src: no-default.conf.j2
+  - src: ssl.no-default.conf.j2
+    enabled: false
 
 # HSTS defaults
 nginx_hsts_max_age: 31536000

--- a/roles/wordpress-setup/tasks/nginx.yml
+++ b/roles/wordpress-setup/tasks/nginx.yml
@@ -29,6 +29,15 @@
   notify: reload nginx
   tags: nginx-sites
 
+- name: Disable Nginx sites
+  file:
+    path: "{{ nginx_path }}/sites-enabled/{{ item.src | basename | regex_replace('.j2$', '') }}"
+    state: absent
+  when: not(item.enabled | default(true))
+  with_items: "{{ nginx_sites_confs }}"
+  notify: reload nginx
+  tags: nginx-sites
+
 - name: Enable Nginx sites
   file:
     path: "{{ nginx_path }}/sites-enabled/{{ item.src | basename | regex_replace('.j2$', '') }}"
@@ -36,15 +45,6 @@
     state: link
     force: yes
   when: item.enabled | default(true)
-  with_items: "{{ nginx_sites_confs }}"
-  notify: reload nginx
-  tags: nginx-sites
-
-- name: Disable Nginx sites
-  file:
-    path: "{{ nginx_path }}/sites-enabled/{{ item.src | basename | regex_replace('.j2$', '') }}"
-    state: absent
-  when: not(item.enabled | default(true))
   with_items: "{{ nginx_sites_confs }}"
   notify: reload nginx
   tags: nginx-sites


### PR DESCRIPTION
https://github.com/roots/trellis/pull/1414 simplified the Nginx "no-default" site confs but broke backwards compatibility for existing servers by leaving the old site enabled. This would result in Nginx failing to restart because of duplicate listen options.

This keeps the `ssl.no-default.conf.j2` site conf but instead sets it to disabled to prevent the duplicate listen options. Now there will only be a single active site for "no-default" that contains both HTTP (port 80) and HTTPS (port 443) listen options.