### PR TITLE
Add integration test step for second deploy

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -61,6 +61,9 @@ jobs:
         working-directory: /srv/www/example.com/current
       - name: Verify install
         run: curl -s http://example.com | grep "<title>Example"
+      - name: Deploy previously deployed site
+        run: trellis deploy --extra-vars "web_user=runner project_git_repo=https://github.com/roots/bedrock.git" production example.com
+        working-directory: example.com
       - name: Deploy https site
         run: trellis deploy --extra-vars "web_user=runner project_git_repo=https://github.com/roots/bedrock.git" production example-https.com
         working-directory: example.com


### PR DESCRIPTION
This will trigger more conditional branches that the first deploy doesn't (since WP isn't yet installed for that one).