### PR TITLE
Remove dynamic SSH key host checks

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -10,5 +10,5 @@ vars_plugins = ~/.ansible/plugins/vars:/usr/share/ansible/plugins/vars:lib/trell
 pipelining = True
 
 [ssh_connection]
-ssh_args = -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s
+ssh_args = -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s -o HostKeyAlgorithms=ssh-ed25519-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ssh-ed25519,ssh-rsa
 retries = 1

--- a/lib/trellis/plugins/callback/vars.py
+++ b/lib/trellis/plugins/callback/vars.py
@@ -10,7 +10,6 @@ from ansible.plugins.callback import CallbackBase
 from ansible.template import Templar
 from ansible.utils.unsafe_proxy import wrap_var
 from ansible import context
-from ansible.plugins.loader import connection_loader
 
 
 class CallbackModule(CallbackBase):
@@ -92,7 +91,6 @@ class CallbackModule(CallbackBase):
 
     def v2_playbook_on_play_start(self, play):
         play_context = PlayContext(play=play)
-        connection = connection_loader.get('ssh', play_context, os.devnull)
 
         env = play.get_variable_manager().get_vars(play=play).get('env', '')
         env_group = next((group for key,group in iteritems(play.get_variable_manager()._inventory.groups) if key == env), False)
@@ -102,7 +100,6 @@ class CallbackModule(CallbackBase):
         for host in play.get_variable_manager()._inventory.list_hosts(play.hosts[0]):
             hostvars = play.get_variable_manager().get_vars(play=play, host=host)
             self.raw_vars(play, host, hostvars)
-            host.vars['ssh_args_default'] = connection.get_option('ssh_args')
             host.vars['cli_options'] = self.cli_options()
             host.vars['cli_ask_pass'] = self._options.get('ask_pass', False)
             host.vars['cli_ask_become_pass'] = self._options.get('become_ask_pass', False)

--- a/roles/connection/defaults/main.yml
+++ b/roles/connection/defaults/main.yml
@@ -1,5 +1,0 @@
-ansible_host_known: "{{ lookup('pipe', 'ssh-keygen -F ' + ansible_host + ' > /dev/null 2>&1 && echo True || echo False') }}"
-ssh_config_host: "{{ lookup('pipe', 'ssh -G ' + ansible_host + ' 2>/dev/null | grep \"^hostname\" ||:') | regex_replace('^hostname ([^\\s]+)', '\\1') }}"
-ssh_config_host_known: "{{ lookup('pipe', 'ssh-keygen -F ' + ssh_config_host + ' > /dev/null 2>&1 && echo True || echo False') }}"
-openssh_6_5_plus: "{{ (lookup('pipe', 'ssh -V 2>&1')) | regex_replace('(.*OpenSSH_([\\d\\.]*).*)', '\\2') is version_compare('6.5', '>=') }}"
-host_key_algorithms: "{{ openssh_6_5_plus | ternary('ssh-ed25519-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ssh-ed25519,ssh-rsa', 'ssh-rsa-cert-v01@openssh.com,ssh-rsa') }}"

--- a/roles/connection/tasks/main.yml
+++ b/roles/connection/tasks/main.yml
@@ -6,22 +6,11 @@
       ansible-playbook server.yml -e env={{ env | default('production') }} -u root --ask-pass
   when: dynamic_user | default(true) and ansible_user is not defined and cli_ask_pass | default(false)
 
-- name: Specify preferred HostKeyAlgorithms for unknown hosts
-  set_fact:
-    ansible_ssh_extra_args: -o HostKeyAlgorithms={{ host_key_algorithms }}
-  register: preferred_host_key_algorithms
-  when:
-    - dynamic_host_key_algorithms | default(true)
-    - not ansible_ssh_extra_args | default(None)
-    - not (ansible_host_known or ssh_config_host_known)
-
 - name: Check whether Ansible can connect as {{ dynamic_user | default(true) | ternary('root', web_user) }}
   command: |
     ansible {{ inventory_hostname }} -m raw -a whoami
     -u {{ dynamic_user | default(true) | ternary('root', web_user) }} {{ cli_options | default('') }} -vvvv
   delegate_to: localhost
-  environment:
-    ANSIBLE_SSH_ARGS: "{{ ssh_args_default }} {{ ansible_ssh_extra_args | default('') }}"
   failed_when: false
   changed_when: false
   check_mode: no
@@ -61,19 +50,6 @@
     debug:
       msg: |
         Note: Ansible will attempt connections as user = {{ ansible_user }}
-        {% if preferred_host_key_algorithms is not skipped %}
-
-        Note: The host `{{ ansible_host }}` was not detected in known_hosts
-        so Trellis prompted the host to offer a key type that will work with
-        the stronger key types Trellis configures on the server. This avoids future
-        connection failures due to changed host keys. Trellis used this SSH option:
-
-          {{ ansible_ssh_extra_args }}
-
-        To prevent Trellis from ever using this SSH option, add this to group_vars:
-
-          dynamic_host_key_algorithms: false
-        {% endif %}
 
   - name: Load become password
     set_fact:


### PR DESCRIPTION
Reverts a feature originally added in https://github.com/roots/trellis/pull/798 (though the implementation has changed over time).

This was first added to avoid SSH host key algorithm mismatches between _old_ versions of OpenSSH on the client (local machine) and servers (VM or remote server). In 2017, ed25519 (the preferred algorithm) was new enough in some macOS versions that this feature was needed. However, now it's 2022 and it should be extremely rare (if at all) that someone is using an OpenSSH version that old where ed25519 isn't supported.

Keeping this code makes maintaining Trellis and Ansible support more complex and has caused issues over the years. If it's not needed, then removing this feature entirely is a net benefit to simplify the codebase.