### PR TITLE
🐛 Fix MariaDB apt-key is deprecated failure

### DIFF
--- a/roles/mariadb/defaults/main.yml
+++ b/roles/mariadb/defaults/main.yml
@@ -1,6 +1,4 @@
 mariadb_version: 10.6
-mariadb_keyserver: "hkp://keyserver.ubuntu.com:80"
-mariadb_keyserver_id: "0xF1656F24C74CD1D8"
 mariadb_ppa: "deb https://mirror.rackspace.com/mariadb/repo/{{ mariadb_version }}/ubuntu {{ ansible_distribution_release }} main"
 
 mariadb_client_package: mariadb-client

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -11,21 +11,10 @@
   args:
     removes: "/tmp/mariadb_release_signing_key.asc"
 
-- name: Setup MariaDB repository
-  ansible.builtin.copy:
-    dest: "/etc/apt/sources.list.d/mariadb.list"
-    content: |
-      # Ansible managed
-      {{ mariadb_ppa }}
-    mode: "0644"
-
-- name: Install necessary packages for repository management
-  ansible.builtin.apt:
-    name:
-      - apt-transport-https
-      - gnupg
-    state: present
-    update_cache: true
+- name: Add MariaDB PPA
+  apt_repository:
+    repo: "{{ mariadb_ppa }}"
+    update_cache: yes
 
 - name: Install MySQL client
   ansible.builtin.apt:

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -1,24 +1,41 @@
 ---
-- block:
-  - name: Add MariaDB APT key
-    apt_key:
-      keyserver: "{{ mariadb_keyserver }}"
-      id: "{{ mariadb_keyserver_id }}"
+- name: Download MariaDB GPG key
+  ansible.builtin.get_url:
+    url: "https://mariadb.org/mariadb_release_signing_key.asc"
+    dest: "/tmp/mariadb_release_signing_key.asc"
+    mode: '0644'
 
-  - name: Add MariaDB PPA
-    apt_repository:
-      repo: "{{ mariadb_ppa }}"
-      update_cache: yes
+- name: Add the MariaDB GPG key to apt
+  ansible.builtin.shell:
+    cmd: "apt-key add /tmp/mariadb_release_signing_key.asc"
+  args:
+    removes: "/tmp/mariadb_release_signing_key.asc"
+
+- name: Setup MariaDB repository
+  ansible.builtin.copy:
+    dest: "/etc/apt/sources.list.d/mariadb.list"
+    content: |
+      # Ansible managed
+      {{ mariadb_ppa }}
+    mode: "0644"
+
+- name: Install necessary packages for repository management
+  ansible.builtin.apt:
+    name:
+      - apt-transport-https
+      - gnupg
+    state: present
+    update_cache: true
 
 - name: Install MySQL client
-  apt:
+  ansible.builtin.apt:
     name: "{{ mariadb_client_package }}"
     state: "{{ mariadb_client_package_state | default(apt_package_state) }}"
-    cache_valid_time: "{{ apt_cache_valid_time }}"
+    update_cache: true
 
 - block:
   - name: Install MySQL server
-    apt:
+    ansible.builtin.apt:
       name: "{{ mariadb_server_package }}"
       state: "{{ mariadb_server_package_state | default(apt_package_state) }}"
       cache_valid_time: "{{ apt_cache_valid_time }}"

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -1,15 +1,8 @@
 ---
-- name: Download MariaDB GPG key
-  ansible.builtin.get_url:
+- name: Add an Apt signing key, uses whichever key is at the URL
+  ansible.builtin.apt_key:
     url: "https://mariadb.org/mariadb_release_signing_key.asc"
-    dest: "/tmp/mariadb_release_signing_key.asc"
-    mode: '0644'
-
-- name: Add the MariaDB GPG key to apt
-  ansible.builtin.shell:
-    cmd: "apt-key add /tmp/mariadb_release_signing_key.asc"
-  args:
-    removes: "/tmp/mariadb_release_signing_key.asc"
+    state: present
 
 - name: Add MariaDB PPA
   apt_repository:


### PR DESCRIPTION
Fixes the issue where MariaDB installation fails on the "Add MariaDB APT key" task

Ref https://discourse.roots.io/t/trellis-task-mariadb-add-maria-apt-key-apt-key-is-deprecated/26706
Ref https://discourse.roots.io/t/apt-key-deprecated-should-playbooks-be-updated/26761