### PR TITLE
Add HTTP/3 support

### DIFF
--- a/group_vars/all/security.yml
+++ b/group_vars/all/security.yml
@@ -2,7 +2,7 @@
 
 ferm_input_list:
   - type: dport_accept
-    dport: [http, https]
+    dport: [http]
     filename: nginx_accept
   - type: dport_accept
     dport: [ssh]

--- a/group_vars/all/security.yml
+++ b/group_vars/all/security.yml
@@ -5,6 +5,15 @@ ferm_input_list:
     dport: [http]
     filename: nginx_accept
   - type: dport_accept
+    dport: [https]
+    filename: nginx_accept_https
+    delete: "{{ not (sites_use_ssl | bool) }}"
+  - type: dport_accept
+    dport: ['443']
+    protocol: udp
+    filename: nginx_accept_http3
+    delete: "{{ not (nginx_http3_enabled and (sites_use_ssl | bool)) }}"
+  - type: dport_accept
     dport: [ssh]
     saddr: "{{ ip_whitelist }}"
   - type: dport_limit

--- a/roles/ferm/defaults/main.yml
+++ b/roles/ferm/defaults/main.yml
@@ -11,3 +11,5 @@ ferm_default_policy_forward: DROP
 ferm_input_list: []
 ferm_input_group_list: []
 ferm_input_host_list: []
+
+sites_using_ssl: "[{% for name, site in wordpress_sites.items() | list if site.ssl.enabled %}'{{ name }}',{% endfor %}]"

--- a/roles/ferm/tasks/main.yml
+++ b/roles/ferm/tasks/main.yml
@@ -35,6 +35,29 @@
   notify:
     - restart ferm
 
+
+- name: allow conditionally inbound HTTPS
+  set_fact:
+    ferm_input_list: "{{ ferm_input_list + [ ferm_dport_nginx_https] }}"
+  when: sites_using_ssl | count
+  vars:
+    ferm_dport_nginx_https:
+      type: dport_accept
+      dport: [https]
+      filename: nginx_accept_https
+
+- name: allow conditionally port UDP/443 for HTTP/3 (QUIC) support
+  set_fact:
+    ferm_input_list: "{{ ferm_input_list + [ ferm_dport_nginx_http3] }}"
+  when: nginx_http3_enabled and (sites_using_ssl | count)
+  vars:
+    ferm_dport_nginx_http3:
+      type: dport_accept
+      dport: ['443']
+      protocol: udp
+      filename: nginx_accept_http3
+
+
 - name: ensure iptables INPUT rules are removed
   file:
     path: "/etc/ferm/filter-input.d/{{ item.weight | default('50') }}_{{ (item.filename is defined and item.filename) | ternary(item.filename, item.type + '_' + item.dport[0]) }}.conf"

--- a/roles/ferm/tasks/main.yml
+++ b/roles/ferm/tasks/main.yml
@@ -35,29 +35,6 @@
   notify:
     - restart ferm
 
