### PR TITLE
Mitigate REST API cache poisoning via Method Override

### DIFF
--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -66,7 +66,7 @@ http {
   fastcgi_cache_path {{ nginx_cache_path }} levels=1:2 keys_zone=wordpress:{{ nginx_cache_key_storage_size }} max_size={{ nginx_cache_size }} inactive={{ nginx_cache_inactive }};
   fastcgi_cache_use_stale updating error timeout invalid_header http_500;
   fastcgi_cache_lock on;
-  fastcgi_cache_key $realpath_root$scheme$host$request_uri$request_method$http_origin;
+  fastcgi_cache_key $realpath_root$scheme$host$request_uri$request_method$http_origin$http_x_http_method_override;
   fastcgi_ignore_headers Cache-Control Expires Set-Cookie;
   fastcgi_pass_header Set-Cookie;
   fastcgi_pass_header Cookie;


### PR DESCRIPTION
Assuming a website chooses to cache responses for specific API routes in the WP REST API (like /wp-json/wp/v2/posts). An attacker could use the `X-HTTP-Method-Override` header to request an endpoint (i.e. /wp/v2/posts/1) until the cache is `STALE` and trigger an update of the cache from the response that served the HEAD request instead of the GET request. The endpoint would then return an empty response body.

Normal routes are not affected by this, but since WP allows method overrides against the REST API, this could become an issue for headless WP instances.