### PR TITLE
Fix issue with variable name 'site' clashing when setting composer au…

### DIFF
--- a/roles/wordpress-install/tasks/main.yml
+++ b/roles/wordpress-install/tasks/main.yml
@@ -18,13 +18,13 @@
 
 - include_tasks: tasks/composer-authentications.yml
   vars:
-    site: "{{ site.key }}"
-    working_dir: "{{ www_root }}/{{ site.key }}/{{ site.value.current_path | default('current') }}/"
+    site: "{{ loop_item.key }}"
+    working_dir: "{{ www_root }}/{{ loop_item.key }}/{{ loop_item.value.current_path | default('current') }}/"
   no_log: true
   loop: "{{ wordpress_sites | dict2items }}"
   loop_control:
-    loop_var: site
-    label: "{{ site.key }}"
+    loop_var: loop_item # cannot be 'item' or 'site'.
+    label: "{{ loop_item.key }}"
 
 - name: Install Dependencies with Composer
   composer:


### PR DESCRIPTION
…thentications.

Coming back to fix an earlier mistake of mine 🙋‍♂️ 

Related to #1469, in which the loop variable was set to `site` to avoid a conflict with the default `item`. As it turns out, setting the loop var to `site` then caused issues when trying to set `site: "{{ site.key }}"`, which does not work and gives different results for local vs remote environments.

To test: 

1. Setup `wordpress_sites` for development AND a remote env
```yml
example.com.au:
    composer_authentications:
      - { hostname: connect.advancedcustomfields.com, username: imnottellingyou, password: https://www.example.com.au }
```

2. Setup debugging
```yml
# Put this in two places: 
 - roles/wordpress-install/tasks/composer-authentications.yml, line 1
 - roles/deploy/hooks/build-after.yml, line 12

---
- name: Debug composer authentications (HTTP Basic)
  debug:
    msg: "{{ site }}"
  loop: "{{ composer_authentications_using_basic_auth }}"
  loop_control:
    label: "{{ item.type | default('default-type') }}.{{ item.hostname }}"

- name: "Setup composer authentications (HTTP Basic) - {{ site }}"
  ...etc
```

3. If testing on a local site that already exists, delete the `auth.json` file. 

4. `trellis provision --tags wordpress development`. Check debug output, you should see something like
```zsh
TASK [wordpress-install : Debug composer authentications (HTTP Basic)] *********
ok: [default] => (item=default-type.connect.advancedcustomfields.com) => {
    "msg": "example.com.au"
}
```

5. Confirm `auth.json` is correct

6. Deploy site. Debug output should match the above. 

Without this PR, the debug output from step 4 (local reprovision) would look like this:
```zsh
TASK [wordpress-install : Debug composer authentications (HTTP Basic)] *********
ok: [default] => (item=default-type.connect.advancedcustomfields.com) => {
    "msg": {
        "key": "example.com.au",
        "value": {
            "admin_email": "wp@codeand.com.au",
            "cache": {
                "enabled": false
            },
            "env": {
                "db_prefix": "wp_"
            },
            "local_path": "../example.com.au",
            "multisite": {
                "enabled": false
            },
            "site_hosts": [
                {
                    "canonical": "lcl.example.com.au"
                }
            ],
            "ssl": {
                "enabled": true,
                "provider": "self-signed"
            },
            "xmlrpc": {
                "enabled": false
            }
        }
    }
}
```