### PR TITLE
Don't use sudo for composer authentications

### DIFF
--- a/roles/wordpress-install/tasks/composer-authentications.yml
+++ b/roles/wordpress-install/tasks/composer-authentications.yml
@@ -4,6 +4,7 @@
     command: config
     arguments: --auth http-basic.{{ composer_authentication.hostname | quote }} {{ composer_authentication.username | quote }} {{ composer_authentication.password | default("") | quote }}
     working_dir: "{{ working_dir }}"
+  become: no
   no_log: true
   changed_when: false
   when:


### PR DESCRIPTION
Sets `become: no` to avoid sudo usage which will prevent Composer from aborting due to its default root/superuser protection.

Ref: https://discourse.roots.io/t/provision-hangs-on-setup-composer-authentications-on-older-project-if-using-trellis-cli-but-works-with-old-process/23804/13?u=swalkinshaw