### PR TITLE
Remove deprecated warn usage

### DIFF
--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -35,5 +35,3 @@
 
 - name: Reload php-fpm
   shell: sudo service php{{ php_version }}-fpm reload
-  args:
-    warn: false

--- a/roles/wp-cli/tasks/main.yml
+++ b/roles/wp-cli/tasks/main.yml
@@ -40,8 +40,6 @@
 
 - name: Install WP-CLI
   command: rsync -c --chmod=0755 --info=name /tmp/wp-cli-{{ wp_cli_version }}.phar {{ wp_cli_bin_path }}
-  args:
-    warn: false
   register: wp_cli
   changed_when: wp_cli.stdout == 'wp-cli-' + wp_cli_version + '.phar'
 
@@ -49,12 +47,9 @@
   command: curl -4Ls {{ wp_cli_completion_url }} -o /tmp/wp-completion-{{ wp_cli_version }}.bash
   args:
     creates: /tmp/wp-completion-{{ wp_cli_version }}.bash
-    warn: false
 
 - name: Install WP-CLI tab completions
   command: rsync -c --chmod=0644 --info=name /tmp/wp-completion-{{ wp_cli_version }}.bash {{ wp_cli_completion_path }}
-  args:
-    warn: false
   register: wp_cli_completion
   changed_when: wp_cli_completion.stdout == 'wp-completion-' + wp_cli_version + '.bash'
 


### PR DESCRIPTION
The `warm` option for `command` and `shell` is deprecated and was removed in ansible-core 2.14

For backwards compat it's easiest to remove all usage.

Ref: https://github.com/ansible/ansible/issues/79379#issuecomment-1314228747