### PR TITLE
Disable chown site directory task by default

### DIFF
--- a/roles/wordpress-install/tasks/directories.yml
+++ b/roles/wordpress-install/tasks/directories.yml
@@ -31,3 +31,4 @@
   loop: "{{ wordpress_sites | dict2items }}"
   loop_control:
     label: "{{ item.key }}"
+  when: chown_site_directory | default(false)


### PR DESCRIPTION
Vagrant creates synced folders with the `web_user`/`web_group` (`vagrant`/`www-data`) already via the `Vagrantfile`. This task can be slow, and since it's redundant, it's being disabled by default.

In case this task is needed, the `chown_site_directory` variable can be set to true in `group_vars/development/main.yml`