### PR TITLE
Fix xdebug role by including PHP vars

### DIFF
--- a/roles/xdebug/tasks/main.yml
+++ b/roles/xdebug/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: Include php{{ php_version }} related vars
+  include_vars: 'roles/php/vars/{{ php_version }}.yml'
+
 - name: Install Xdebug
   apt:
     name: "{{ php_xdebug_package }}"


### PR DESCRIPTION
Include php role vars to get the otherwise missing php_xdebug_package vars