### PR TITLE
Add MariaDB server config for optimizatons

### DIFF
--- a/roles/mariadb/defaults/main.yml
+++ b/roles/mariadb/defaults/main.yml
@@ -1,6 +1,7 @@
+mariadb_version: 10.6
 mariadb_keyserver: "hkp://keyserver.ubuntu.com:80"
 mariadb_keyserver_id: "0xF1656F24C74CD1D8"
-mariadb_ppa: "deb https://mirror.rackspace.com/mariadb/repo/10.6/ubuntu {{ ansible_distribution_release }} main"
+mariadb_ppa: "deb https://mirror.rackspace.com/mariadb/repo/{{ mariadb_version }}/ubuntu {{ ansible_distribution_release }} main"
 
 mariadb_client_package: mariadb-client
 mariadb_server_package: mariadb-server
@@ -9,3 +10,8 @@ mysql_binary_logging_disabled: true
 mysql_root_user: root
 
 sites_using_remote_db: "[{% for name, site in wordpress_sites.items() | list if site.env is defined and site.env.db_host | default('localhost') != 'localhost' %}'{{ name }}',{% endfor %}]"
+
+mariadb_set_innodb_buffer_pool_size: false
+mariadb_innodb_buffer_pool_size: 128M
+mariadb_set_innodb_log_file_size: false
+mariadb_innodb_log_file_size: 96M

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -41,6 +41,13 @@
       group: root
       mode: '0600'
 
+  - name: Copy server config file with MariaDB optimisations.
+    template:
+      src: 50-server.cnf.j2
+      dest: /etc/mysql/mariadb.conf.d/50-server.cnf
+      mode: '0644'
+    notify: restart mysql server
+
   - name: Set root user password
     mysql_user:
       name: root

--- a/roles/mariadb/templates/50-server.cnf.j2
+++ b/roles/mariadb/templates/50-server.cnf.j2
@@ -1,0 +1,132 @@
+# {{ ansible_managed }}
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+
+#
+# * Basic Settings
+#
+
+user                    = mysql
+pid-file                = /run/mysqld/mysqld.pid
+basedir                 = /usr
+datadir                 = /var/lib/mysql
+tmpdir                  = /tmp
+lc-messages-dir         = /usr/share/mysql
+lc-messages             = en_US
+skip-external-locking
+
+# Broken reverse DNS slows down connections considerably and name resolve is
+# safe to skip if there are no "host by domain name" access grants
+#skip-name-resolve
+
+# Instead of skip-networking the default is now to listen only on
+# localhost which is more compatible and is not less secure.
+bind-address            = 127.0.0.1
+
+#
+# * Fine Tuning
+#
+
+#key_buffer_size        = 128M
+#max_allowed_packet     = 1G
+#thread_stack           = 192K
+#thread_cache_size      = 8
+# This replaces the startup script and checks MyISAM tables if needed
+# the first time they are touched
+#myisam_recover_options = BACKUP
+#max_connections        = 100
+#table_cache            = 64
+
+#
+# * Logging and Replication
+#
+
+# Both location gets rotated by the cronjob.
+# Be aware that this log type is a performance killer.
+# Recommend only changing this at runtime for short testing periods if needed!
+#general_log_file       = /var/log/mysql/mysql.log
+#general_log            = 1
+
+# When running under systemd, error logging goes via stdout/stderr to journald
+# and when running legacy init error logging goes to syslog due to
+# /etc/mysql/conf.d/mariadb.conf.d/50-mysqld_safe.cnf
+# Enable this if you want to have error logging into a separate file
+#log_error = /var/log/mysql/error.log
+# Enable the slow query log to see queries with especially long duration
+#slow_query_log_file    = /var/log/mysql/mariadb-slow.log
+#long_query_time        = 10
+#log_slow_verbosity     = query_plan,explain
+#log-queries-not-using-indexes
+#min_examined_row_limit = 1000
+
+# The following can be used as easy to replay backup logs or for replication.
+# note: if you are setting up a replication slave, see README.Debian about
+#       other settings you may need to change.
+#server-id              = 1
+#log_bin                = /var/log/mysql/mysql-bin.log
+expire_logs_days        = 10
+#max_binlog_size        = 100M
+
+#
+# * SSL/TLS
+#
+
+# For documentation, please read
+# https://mariadb.com/kb/en/securing-connections-for-client-and-server/
+#ssl-ca = /etc/mysql/cacert.pem
+#ssl-cert = /etc/mysql/server-cert.pem
+#ssl-key = /etc/mysql/server-key.pem
+#require-secure-transport = on
+
+#
+# * Character sets
+#
+
+# MySQL/MariaDB default is Latin1, but in Debian we rather default to the full
+# utf8 4-byte character set. See also client.cnf
+character-set-server  = utf8mb4
+collation-server      = utf8mb4_general_ci
+
+#
+# * InnoDB
+#
+
+# InnoDB is enabled by default with a 10MB datafile in /var/lib/mysql/.
+# Read the manual for more InnoDB related options. There are many!
+# Most important is to give InnoDB 80 % of the system RAM for buffer use:
+# https://mariadb.com/kb/en/innodb-system-variables/#innodb_buffer_pool_size
+
+# Amount of RAM to allocate to database buffering.
+# - Max is 80% of total RAM. i.e. 80% of 8G, 6.4G is the max.
+# - On server doing PHP and MySQL, don't allocate more than 50% because the rest needs to go to PHP.
+# - Default is 128M
+{% if mariadb_set_innodb_buffer_pool_size %}
+innodb_buffer_pool_size = {{ mariadb_innodb_buffer_pool_size }}
+{% endif %}
+
+# Amount of disk space to allocate to database redo file
+# - Should be 25% of buffer pool size as per MySQL Tuner (https://github.com/major/MySQLTuner-perl)
+# - Default is 96M
+{% if mariadb_set_innodb_log_file_size %}
+innodb_log_file_size = {{ mariadb_innodb_log_file_size }}
+{% endif %}
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+# This group is only read by MariaDB-{{mariadb_version}} servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mariadb-{{mariadb_version}}]


### PR DESCRIPTION
Opening a new PR so I can more easily more this. Co-authored by @paulbrzeski  

Original PR description from #1443:

Sharing a couple of changes we've made to our Trellis so we can fine tune MariaDB settings for high traffic websites.

Changes include,
- MariaDB/innodb optimisation
- Small improvements to make things more semantic
- Various configs to support above

This PR only provides the defaults, you can override these settings like any other using your group_vars configs.

Example settings from our production servers below,

MariaDB for a server with 4GB of RAM and sharing environment with PHP and Nginx
New variables to add to ```group_vars/%ENV%/mariadb.yml```,
```
mariadb_set_innodb_buffer_pool_size: true
mariadb_innodb_buffer_pool_size: 512M
mariadb_set_innodb_log_file_size: true
mariadb_innodb_log_file_size: 128M
```
More info - https://mariadb.com/kb/en/innodb-system-variables/#innodb_buffer_pool_size

(previously roots/trellis#1430)