### PR TITLE
Update oefenweb.swapfile role

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -14,7 +14,7 @@ roles:
 
   - name: swapfile
     src: oefenweb.swapfile
-    version: v2.0.32
+    version: v2.0.36
 
   - src: geerlingguy.mailhog
     version: 2.3.0


### PR DESCRIPTION
Bump swapfile to `v2.0.36` which fixes the deprecated `warn` option for `command` and `shell` (removed in ansible-core 2.14).

See [this commit](https://github.com/Oefenweb/ansible-swapfile/commit/f8d3ef471d94bc912a5d8b21ad11ecfbdc3dd17f) in [Oefenweb/ansible-swapfile](https://github.com/Oefenweb/ansible-swapfile) for more details.