### PR TITLE
Use appropriate mount_option for 'parallels' provider (Apple Silicon Macs)

### DIFF
--- a/lib/trellis/vagrant.rb
+++ b/lib/trellis/vagrant.rb
@@ -65,6 +65,8 @@ end
 def mount_options(mount_type, dmode:, fmode:)
   if mount_type == 'smb'
     ["vers=3.02", "mfsymlinks", "dir_mode=0#{dmode}", "file_mode=0#{fmode}", "sec=ntlm"]
+  elsif mount_type == 'parallels'
+    ["share"]
   else
     ["dmode=#{dmode}", "fmode=#{fmode}"]
   end


### PR DESCRIPTION
For Apple Silicon Macs there is a section in the docs: https://roots.io/trellis/docs/vagrant/#parallels-apple-silicon-m1-macs but that page doesn't give much information about the configuration.

I suggest to mention there that after the duplication of the `vagrant.default.yml`, you have to change in the `vagrant.local.yml` file at least the `vagrant_mount_type` to:
```yml
vagrant_mount_type: 'parallels'
```

otherwise you will get the following error (hence the 'nfs' mount type):
```
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

mount -o vers=3 10.211.55.2:/path/to/site /vagrant-nfs-<SITENAME>

Stdout from the command:



Stderr from the command:

mount.nfs: access denied by server while mounting 10.211.55.2:/path/to/site

exit status 1
```

When you change the `vagrant_mount_type` to `parallels` the `trellis up` command will fails with:
```
Failed to mount folders in Linux guest. You've specified mount options
which are not supported by "prl_fs" file system.

Invalid mount options: ["dmode=755", "fmode=644"]
exit status 1
```

That's because `dmode` and `fmode` are VirtualBox specific options, we need to use a Parallels specific: `share`.
