### PR TITLE
🔧 Change MariaDB PPA mirror to Rackspace

### DIFF
--- a/roles/mariadb/defaults/main.yml
+++ b/roles/mariadb/defaults/main.yml
@@ -1,6 +1,6 @@
 mariadb_keyserver: "hkp://keyserver.ubuntu.com:80"
 mariadb_keyserver_id: "0xF1656F24C74CD1D8"
-mariadb_ppa: "deb http://mariadb.mirror.globo.tech/repo/10.5/ubuntu {{ ansible_distribution_release }} main"
+mariadb_ppa: "deb https://mirror.rackspace.com/mariadb/repo/10.5/ubuntu {{ ansible_distribution_release }} main"
 
 mariadb_client_package: mariadb-client
 mariadb_server_package: mariadb-server


### PR DESCRIPTION
It looks like the Release file error has returned again:

```
TASK [mariadb : Add MariaDB PPA] ***********************************************
---------------------------------------------------
Failed to update apt cache: E:The repository
'http://mirrors.gigenet.com/mariadb/repo/10.5/ubuntu focal Release' does not
have a Release file.
fatal: [default]: FAILED! => {"changed": false}
```

This PR changes the MariaDB mirror to Rackspace

Ref https://discourse.roots.io/t/provisioning-production-fails-no-release-file/21678