### PR TITLE
Add JIT options

### DIFF
--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -33,7 +33,7 @@ php_opcache_revalidate_freq: 60
 php_opcache_validate_timestamps: 1
 php_opcache_max_wasted_percentage: 5
 php_opcache_huge_code_pages: 0
-php_opcache_jit: 'Off'
+php_opcache_jit: 'tracing'
 php_opcache_jit_buffer_size: 0
 
 php_fpm_set_emergency_restart_threshold: false

--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -33,6 +33,7 @@ php_opcache_revalidate_freq: 60
 php_opcache_validate_timestamps: 1
 php_opcache_max_wasted_percentage: 5
 php_opcache_huge_code_pages: 0
+php_opcache_jit: 'Off'
 php_opcache_jit_buffer_size: 256M
 
 php_fpm_set_emergency_restart_threshold: false

--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -34,7 +34,7 @@ php_opcache_validate_timestamps: 1
 php_opcache_max_wasted_percentage: 5
 php_opcache_huge_code_pages: 0
 php_opcache_jit: 'tracing'
-php_opcache_jit_buffer_size: 0
+php_opcache_jit_buffer_size: 256M
 
 php_fpm_set_emergency_restart_threshold: false
 php_fpm_emergency_restart_threshold: 0

--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -34,7 +34,7 @@ php_opcache_validate_timestamps: 1
 php_opcache_max_wasted_percentage: 5
 php_opcache_huge_code_pages: 0
 php_opcache_jit: 'Off'
-php_opcache_jit_buffer_size: 256M
+php_opcache_jit_buffer_size: 0
 
 php_fpm_set_emergency_restart_threshold: false
 php_fpm_emergency_restart_threshold: 0

--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -33,6 +33,7 @@ php_opcache_revalidate_freq: 60
 php_opcache_validate_timestamps: 1
 php_opcache_max_wasted_percentage: 5
 php_opcache_huge_code_pages: 0
+php_opcache_jit_buffer_size: 256M
 
 php_fpm_set_emergency_restart_threshold: false
 php_fpm_emergency_restart_threshold: 0

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -61,6 +61,13 @@
     dest: /etc/php/{{ php_version }}/cli/php.ini
     mode: '0644'
 
+- name: Copy 10-opcache.ini configuration file
+  template:
+    src: 10-opcache.ini.j2
+    dest: /etc/php/{{ php_version }}/fpm/conf.d/10-opcache.ini
+    mode: '0644'
+  notify: reload php-fpm
+
 - name: Change ImageMagick policy.xml to allow for PDFs
   replace:
     path: /etc/ImageMagick-6/policy.xml

--- a/roles/php/templates/10-opcache.ini.j2
+++ b/roles/php/templates/10-opcache.ini.j2
@@ -1,0 +1,6 @@
+; {{ ansible_managed }}
+
+; configuration for php opcache module
+; priority=10
+zend_extension=opcache.so
+opcache.jit={{ php_opcache_jit }}

--- a/roles/php/templates/php-fpm.ini.j2
+++ b/roles/php/templates/php-fpm.ini.j2
@@ -33,3 +33,4 @@ opcache.revalidate_freq = {{ php_opcache_revalidate_freq }}
 opcache.fast_shutdown = {{ php_opcache_fast_shutdown }}
 opcache.max_wasted_percentage = {{ php_opcache_max_wasted_percentage }}
 opcache.huge_code_pages = {{ php_opcache_huge_code_pages }}
+opcache.jit_buffer_size = {{ php_opcache_jit_buffer_size }}


### PR DESCRIPTION
This PR adds PHP `8` OPcache `JIT` related options minimally required for (optionally) enabling `JIT`.

The Ubuntu default configuration file `/etc/php/<php_version>/fpm/conf.d/10-opcache.ini` disables JIT (by explicitly setting it to `off`), hence the configuration file is controlled by a template to allow enabling or disabling JIT.
The default value for `php_opcache_jit` (corresponding ansible variable for `opcache.jit`) is ~~`Off`~~ `tracing` (which enables JIT by default). (Note: Other [option values available](https://php.watch/versions/8.0/JIT#jit-opcache.jit): `disable` (like `off`, but prevents changing option on PHP runtime; `on` (enables JIT; aliases to `tracing`); `tracing` (currently the same as `on`); `function`.)

In order to enable JIT, the value `opcache.jit_buffer_size` (corresponding ansible variable `php_opcache_jit_buffer_size`) option also has to be set to something different than its default `0`, as `0` also disables JIT. `0` is used as the default for `php_opcache_jit_buffer_size`. (Note: A reasonable, often proposed size for `opcache.jit_buffer_size` would be `256M`.)

🤔 when someone manually edited that `/etc/php/<php_version>/fpm/conf.d/10-opcache.ini` file, it would be overwritten by Ansible of course, as it is now managed by Ansible. Add warning, skip when edited or something else in that case?