### PR TITLE
Vagrant: disable NFS udp by default

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -93,17 +93,18 @@ Vagrant.configure('2') do |config|
     fail_with_message "vagrant-bindfs missing, please install the plugin with this command:\nvagrant plugin install vagrant-bindfs"
   else
     trellis_config.wordpress_sites.each_pair do |name, site|
-      config.vm.synced_folder local_site_path(site), nfs_path(name), type: 'nfs'
+      config.vm.synced_folder local_site_path(site), nfs_path(name), type: 'nfs', nfs_udp: vconfig.fetch('vagrant_nfs_udp')
       config.bindfs.bind_folder nfs_path(name), remote_site_path(name, site), u: 'vagrant', g: 'www-data', o: 'nonempty'
     end
 
-    config.vm.synced_folder ANSIBLE_PATH, '/ansible-nfs', type: 'nfs'
+    config.vm.synced_folder ANSIBLE_PATH, '/ansible-nfs', type: 'nfs', nfs_udp: vconfig.fetch('vagrant_nfs_udp')
     config.bindfs.bind_folder '/ansible-nfs', ANSIBLE_PATH_ON_VM, o: 'nonempty', p: '0644,a+D'
   end
 
   vconfig.fetch('vagrant_synced_folders', []).each do |folder|
     options = {
       type: folder.fetch('type', 'nfs'),
+      nfs_udp: folder.fetch('nfs_udp', false),
       create: folder.fetch('create', false),
       mount_options: folder.fetch('mount_options', [])
     }

--- a/vagrant.default.yml
+++ b/vagrant.default.yml
@@ -8,6 +8,7 @@ vagrant_box_auto_arch: true
 vagrant_ansible_version: '2.10.7'
 vagrant_skip_galaxy: false
 vagrant_mount_type: 'nfs'
+vagrant_nfs_udp: false
 vagrant_require_version: '>= 2.1.0'
 
 vagrant_install_plugins: true
@@ -20,6 +21,7 @@ vagrant_plugins:
 #   destination: /path/on/vm
 #   create: false
 #   type: nfs
+#   nfs_udp: false
 #   bindfs: true
 #   mount_options: []
 #   bindfs_options: {}


### PR DESCRIPTION
Ubuntu 22.04 no longer supports UDP for NFS. UDP might offer better performance on 20.04 and older boxes so it can be re-enabled manually.

And while there's no plans to switch to NFS v4, it doesn't support UDP either.