### PR TITLE
✨ Ubuntu 24.04 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ['3.x']

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - run: mkdir $HOME/.ssh
       - name: Remove and cleanup mysql

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### HEAD
+* Update boxes to Ubuntu 24.04 [#1519](https://github.com/roots/trellis/pull/1519)
+
 ### 1.22.1: May 30th, 2024
 * Fix Nginx apt-key is deprecated failure [#1518](https://github.com/roots/trellis/pull/1518)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### HEAD
 * Update boxes to Ubuntu 24.04 [#1519](https://github.com/roots/trellis/pull/1519)
+* Update MariaDB to 10.11 [#1520](https://github.com/roots/trellis/pull/1520)
 
 ### 1.22.1: May 30th, 2024
 * Fix Nginx apt-key is deprecated failure [#1518](https://github.com/roots/trellis/pull/1518)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,14 +19,7 @@ trellis_config = Trellis::Config.new(root_path: ANSIBLE_PATH)
 Vagrant.require_version vconfig.fetch('vagrant_require_version', '>= 2.1.0')
 
 Vagrant.configure('2') do |config|
-  box = vconfig.fetch('vagrant_box')
-  box_auto_arch = vconfig.fetch('vagrant_box_auto_arch', true)
-
-  if box_auto_arch && !box.end_with?("-arm64") && apple_silicon?
-    box = "#{box}-arm64"
-  end
-
-  config.vm.box = box
+  config.vm.box = vconfig.fetch('vagrant_box')
   config.vm.box_version = vconfig.fetch('vagrant_box_version')
   config.ssh.forward_agent = true
   config.vm.post_up_message = post_up_message

--- a/roles/sshd/tasks/main.yml
+++ b/roles/sshd/tasks/main.yml
@@ -10,7 +10,9 @@
   notify: restart ssh
 
 - name: Create the /run/sshd directory
-  file: path=/run/sshd state=directory
+  file:
+    path: /run/sshd
+    state: directory
 
 - name: Create a secure sshd_config
   template:

--- a/roles/sshd/tasks/main.yml
+++ b/roles/sshd/tasks/main.yml
@@ -9,6 +9,9 @@
     label: "{{ item.key }}"
   notify: restart ssh
 
+- name: Create the /run/sshd directory
+  file: path=/run/sshd state=directory
+
 - name: Create a secure sshd_config
   template:
     src: "{{ sshd_config }}"

--- a/vagrant.default.yml
+++ b/vagrant.default.yml
@@ -2,14 +2,13 @@
 vagrant_ip: '192.168.56.5'
 vagrant_cpus: 1
 vagrant_memory: 1024 # in MB
-vagrant_box: 'bento/ubuntu-22.04'
+vagrant_box: 'bento/ubuntu-24.04'
 vagrant_box_version: '>= 0'
-vagrant_box_auto_arch: true
 vagrant_ansible_version: '2.10.7'
 vagrant_skip_galaxy: false
 vagrant_mount_type: 'nfs'
 vagrant_nfs_udp: false
-vagrant_require_version: '>= 2.1.0'
+vagrant_require_version: '>= 2.4.0'
 
 vagrant_install_plugins: true
 vagrant_plugins:


### PR DESCRIPTION
* [x] Use new 24.04 box
* [x] Require Vagrant 2.4.0
* [x] Drop old arch conditional in favor of Vagrant's [new arch support](https://developer.hashicorp.com/vagrant/vagrant-cloud/boxes/architecture)
* [x] Update trellis-cli/Lima to use 24.04 (https://github.com/roots/trellis-cli/pull/445)
* [x] Fix provisioning errors
  * [x] Update MariaDB (#1520)
  * [x] ❌ `php8.2-imagick` extension is missing in the ondrej/php PPA
  * [x] ❌ `php8.2-memcached` extension is missing in the ondrej/php PPA
  * [x] Create a secure sshd_config: Missing privilege separation directory: /run/sshd

Ref https://github.com/oerdnj/deb.sury.org/issues/2127

Close #1495 (no longer an issue with the new box)
Close #1516 