### PR TITLE
[upd] wordpress-site.conf.j2 fix deprecated directive nginx ^1.25.1

### DIFF
--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -4,8 +4,9 @@
 
 server {
   {% block server_id -%}
-  listen {{ ssl_enabled | ternary('[::]:443 ssl http2', '[::]:80') }};
-  listen {{ ssl_enabled | ternary('443 ssl http2', '80') }};
+  listen {{ ssl_enabled | ternary('[::]:443 ssl', '[::]:80') }};
+  listen {{ ssl_enabled | ternary('443 ssl', '80') }};
+  http2 on;
   server_name {{ site_hosts_canonical | union(multisite_subdomains_wildcards) | join(' ') }};
   {% endblock %}
 
@@ -290,8 +291,9 @@ server {
 {% for host in item.value.site_hosts if host.redirects | default([]) %}
 server {
   {% if ssl_enabled -%}
-  listen [::]:443 ssl http2;
-  listen 443 ssl http2;
+  listen [::]:443 ssl;
+  listen 443 ssl;
+  http2 on;
   {% endif -%}
   listen [::]:80;
   listen 80;


### PR DESCRIPTION
Fix for nginx: [warn] the "listen ... http2" directive is deprecated, use the "http2" directive instead