### PR TITLE
Update Vagrant required version

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,12 +16,8 @@ ensure_plugins(vconfig.fetch('vagrant_plugins')) if vconfig.fetch('vagrant_insta
 
 trellis_config = Trellis::Config.new(root_path: ANSIBLE_PATH)
 
-if Vagrant::Util::Platform.darwin?
-  Vagrant.require_version '>= 2.1.0', '< 2.2.19'
-else
-  Vagrant.require_version '>= 2.1.0'
-end
-  
+Vagrant.require_version vconfig.fetch('vagrant_require_version', '>= 2.1.0')
+
 Vagrant.configure('2') do |config|
   config.vm.box = vconfig.fetch('vagrant_box')
   config.vm.box_version = vconfig.fetch('vagrant_box_version')

--- a/vagrant.default.yml
+++ b/vagrant.default.yml
@@ -7,6 +7,7 @@ vagrant_box_version: '>= 202012.23.0'
 vagrant_ansible_version: '2.10.7'
 vagrant_skip_galaxy: false
 vagrant_mount_type: 'nfs'
+vagrant_require_version: '>= 2.1.0'
 
 vagrant_install_plugins: true
 vagrant_plugins:


### PR DESCRIPTION
Now that Vagrant 2.3.0, we can drop the exception for the broken 2.2.19 release.

This also removes the platform check and introduces a new `vagrant_require_version` config setting. This makes it easier to override the version constraint in a local config if need be without changing the `Vagrantfile`.