### PR TITLE
Add conditional dry_run

### DIFF
--- a/roles/deploy/tasks/dryrun.yml
+++ b/roles/deploy/tasks/dryrun.yml
@@ -1,0 +1,12 @@
+- name: "Delete the deploy if this is a dry-run"
+  ansible.builtin.file:
+    state: absent
+    path: "{{ deploy_helper.new_release_path }}"
+
+- name: "Clean up if this is a dry-run"
+  ansible.builtin.file:
+    state: absent
+    path: "{{ project_root }}/shared"
+
+- name: "Stop here if this is a dry-run"
+  meta: end_play

--- a/roles/deploy/tasks/dryrun.yml
+++ b/roles/deploy/tasks/dryrun.yml
@@ -3,10 +3,5 @@
     state: absent
     path: "{{ deploy_helper.new_release_path }}"
 
-- name: "Clean up if this is a dry-run"
-  ansible.builtin.file:
-    state: absent
-    path: "{{ project_root }}/shared"
-
 - name: "Stop here if this is a dry-run"
   meta: end_play

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -17,6 +17,11 @@
 - import_tasks: update.yml
 - import_tasks: prepare.yml
 - import_tasks: build.yml
+
+- name: "Stop here if this is a dry-run"
+  meta: end_play
+  when: dry_run|default(False)
+
 - import_tasks: share.yml
 - import_tasks: finalize.yml
 

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -18,14 +18,7 @@
 - import_tasks: prepare.yml
 - import_tasks: build.yml
 
-- name: "Delete the deploy if this is a dry-run"
-  ansible.builtin.file:
-    state: absent
-    path: /tmp/trellis
-  when: dry_run|default(False)
-
-- name: "Stop here if this is a dry-run"
-  meta: end_play
+- include_tasks: dryrun.yml
   when: dry_run|default(False)
 
 - import_tasks: share.yml

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -18,6 +18,12 @@
 - import_tasks: prepare.yml
 - import_tasks: build.yml
 
+- name: "Delete the deploy if this is a dry-run"
+  ansible.builtin.file:
+    state: absent
+    path: /tmp/trellis
+  when: dry_run|default(False)
+
 - name: "Stop here if this is a dry-run"
   meta: end_play
   when: dry_run|default(False)


### PR DESCRIPTION
Sometimes I want to be able to check if Trellis can deploy, including whether it can run its build hooks, install Composer dependencies, etc, without actually deploying. A use case example is a check using a GitHub workflow.

Test with the following:
```
$ trellis deploy --extra-vars "dry_run=true" production
```

I was able to get this working using the following GitHub workflow(s)
```yml
# .github/workflows/dry-run.yml
name: Dry-run deploy to target branch
run-name: Dry-run deploy to target branch

on:
  pull_request:
    branches: [staging, production]

jobs:
  dry-run:
    uses: ./.github/workflows/trellis-cli.yml
    secrets: inherit
    with:
      extra-vars: '"dry_run=true"'
```

```yml
# .github/workflows/trellis-cli.yml

name: trellis-cli
run-name: 'Trellis CLI'

on:
  workflow_call:
    inputs:
      extra-vars:
        required: false
        type: string

jobs:
  trellis-cli:
    runs-on: ubuntu-latest

    steps:
    - uses: actions/checkout@v2
    - uses: andstor/file-existence-action@v2
      id: check_files
      with:
        files: "trellis/deploy.yml"
    - uses: shimataro/ssh-key-action@v2
      with:
        key: ${{ secrets.TRELLIS_DEPLOY_SSH_PRIVATE_KEY }}
        known_hosts: ${{ secrets.TRELLIS_DEPLOY_SSH_KNOWN_HOSTS }}
    - uses: webfactory/ssh-agent@v0.5.4
      with:
        ssh-private-key: ${{ secrets.TRELLIS_DEPLOY_SSH_PRIVATE_KEY }}
    - uses: roots/setup-trellis-cli@v1
      with:
        repo-token: ${{ secrets.GITHUB_TOKEN }}
        ansible-vault-password: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
    - name: Deploy
      if: steps.check_files.outputs.files_exists == 'true'
      run: trellis deploy --extra-vars ${{ inputs.extra-vars }} ${{ github.base_ref }}
```