### PR TITLE
Use proper `$host` for FastCGI `SERVER_NAME` param

### DIFF
--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -255,6 +255,7 @@ server {
 
     {% block fastcgi_basic -%}
     include fastcgi_params;
+    fastcgi_param SERVER_NAME $host;
     fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
     fastcgi_param DOCUMENT_ROOT $realpath_root;
     fastcgi_pass unix:/var/run/php-fpm-wordpress.sock;


### PR DESCRIPTION
This PR adds a `fastcgi_param` line to wordpress site configuration to ensure that `SERVER_NAME` FastCGI (PHP) variable is set to `$host`. This is important as the included default `fastcgi_params` set `SERVER_NAME` to `$server_name` which is set (arbitrarily) to one of the matching hostnames of a site, but not the actual matching one.
Fixes #1550.