### PR TITLE
Tweak multisite cron job to fix standard output

### DIFF
--- a/roles/wordpress-setup/tasks/main.yml
+++ b/roles/wordpress-setup/tasks/main.yml
@@ -62,7 +62,7 @@
     name: "{{ item.key }} WordPress network cron"
     minute: "{{ item.value.cron_interval_multisite | default('*/30') }}"
     user: "{{ web_user }}"
-    job: "cd {{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }} && wp site list --field=url | xargs -n1 -I \\% wp --url=\\% cron event run --due-now > /dev/null 2>&1"
+    job: "cd {{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }} && (wp site list --field=url | xargs -n1 -I \\% wp --url=\\% cron event run --due-now) > /dev/null 2>&1"
     cron_file: "wordpress-multisite-{{ item.key | replace('.', '_') }}"
     state: "{{ (cron_enabled and item.value.multisite.enabled) | ternary('present', 'absent') }}"
   loop: "{{ wordpress_sites | dict2items }}"


### PR DESCRIPTION
With our multisite-setup I have been seeing hourly attempts within our Mailgun-logs to send out an email notification regarding the cron job that is set up there:

`cd {{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }} && wp site list --field=url | xargs -n1 -I \\% wp --url=\\% cron event run --due-now > /dev/null 2>&1`

Seeing that `> /dev/null 2>&1` is appended, this shouldn't be happening...

Wrapping the two joint commands in brackets (`(wp site list --field=url | xargs -n1 -I \\% wp --url=\\% cron event run --due-now) > /dev/null 2>&1`) fixes the standard output and I am not seeing any attempts to send out email notifications in our Mailgun logs any more.

Have successfully tested running the new command in full on our server and it performs as expected.