### PR TITLE
Fix ansible_user references for local provisioning

### DIFF
--- a/group_vars/development/main.yml
+++ b/group_vars/development/main.yml
@@ -1,4 +1,4 @@
 acme_tiny_challenges_directory: "{{ www_root }}/letsencrypt"
 env: development
 mysql_root_password: "{{ vault_mysql_root_password }}" # Define this variable in group_vars/development/vault.yml
-web_user: "{{ ansible_user }}"
+web_user: "{{ ansible_user | default ('vagrant') }}"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -172,7 +172,7 @@
 
 - name: Generate SSH key for vagrant user for ansible_local provisioning
   user:
-    name: "{{ ansible_user }}"
+    name: vagrant
     generate_ssh_key: yes
   when: vagrant_local_provisioning | default(false)
 


### PR DESCRIPTION
`ansible_user` can't be assumed to be defined during Ansible local provisioning (the default mode in Vagrant if Ansible is not installed on the host machine).

Ref: https://discourse.roots.io/t/logrotate-outputting-wrong-error/24843/2