### PR TITLE
🔧 Default to PHP 8.1

### DIFF
--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -3,7 +3,7 @@ apt_package_state: present
 apt_security_package_state: latest
 apt_dev_package_state: latest
 composer_keep_updated: true
-php_version: "8.0"
+php_version: "8.1"
 ntp_timezone: Etc/UTC
 ntp_manage_config: true
 www_root: /srv/www


### PR DESCRIPTION
PHP 8.1 compatibility has been improved since WordPress 6.2, and there is no longer [deprecated notices out of the box](https://roots.io/wordpress-php-8-1-support-not-found/)