### PR TITLE
Automate arm64 Vagrant box support for Apple Silicon

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,14 @@ trellis_config = Trellis::Config.new(root_path: ANSIBLE_PATH)
 Vagrant.require_version vconfig.fetch('vagrant_require_version', '>= 2.1.0')
 
 Vagrant.configure('2') do |config|
-  config.vm.box = vconfig.fetch('vagrant_box')
+  box = vconfig.fetch('vagrant_box')
+  box_auto_arch = vconfig.fetch('vagrant_box_auto_arch', true)
+
+  if box_auto_arch && !box.end_with?("-arm64") && apple_silicon?
+    box = "#{box}-arm64"
+  end
+
+  config.vm.box = box
   config.vm.box_version = vconfig.fetch('vagrant_box_version')
   config.ssh.forward_agent = true
   config.vm.post_up_message = post_up_message

--- a/lib/trellis/vagrant.rb
+++ b/lib/trellis/vagrant.rb
@@ -6,6 +6,19 @@ ENV['ANSIBLE_LIBRARY'] = "~/.ansible/plugins/modules:/usr/share/ansible/plugins/
 ENV['ANSIBLE_ROLES_PATH'] = File.join(ANSIBLE_PATH, 'vendor', 'roles')
 ENV['ANSIBLE_VARS_PLUGINS'] = "~/.ansible/plugins/vars:/usr/share/ansible/plugins/vars:#{File.join(ANSIBLE_PATH, 'lib/trellis/plugins/vars')}"
 
+def apple_silicon?
+  return false unless Vagrant::Util::Platform.darwin?
+
+  arch = `uname -m`.chomp
+  case arch
+  when "x86_64"
+    translated = `sysctl -in sysctl.proc_translated`.chomp
+    translated == "1"
+  when "arm64"
+    true
+  end
+end
+
 def ensure_plugins(plugins)
   logger = Vagrant::UI::Colored.new
   installed = false

--- a/vagrant.default.yml
+++ b/vagrant.default.yml
@@ -3,7 +3,8 @@ vagrant_ip: '192.168.56.5'
 vagrant_cpus: 1
 vagrant_memory: 1024 # in MB
 vagrant_box: 'bento/ubuntu-20.04'
-vagrant_box_version: '>= 202012.23.0'
+vagrant_box_version: '>= 0'
+vagrant_box_auto_arch: true
 vagrant_ansible_version: '2.10.7'
 vagrant_skip_galaxy: false
 vagrant_mount_type: 'nfs'


### PR DESCRIPTION
Adds built-in support to automate host architecture detection and setting of arm64 specific boxes for Apple Silicon.

Previously the `vagrant_box` config setting would have to be manually overwritten. Now Vagrant will detect the OS architecture of the host and _append_ `-arm64` (by convention) when three conditions apply:

1. `vagrant_box_auto_arch` is enabled (default: true)
2. `vagrant_box` does not already end up with `-arm64`
3. the OS is running on Apple Silicon