### PR TITLE
Set development web_user to ansible_user

### DIFF
--- a/group_vars/development/main.yml
+++ b/group_vars/development/main.yml
@@ -1,4 +1,4 @@
 acme_tiny_challenges_directory: "{{ www_root }}/letsencrypt"
 env: development
 mysql_root_password: "{{ vault_mysql_root_password }}" # Define this variable in group_vars/development/vault.yml
-web_user: vagrant
+web_user: "{{ ansible_user }}"


### PR DESCRIPTION
This removes another place where `vagrant` is harcoded while still ensuring its set to that value according to `dev.yml`'s `remote_user` setting.