### PR TITLE
Limit Ansible version to less than v10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ansible>=2.10.0
+ansible>=2.10.0,<10
 passlib


### PR DESCRIPTION
Fixes #1525

This is what I have used on a project as a workaround.

Similar to https://github.com/roots/trellis/pull/1393 