### PR TITLE
Update to MariaDB 10.6

### DIFF
--- a/roles/mariadb/defaults/main.yml
+++ b/roles/mariadb/defaults/main.yml
@@ -1,6 +1,6 @@
 mariadb_keyserver: "hkp://keyserver.ubuntu.com:80"
 mariadb_keyserver_id: "0xF1656F24C74CD1D8"
-mariadb_ppa: "deb https://mirror.rackspace.com/mariadb/repo/10.5/ubuntu {{ ansible_distribution_release }} main"
+mariadb_ppa: "deb https://mirror.rackspace.com/mariadb/repo/10.6/ubuntu {{ ansible_distribution_release }} main"
 
 mariadb_client_package: mariadb-client
 mariadb_server_package: mariadb-server


### PR DESCRIPTION
This bumps the MariaDB PPA from 10.5 to 10.6.

Note that this will *not* actually upgrade the version of MariaDB already installed on a server.

Upgrading is a manual process that involves:

1. stopping the service
2. removing the installed package
3. re-installing the package

The full process is detailed at https://mariadb.com/kb/en/upgrading-from-mariadb-105-to-mariadb-106/

Though it's not required, backing up your database before the upgrade is recommended.

Note: Will be required for before we can support Ubuntu 22.04 in https://github.com/roots/trellis/issues/1392