-
-- name: allow conditionally inbound HTTPS
-  set_fact:
-    ferm_input_list: "{{ ferm_input_list + [ ferm_dport_nginx_https] }}"
-  when: sites_using_ssl | count
-  vars:
-    ferm_dport_nginx_https:
-      type: dport_accept
-      dport: [https]
-      filename: nginx_accept_https
-
-- name: allow conditionally port UDP/443 for HTTP/3 (QUIC) support
-  set_fact:
-    ferm_input_list: "{{ ferm_input_list + [ ferm_dport_nginx_http3] }}"
-  when: nginx_http3_enabled and (sites_using_ssl | count)
-  vars:
-    ferm_dport_nginx_http3:
-      type: dport_accept
-      dport: ['443']
-      protocol: udp
-      filename: nginx_accept_http3
-
-
 - name: ensure iptables INPUT rules are removed
   file:
     path: "/etc/ferm/filter-input.d/{{ item.weight | default('50') }}_{{ (item.filename is defined and item.filename) | ternary(item.filename, item.type + '_' + item.dport[0]) }}.conf"

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -6,6 +6,13 @@ server {
   {% block server_id -%}
   listen {{ ssl_enabled | ternary('[::]:443 ssl', '[::]:80') }};
   listen {{ ssl_enabled | ternary('443 ssl', '80') }};
+
+  {% if ssl_enabled and nginx_http3_enabled -%}
+  # Listen on UDP for QUIC+HTTP/3
+  listen [::]:443 quic;
+  listen 443 quic;
+  {% endif -%}
+
   http2 {{ nginx_http2_enabled | default(false) | ternary('on', 'off') }};
   http3 {{ nginx_http3_enabled | default(false) | ternary('on', 'off') }};
   server_name {{ site_hosts_canonical | union(multisite_subdomains_wildcards) | join(' ') }};
@@ -15,6 +22,17 @@ server {
   access_log   {{ www_root }}/{{ item.key }}/logs/access.log main;
   error_log    {{ www_root }}/{{ item.key }}/logs/error.log;
   {% endblock %}
+
+  {% if ssl_enabled and nginx_http3_enabled -%}
+  quic_retry on;
+  # enable 0-RTT
+  ssl_early_data on;
+  proxy_set_header Early-Data $ssl_early_data;
+  quic_gso on;
+
+  # Add Alt-Svc header to negotiate HTTP/3.
+  add_header alt-svc 'h3=":443"; ma=86400';
+  {% endif -%}
 
   {% block server_basic -%}
   root  {{ www_root }}/{{ item.key }}/{{ item.value.current_path | default('current') }}/{{ item.value.public_path | default('web') }};
@@ -277,6 +295,11 @@ server {
 
   {{ self.includes_d() -}}
 
+  {% if ssl_enabled and nginx_http3_enabled -%}
+  # Add Alt-Svc header to negotiate HTTP/3 (when redirecting from HTTP).
+  add_header alt-svc 'h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443"; ma=86400';
+  {% endif -%}
+
   location / {
     return 301 https://$host$request_uri;
   }
@@ -295,11 +318,30 @@ server {
   listen [::]:443 ssl;
   listen 443 ssl;
   {% endif -%}
+
   listen [::]:80;
   listen 80;
+
+  {% if ssl_enabled and nginx_http3_enabled -%}
+  # Listen on UDP for QUIC+HTTP/3
+  listen [::]:443 quic;
+  listen 443 quic;
+  {% endif -%}
+
   http2 {{ nginx_http2_enabled | default(false) | ternary('on', 'off') }};
   http3 {{ nginx_http3_enabled | default(false) | ternary('on', 'off') }};
   server_name {{ host.redirects | join(' ') }};
+
+  {% if ssl_enabled and nginx_http3_enabled -%}
+  quic_retry on;
+  # enable 0-RTT
+  ssl_early_data on;
+  proxy_set_header Early-Data $ssl_early_data;
+  quic_gso on;
+
+  # Add Alt-Svc header to negotiate HTTP/3 (when redirecting from HTTP).
+  add_header alt-svc 'h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443"; ma=86400';
+  {% endif -%}
 
   {{ self.https() -}}
 


### PR DESCRIPTION
This PR adds the necessary configuration for proper HTTP/3 support (by `nginx`).
Some additional SSL/QUIC/HTTP/3 tweaks are added to the configuration when HTTP/3 support is turned on.
The OS ansible-managed `ferm` firewall is also configured to allow inbound UDP/433 for QUIC (HTTP/3). The approach is also used in the previous PR for HTTPS (https://github.com/roots/trellis/pull/1530).

Additional notes:
- Besides the OS firewall (that is configured by Trellis) there is often a hardware/cloud firewall in front of the server, 
of course it also needs to be configured for allowing inbound UDP/443 traffic for QUIC (HTTP/3).
- HTTP/3 requires an additional HTTP header to be sent for advertising the availability of QUIC/HTTP/3,
without this HTTP header, HTTP/3 will not work, despite everything else working fine.
- Port `443` is not mandatory for HTTP/3, but it is recommended to use the same port `443` as for HTTPS (TCP), `nginx` can listen on QUIC/UDP `443` in parallel to the `443` TCP for HTTPS.
- In my experience, testing HTTP/3 requests worked best with the Chrome Developer Tools (Network tab, toggle `Protocol` column on). 
`curl`/`wget` HTTP/3 support is not a given in current stable Ubuntu. I used a [`curl Docker image with HTTP/3 support`](https://github.com/yurymuski/curl-http3). Some online HTTP/3 testing tools do not always work and incorrectly report HTTP/3 not being supported.