### PR TITLE
Composer Authentications: Fix `loop_var` already in use issue

### DIFF
--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -18,12 +18,13 @@
 
 - include_tasks: tasks/composer-authentications.yml
   vars:
-    site: "{{ item.key }}"
-    working_dir: "{{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/"
+    site: "{{ site.key }}"
+    working_dir: "{{ www_root }}/{{ site.key }}/{{ site.value.current_path | default('current') }}/"
   no_log: true
   loop: "{{ wordpress_sites | dict2items }}"
   loop_control:
-    label: "{{ item.key }}"
+    loop_var: site
+    label: "{{ site.key }}"
 
 - name: Install Dependencies with Composer
   composer:


### PR DESCRIPTION
https://discourse.roots.io/t/composer-issue-with-http-auth/24696/5

Props to @dalepgrant