### PR TITLE
⬆️ Update wp_cli_version to 2.8.1

### DIFF
--- a/roles/wp-cli/defaults/main.yml
+++ b/roles/wp-cli/defaults/main.yml
@@ -1,5 +1,5 @@
 gpg2_package: gnupg2
-wp_cli_version: 2.8.0
+wp_cli_version: 2.8.1
 wp_cli_bin_path: /usr/bin/wp
 wp_cli_phar_url: "https://github.com/wp-cli/wp-cli/releases/download/v{{ wp_cli_version }}/wp-cli-{{ wp_cli_version }}.phar"
 wp_cli_phar_asc_url: "https://github.com/wp-cli/wp-cli/releases/download/v{{ wp_cli_version }}/wp-cli-{{ wp_cli_version }}.phar.asc"


### PR DESCRIPTION
[WP-CLI v2.8.1 Release Notes](https://make.wordpress.org/cli/2023/06/05/wp-cli-v2-8-1-release-notes/)
=====================================================================================================

A new release of WP-CLI is available as of today: **WP-CLI v2.8.1**. For this release, we had **3 contributors** collaborate to get **7 pull requests** merged. 

This is a hotfix release to fix 2 critical bugs with release v2.8.0.

### Detailed change log

#### [wp-cli/wp-cli-bundle](https://github.com/wp-cli/wp-cli-bundle)

*   Release v2.8.1 \[[#556](https://github.com/wp-cli/wp-cli-bundle/pull/556)\]
*   Update Composer lock file \[[#555](https://github.com/wp-cli/wp-cli-bundle/pull/555)\]
*   Update wp-cli/search-replace-command to latest \[[#554](https://github.com/wp-cli/wp-cli-bundle/pull/554)\]
*   Avoid fatal errors when pulling in the bundle with Requests v2 via Composer \[[#552](https://github.com/wp-cli/wp-cli-bundle/pull/552)\]

#### [wp-cli/wp-cli](https://github.com/wp-cli/wp-cli)

*   Define `WP_CLI_ROOT` if needed \[[#5797](https://github.com/wp-cli/wp-cli/pull/5797)\]
*   Extract Requests out of Composer \[[#5796](https://github.com/wp-cli/wp-cli/pull/5796)\]

#### [wp-cli/search-replace-command](https://github.com/wp-cli/search-replace-command)

*   Fix search-replace for tables with composite primary keys \[[#183](https://github.com/wp-cli/search-replace-command/pull/183)\]

### Contributors

[@brandonpayton](https://github.com/brandonpayton), [@danielbachhuber](https://github.com/danielbachhuber), [@schlessera](https://github.com/schlessera)

[#release](https://make.wordpress.org/cli/tag/release/), [#v2-8-1](https://make.wordpress.org/cli/tag/v2-8-1/)
