### PR TITLE
🔧 PHP 8.4 support

### DIFF
--- a/roles/php/vars/8.4.yml
+++ b/roles/php/vars/8.4.yml
@@ -1,0 +1,18 @@
+php_extensions_default:
+  php8.4-bcmath: "{{ apt_package_state }}"
+  php8.4-cli: "{{ apt_package_state }}"
+  php8.4-curl: "{{ apt_package_state }}"
+  php8.4-dev: "{{ apt_package_state }}"
+  php8.4-fpm: "{{ apt_package_state }}"
+  php8.4-imagick: "{{ apt_package_state }}"
+  php8.4-intl: "{{ apt_package_state }}"
+  php8.4-mbstring: "{{ apt_package_state }}"
+  php8.4-mysql: "{{ apt_package_state }}"
+  php8.4-xml: "{{ apt_package_state }}"
+  php8.4-xmlrpc: "{{ apt_package_state }}"
+  php8.4-zip: "{{ apt_package_state }}"
+
+php_memcached_packages:
+  php8.4-memcached: "{{ apt_package_state }}"
+
+php_xdebug_package: php8.4-xdebug


### PR DESCRIPTION
⚠️ WP-CLI doesn't support PHP 8.4 at this time — expect lots of deprecated spam if you're wanting to use PHP 8.4 right now