### PR TITLE
Enable PHP opcache in development

### DIFF
--- a/group_vars/development/php.yml
+++ b/group_vars/development/php.yml
@@ -2,7 +2,7 @@ php_error_reporting: 'E_ALL'
 php_display_errors: 'On'
 php_display_startup_errors: 'On'
 php_mysqlnd_collect_memory_statistics: 'On'
-php_opcache_enable: 0
+php_opcache_revalidate_freq: 0
 
 xdebug_mode: 'debug'
 xdebug_start_with_request: 'yes'

--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -24,8 +24,10 @@ php_output_buffering: 'Off'
 
 php_opcache_enable: 1
 php_opcache_enable_cli: 1
+php_opcache_enable_file_override: 0
 php_opcache_fast_shutdown: 1
 php_opcache_interned_strings_buffer: 8
 php_opcache_max_accelerated_files: 4000
 php_opcache_memory_consumption: 128
 php_opcache_revalidate_freq: 60
+php_opcache_validate_timestamps: 1

--- a/roles/php/templates/php-fpm.ini.j2
+++ b/roles/php/templates/php-fpm.ini.j2
@@ -27,5 +27,7 @@ opcache.enable_cli = {{ php_opcache_enable_cli }}
 opcache.memory_consumption = {{ php_opcache_memory_consumption }}
 opcache.interned_strings_buffer = {{ php_opcache_interned_strings_buffer }}
 opcache.max_accelerated_files = {{ php_opcache_max_accelerated_files }}
+opcache.validate_timestamps = {{ php_opcache_validate_timestamps }}
+opcache.enable_file_override = {{ php_opcache_enable_file_override }}
 opcache.revalidate_freq = {{ php_opcache_revalidate_freq }}
 opcache.fast_shutdown = {{ php_opcache_fast_shutdown }}


### PR DESCRIPTION
Closes #1442

OPcache was previously disabled in development to ensure no stale cached PHP. However, there are still performance benefits to having OPcache enabled with a `revalidate_freq` of `0` which will result in OPcache checking for updates on every request (instead of the default of `60` in production).