### PR TITLE
Fix Nginx apt-key is deprecated failure

### DIFF
--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
-nginx_keyserver: "https://nginx.org/keys/nginx_signing.key"
-nginx_keyserver_id: "ABF5BD827BD9BF62"
 nginx_ppa: "deb http://nginx.org/packages/mainline/ubuntu {{ ansible_distribution_release }} nginx"
 nginx_package: nginx
 nginx_conf: nginx.conf.j2

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: Add Nginx APT key
-  apt_key:
-    keyserver: "{{ nginx_keyserver }}"
-    id: "{{ nginx_keyserver_id }}"
+  ansible.builtin.apt_key:
+    url: "https://nginx.org/keys/nginx_signing.key"
+    state: present
 
 - name: Add Nginx PPA
   apt_repository:
@@ -10,10 +10,10 @@
     update_cache: yes
 
 - name: Install Nginx
-  apt:
+  ansible.builtin.apt:
     name: "{{ nginx_package }}"
     state: "{{ nginx_package_state | default(apt_package_state) }}"
-    cache_valid_time: "{{ apt_cache_valid_time }}"
+    update_cache: true
 
 - name: Ensure site directories exist
   file:


### PR DESCRIPTION
🐛 Fix NginxDB apt-key is deprecated failure

* Use apt_repository
* Use apt_key module