### PR TITLE
Use `http2` and `http3` `nginx` directives

### DIFF
--- a/roles/wordpress-setup/defaults/main.yml
+++ b/roles/wordpress-setup/defaults/main.yml
@@ -7,6 +7,8 @@ nginx_sites_confs:
   - src: ssl.no-default.conf.j2
     enabled: false
 
+http2_enabled: true
+
 # HSTS defaults
 nginx_hsts_max_age: 31536000
 nginx_hsts_include_subdomains: false

--- a/roles/wordpress-setup/defaults/main.yml
+++ b/roles/wordpress-setup/defaults/main.yml
@@ -8,6 +8,7 @@ nginx_sites_confs:
     enabled: false
 
 http2_enabled: true
+http3_enabled: false
 
 # HSTS defaults
 nginx_hsts_max_age: 31536000

--- a/roles/wordpress-setup/defaults/main.yml
+++ b/roles/wordpress-setup/defaults/main.yml
@@ -7,8 +7,8 @@ nginx_sites_confs:
   - src: ssl.no-default.conf.j2
     enabled: false
 
-http2_enabled: true
-http3_enabled: false
+nginx_http2_enabled: true
+nginx_http3_enabled: false
 
 # HSTS defaults
 nginx_hsts_max_age: 31536000

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -4,8 +4,9 @@
 
 server {
   {% block server_id -%}
-  listen {{ ssl_enabled | ternary('[::]:443 ssl http2', '[::]:80') }};
-  listen {{ ssl_enabled | ternary('443 ssl http2', '80') }};
+  listen {{ ssl_enabled | ternary('[::]:443 ssl', '[::]:80') }};
+  listen {{ ssl_enabled | ternary('443 ssl', '80') }};
+  http2 {{ http2_enabled | default(false) | ternary('on', 'off') }};
   server_name {{ site_hosts_canonical | union(multisite_subdomains_wildcards) | join(' ') }};
   {% endblock %}
 
@@ -290,11 +291,12 @@ server {
 {% for host in item.value.site_hosts if host.redirects | default([]) %}
 server {
   {% if ssl_enabled -%}
-  listen [::]:443 ssl http2;
-  listen 443 ssl http2;
+  listen [::]:443 ssl;
+  listen 443 ssl;
   {% endif -%}
   listen [::]:80;
   listen 80;
+  http2 {{ http2_enabled | default(false) | ternary('on', 'off') }};
   server_name {{ host.redirects | join(' ') }};
 
   {{ self.https() -}}

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -6,8 +6,8 @@ server {
   {% block server_id -%}
   listen {{ ssl_enabled | ternary('[::]:443 ssl', '[::]:80') }};
   listen {{ ssl_enabled | ternary('443 ssl', '80') }};
-  http2 {{ http2_enabled | default(false) | ternary('on', 'off') }};
-  http3 {{ http3_enabled | default(false) | ternary('on', 'off') }};
+  http2 {{ nginx_http2_enabled | default(false) | ternary('on', 'off') }};
+  http3 {{ nginx_http3_enabled | default(false) | ternary('on', 'off') }};
   server_name {{ site_hosts_canonical | union(multisite_subdomains_wildcards) | join(' ') }};
   {% endblock %}
 
@@ -297,8 +297,8 @@ server {
   {% endif -%}
   listen [::]:80;
   listen 80;
-  http2 {{ http2_enabled | default(false) | ternary('on', 'off') }};
-  http3 {{ http3_enabled | default(false) | ternary('on', 'off') }};
+  http2 {{ nginx_http2_enabled | default(false) | ternary('on', 'off') }};
+  http3 {{ nginx_http3_enabled | default(false) | ternary('on', 'off') }};
   server_name {{ host.redirects | join(' ') }};
 
   {{ self.https() -}}

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -7,6 +7,7 @@ server {
   listen {{ ssl_enabled | ternary('[::]:443 ssl', '[::]:80') }};
   listen {{ ssl_enabled | ternary('443 ssl', '80') }};
   http2 {{ http2_enabled | default(false) | ternary('on', 'off') }};
+  http3 {{ http3_enabled | default(false) | ternary('on', 'off') }};
   server_name {{ site_hosts_canonical | union(multisite_subdomains_wildcards) | join(' ') }};
   {% endblock %}
 
@@ -297,6 +298,7 @@ server {
   listen [::]:80;
   listen 80;
   http2 {{ http2_enabled | default(false) | ternary('on', 'off') }};
+  http3 {{ http3_enabled | default(false) | ternary('on', 'off') }};
   server_name {{ host.redirects | join(' ') }};
 
   {{ self.https() -}}


### PR DESCRIPTION
This PR uses the `http2` and `http3` directives instead the deprecated `http2` keyword in `listen` directive.
`HTTP 2` and `HTTP 3` support can be controlled using the ansible `http2_enabled` and `http3_enabled` options.

Using the [`h5bp` `nginx` configuration](https://github.com/h5bp/server-configs-nginx/pull/335/files#diff-1fef7bb78ec8a7315a2a8d18eaebf796065a236e3f17d4d1b6bae8b89965ed39) as base.

As some may still be hesitant to enabling HTTP 3 support in nginx, the
option for HTTP 3 is turned off by default and can be turned on manually.