### PR TITLE
Update `wp_cli_version` to 2.7.1

### DIFF
--- a/roles/wp-cli/defaults/main.yml
+++ b/roles/wp-cli/defaults/main.yml
@@ -1,5 +1,5 @@
 gpg2_package: gnupg2
-wp_cli_version: 2.6.0
+wp_cli_version: 2.7.1
 wp_cli_bin_path: /usr/bin/wp
 wp_cli_phar_url: "https://github.com/wp-cli/wp-cli/releases/download/v{{ wp_cli_version }}/wp-cli-{{ wp_cli_version }}.phar"
 wp_cli_phar_asc_url: "https://github.com/wp-cli/wp-cli/releases/download/v{{ wp_cli_version }}/wp-cli-{{ wp_cli_version }}.phar.asc"


### PR DESCRIPTION
- https://make.wordpress.org/cli/2022/10/18/wp-cli-v2-7-1-release-notes/
- https://make.wordpress.org/cli/2022/10/11/wp-cli-v2-7-0-release-notes/