### PR TITLE
Disable Landrush DNS Resolver in Parallels

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -181,6 +181,11 @@ Vagrant.configure('2') do |config|
     prl.cpus = vconfig.fetch('vagrant_cpus')
     prl.memory = vconfig.fetch('vagrant_memory')
     prl.update_guest_tools = true
+
+    # Parallels handles DNS resolution itself when used in conjunction with landrush
+    if Vagrant.has_plugin?('landrush') && trellis_config.multisite_subdomains?
+      config.landrush.guest_redirect_dns = false
+    end
   end
 
   # Hyper-V settings


### PR DESCRIPTION
## Issue this fixes

Specific to the following configuration:

- HEAD Trellis
- Parallels as a provisioner
- Multisite subdomains enabled and Landrush used as DNS resolver

Without this change, when provisioning the above this will fail. Due to the attempt of Landrush attempting to being the DNS resolver for guest. For more information: https://discourse.roots.io/t/no-dns-resolution-in-development-vm-vagrant-parallels-multisite-landrush/23170

Specifically Landrush will attempt to change IP Tables and internal DNS on the vagrant machine, upon attempting this communication to services such as APT and any outside connections will fail. This is due to Parallels differing in network adapters created. Parallels by default wlll configure a shared adapter for NAT / DNS resolution. And a secondary adapter for the custom IP we specify. Landrush not knowing that DNS is handled that way will therefore break DNS/NAT.

Credit to this fix is all on @Twansparant

The current addition adds a conditional to Parallels provisioner, however if double nested `if` statements are okay, we could move this up to the block below, and instead check if the current provisioner is Parallels and prefer Landrush config grouping: https://github.com/roots/trellis/blob/e9e7c370410dc3c680d64c5b846a4bab8b00c5f0/Vagrantfile#L60-L62



