### PR TITLE
Add Libvirt to the Vagrant config file

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -208,4 +208,11 @@ Vagrant.configure('2') do |config|
     h.enable_virtualization_extensions = true
     h.linked_clone = true
   end
+
+  # Libvirt/KVM settings
+  config.vm.provider 'libvirt' do [lv]
+    lv.vmname = config.vm.hostname
+    lv.cpus = vconfig.fetch('vagrant_cpus')
+    lv.memory = vconfig.fetch('vagrant_memory')
+  end
 end


### PR DESCRIPTION
Gives the ability for users who have the libvirt plugin installed in vagrant on linux to use libvirt for creating the virtual machine. This change will make sure that the RAM and CPU count will be properly set on each trellis up. Libvirt is working properly so far, but is causing a kernel panic on trellis up because the RAM is set to 512. Currently I have to manually set the RAM to a higher number in order to be able to boot the machine.

I haven't tested this change yet, I'm about to do that right now.

Please add this when people have confirmed it working (not just me).

Basically for this to work, all you have to do is follow the setup instructions for your distribution here: https://vagrant-libvirt.github.io/vagrant-libvirt/