### PR TITLE
Support ARM64 arch in Mailhog role

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -16,6 +16,5 @@ roles:
     src: oefenweb.swapfile
     version: v2.0.32
 
-  - name: mailhog
-    src: geerlingguy.mailhog
+  - src: geerlingguy.mailhog
     version: 2.3.0

--- a/roles/mailhog/defaults/main.yml
+++ b/roles/mailhog/defaults/main.yml
@@ -1,0 +1,1 @@
+mailhog_install_dir: /opt/mailhog

--- a/roles/mailhog/tasks/main.yml
+++ b/roles/mailhog/tasks/main.yml
@@ -1,0 +1,13 @@
+- ansible.builtin.include_vars:
+    file: "{{ item }}"
+    name: mailhog_overrides
+  with_first_found:
+    - files:
+      - "vars/{{ ansible_architecture }}.yml"
+      - "vars/default.yml"
+
+- ansible.builtin.include_role:
+    name: geerlingguy.mailhog
+  vars:
+    mailhog_binary_url: "{{ mailhog_overrides.mailhog_binary_url }}"
+    mhsendmail_binary_url: "{{ mailhog_overrides.mhsendmail_binary_url }}"

--- a/roles/mailhog/vars/aarch64.yml
+++ b/roles/mailhog/vars/aarch64.yml
@@ -1,0 +1,2 @@
+mailhog_binary_url: "https://github.com/evertiro/MailHog/releases/download/v1.0.1-M1/MailHog_linux_arm64"
+mhsendmail_binary_url: "https://github.com/evertiro/mhsendmail/releases/download/v0.2.0-M1/mhsendmail_linux_arm64"

--- a/roles/mailhog/vars/default.yml
+++ b/roles/mailhog/vars/default.yml
@@ -1,0 +1,2 @@
+mailhog_binary_url: "https://github.com/mailhog/MailHog/releases/download/v{{ mailhog_version }}/MailHog_linux_{{ mailhog_arch }}"
+mhsendmail_binary_url: "https://github.com/mailhog/mhsendmail/releases/download/v{{ mhsendmail_version }}/mhsendmail_linux_{{ mailhog_arch }}"


### PR DESCRIPTION
`geerlingguy.mailhog` doesn't support arm64 (Apple Silicon) because the underlying binaries (`mailhog` and `mhsendmail`) don't have official `arm64` builds.

To support this by default, we need to override the url variables to point to forks that have these builds.

This adds a new "shim loader" `mailhog` role which simply loads the proper vars and then passes them to the included `geerlingguy.mailhog` role.