### PR TITLE
Fix typo in all/vault.yml

### DIFF
--- a/group_vars/all/vault.yml
+++ b/group_vars/all/vault.yml
@@ -2,7 +2,7 @@
 vault_mail_password: smtp_password
 
 # Variables to accompany `wordpress_env_defaults` in `group_vars/all/helpers.yml`
-# Note: These values can be overriden by `vault_wordpress_sites.*.env`
+# Note: These values can be overridden by `vault_wordpress_sites.*.env`
 #
 # vault_wordpress_env_defaults:
 #   my_api_key: 'available to all environments'


### PR DESCRIPTION
Hello! Your friendly neighborhood grammar police here. 

Overridden has been spelled wrong for the past 6 years. This fixes that ;)

I need a hobby or something.