### PR TITLE
Fix sshd config - set AcceptEnv conditionally

### DIFF
--- a/roles/sshd/templates/sshd_config.j2
+++ b/roles/sshd/templates/sshd_config.j2
@@ -13,7 +13,9 @@ ListenAddress {{ address }}
 
 Protocol {{ sshd_protocol }}
 
-AcceptEnv {{ sshd_accept_env | join(' ') }}
+{% if sshd_accept_env | count %}
+  AcceptEnv {{ sshd_accept_env | join(' ') }}
+{% endif -%}
 AllowAgentForwarding {{ sshd_allow_agent_forwarding | ternary('yes', 'no') }}
 AllowTcpForwarding {{ sshd_allow_tcp_forwarding is string | ternary(sshd_allow_tcp_forwarding, sshd_allow_tcp_forwarding | ternary('yes', 'no')) }}
 ChallengeResponseAuthentication {{ sshd_challenge_response_authentication | ternary('yes', 'no') }}


### PR DESCRIPTION
GH workflows switching to Ubuntu 22.04 exposed this bug. https://github.com/roots/trellis/pull/1454 is the proper fix for now.

This might be needed for https://github.com/roots/trellis/issues/1392