### PR TITLE
Enable PHP OPCache overwrites for `max_wasted_percentage` & `huge_code_pages`

### DIFF
--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -31,6 +31,8 @@ php_opcache_max_accelerated_files: 4000
 php_opcache_memory_consumption: 128
 php_opcache_revalidate_freq: 60
 php_opcache_validate_timestamps: 1
+php_opcache_max_wasted_percentage: 5
+php_opcache_huge_code_pages: 0
 
 php_fpm_set_emergency_restart_threshold: false
 php_fpm_emergency_restart_threshold: 0

--- a/roles/php/templates/php-fpm.ini.j2
+++ b/roles/php/templates/php-fpm.ini.j2
@@ -31,3 +31,5 @@ opcache.validate_timestamps = {{ php_opcache_validate_timestamps }}
 opcache.enable_file_override = {{ php_opcache_enable_file_override }}
 opcache.revalidate_freq = {{ php_opcache_revalidate_freq }}
 opcache.fast_shutdown = {{ php_opcache_fast_shutdown }}
+opcache.max_wasted_percentage = {{ php_opcache_max_wasted_percentage }}
+opcache.huge_code_pages = {{ php_opcache_huge_code_pages }}


### PR DESCRIPTION
This PR adds `max_wasted_percentage` & `huge_code_pages` as configurable overwrites with defaults being set.

Let me know if this is in any way undesired or could potentially be harmful – but I cannot see how...?