### PR TITLE
CLI config updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ vagrant.local.yml
 vendor/roles
 *.py[co]
 *.retry
-.trellis/virtualenv
+.trellis/*
+!.trellis/cli.yml
+trellis.cli.local.yml

--- a/trellis.cli.yml
+++ b/trellis.cli.yml
@@ -1,0 +1,6 @@
+# Trellis CLI example config file
+# https://roots.io/trellis/docs/cli/#configuration
+#
+# database_app: sequel-ace
+# open:
+#   admin: "https://mysite.com/wp/wp-admin"


### PR DESCRIPTION
Trellis CLI will soon be preferring `trellis.cli.yml` as the main config file path over `.trellis/cli.yml` (though it remains supported).

This now makes it possible to Git ignore the entire `.trellis` directory as it contains CLI generated files for machine use only.

`.trellis/cli.yml` is exempted in the gitignore for legacy compatibility purposes.