### PR TITLE
[Security] Due to the default caching of POST requests personal information can be leaked

### DIFF
--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -43,7 +43,7 @@ server {
   }
 
   # Prevent common API POST like requests being cached
-  if ($request_method ~* (PUT|PATCH|DELETE)) {
+  if ($request_method ~ (PUT|PATCH|DELETE)) {
     set $skip_cache 1;
   }
 

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -39,7 +39,7 @@ server {
 
   # Prevent POST data being held in cache
   if ($request_method = POST) {
-      set $skip_cache 1;
+    set $skip_cache 1;
   }
 
   # Prevent common API POST like requests being cached

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -42,14 +42,9 @@ server {
       set $skip_cache 1;
   }
 
-  # Prevent PATCH requests from hitting cache in APIs
-  if ($request_method = PATCH) {
-      set $skip_cache 1;
-  }
-
-  # Prevent PUT requests from hitting cache in APIs
-  if ($request_method = PUT) {
-      set $skip_cache 1;
+  # Prevent common API POST like requests being cached
+  if ( $request_method ~* (PUT|PATCH|DELETE) ) {
+    set $skip_cache 1;
   }
 
   if ($query_string != "") {

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -43,7 +43,7 @@ server {
   }
 
   # Prevent common API POST like requests being cached
-  if ($request_method ~ (PUT|PATCH|DELETE)) {
+  if ($request_method ~ ^(PUT|PATCH|DELETE)$) {
     set $skip_cache 1;
   }
 

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -36,6 +36,22 @@ server {
   {% if item.value.cache is defined and item.value.cache.enabled | default(false) -%}
   # Fastcgi cache conditions
   set $skip_cache 0;
+
+  # Prevent POST data being held in cache
+  if ($request_method = POST) {
+      set $skip_cache 1;
+  }
+
+  # Prevent PATCH requests from hitting cache in APIs
+  if ($request_method = PATCH) {
+      set $skip_cache 1;
+  }
+
+  # Prevent PUT requests from hitting cache in APIs
+  if ($request_method = PUT) {
+      set $skip_cache 1;
+  }
+
   if ($query_string != "") {
     set $skip_cache 1;
   }

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -43,7 +43,7 @@ server {
   }
 
   # Prevent common API POST like requests being cached
-  if ( $request_method ~* (PUT|PATCH|DELETE) ) {
+  if ($request_method ~* (PUT|PATCH|DELETE)) {
     set $skip_cache 1;
   }
 


### PR DESCRIPTION
We've just had a GDPR issue with WooCommerce and Trellis, based on the trellis docs here: https://docs.roots.io/trellis/master/fastcgi-caching/#example-cache-configurations

Specifically for WooCommerce you assume that by adding the `skip_cache_uri` parameters for WooCommerce is enough, however, POST data can still be stored on another URL, and recalled on an uncached page.

As a result although our checkout page was uncached, the way that WooCommerce outputs data on the checkout page, is to check for POST data containing customer information, if that data exists it outputs it. This is only visible as an issue if you are making requests within the cache window specified.

That POST data can be set on other WooCommerce pages not included in the `skip_cache_uri`, such as checkout completion.

This could also be a problem for other plugins taking personal data via POST such as Gravity Forms etc. Although Trellis can't account for a users specific configuration, should someone not set a URI where POST data is set in the `skip_cache_uri` then that data is cached by default and potentially leaked to the world

The caveat to this is, that setting a default of not caching any POST data could result as a bypass to any DDoS protection via POST requests, however this seems like a safer default given the data POST can contain. To get around DDoS concerns we could potentially add an option to enable caching of POST data, but with a warning / disclaimer

