### PR TITLE
🔧 Sage 10 deploy: Fail if entrypoints is missing

### DIFF
--- a/deploy-hooks/build-before.yml
+++ b/deploy-hooks/build-before.yml
@@ -24,6 +24,17 @@
 #   args:
 #     chdir: "{{ project_local_path }}/web/app/themes/sage"
 #
+# - name: Check for entrypoints
+#   stat:
+#     path: "{{ project_local_path }}/web/app/themes/sage/public/entrypoints.json"
+#   delegate_to: localhost
+#   register: entrypoints_data
+
+# - name: Entrypoints missing
+#   ansible.builtin.fail:
+#     msg: "The theme is missing the public/entrypoints.json file"
+#   when: not entrypoints_data.stat.exists
+#
 # - name: Copy production assets
 #   synchronize:
 #     src: "{{ project_local_path }}/web/app/themes/sage/public"


### PR DESCRIPTION
This PR adds a failsafe to deploying a site with a Sage 10 theme for if Bud ever fails to exit when a build fails

Ref https://github.com/roots/bud/issues/1698