### PR TITLE
🔧 FastCGI Cache: Stop ignoring Cache-Control headers

### DIFF
--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -67,7 +67,7 @@ http {
   fastcgi_cache_use_stale updating error timeout invalid_header http_500;
   fastcgi_cache_lock on;
   fastcgi_cache_key $realpath_root$scheme$host$request_uri$request_method$http_origin$http_x_http_method_override;
-  fastcgi_ignore_headers Cache-Control Expires Set-Cookie;
+  fastcgi_ignore_headers Expires Set-Cookie;
   fastcgi_pass_header Set-Cookie;
   fastcgi_pass_header Cookie;
   {% endblock %}


### PR DESCRIPTION
Follow-ups:

* [ ] Update https://roots.io/trellis/docs/fastcgi-caching/ examples

Ref https://discourse.roots.io/t/skip-cache-url-localized-shop-urls/29025/4
Ref https://github.com/roots/trellis/pull/234