### PR TITLE
Replace link for creating CSP

### DIFF
--- a/roles/nginx/templates/h5bp/directive-only/extra-security.conf
+++ b/roles/nginx/templates/h5bp/directive-only/extra-security.conf
@@ -13,5 +13,5 @@ add_header X-XSS-Protection "1; mode=block" always;
 # with Content Security Policy (CSP) enabled (and a browser that supports it (http://caniuse.com/#feat=contentsecuritypolicy),
 # you can tell the browser that it can only download content from the domains you explicitly allow
 # CSP can be quite difficult to configure, and cause real issues if you get it wrong
-# There is website that helps you generate a policy here http://cspisawesome.com/
+# There is a browser extension that helps you generate a policy here https://csper.io/generator
 # add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' https://www.google-analytics.com;" always;

--- a/roles/nginx/templates/h5bp/directive-only/extra-security.conf
+++ b/roles/nginx/templates/h5bp/directive-only/extra-security.conf
@@ -1,17 +1,28 @@
-# The X-Frame-Options header indicates whether a browser should be allowed
-# to render a page within a frame or iframe.
-# add_header X-Frame-Options SAMEORIGIN always;
+# ----------------------------------------------------------------------
+# | Content Security Policy (CSP)                                      |
+# ----------------------------------------------------------------------
 
-# MIME type sniffing security protection
-#	There are very few edge cases where you wouldn't want this enabled.
-add_header X-Content-Type-Options nosniff always;
+# Mitigate the risk of cross-site scripting and other content-injection
+# attacks.
+#
+# This can be done by setting a Content Security Policy which permits
+# trusted sources of content for your website.
+#
+# There is no policy that fits all websites, you will have to modify the
+# `Content-Security-Policy` directives in the example depending on your needs.
+#
+# To make your CSP implementation easier, you can use an online CSP header
+# generator such as:
+# https://report-uri.com/home/generate/
+#
+# It is encouraged that you validate your CSP header using a CSP validator
+# such as:
+# https://csp-evaluator.withgoogle.com
+#
+# https://www.w3.org/TR/CSP/
+# https://owasp.org/www-project-secure-headers/#content-security-policy
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
+# https://developers.google.com/web/fundamentals/security/csp
+# https://content-security-policy.com/
 
-# The X-XSS-Protection header is used by Internet Explorer version 8+
-# The header instructs IE to enable its inbuilt anti-cross-site scripting filter.
-add_header X-XSS-Protection "1; mode=block" always;
-
-# with Content Security Policy (CSP) enabled (and a browser that supports it (http://caniuse.com/#feat=contentsecuritypolicy),
-# you can tell the browser that it can only download content from the domains you explicitly allow
-# CSP can be quite difficult to configure, and cause real issues if you get it wrong
-# There is a browser extension that helps you generate a policy here https://csper.io/generator
 # add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' https://www.google-analytics.com;" always;

--- a/roles/nginx/templates/h5bp/directive-only/extra-security.conf
+++ b/roles/nginx/templates/h5bp/directive-only/extra-security.conf
@@ -1,6 +1,14 @@
-# ----------------------------------------------------------------------
-# | Content Security Policy (CSP)                                      |
-# ----------------------------------------------------------------------
+# The X-Frame-Options header indicates whether a browser should be allowed
+# to render a page within a frame or iframe.
+# add_header X-Frame-Options SAMEORIGIN always;
+
+# MIME type sniffing security protection
+#	There are very few edge cases where you wouldn't want this enabled.
+add_header X-Content-Type-Options nosniff always;
+
+# The X-XSS-Protection header is used by Internet Explorer version 8+
+# The header instructs IE to enable its inbuilt anti-cross-site scripting filter.
+add_header X-XSS-Protection "1; mode=block" always;
 
 # Mitigate the risk of cross-site scripting and other content-injection
 # attacks.


### PR DESCRIPTION
Hello!

I woke up this morning and decided to add CSP to the company website. Turns out that the *checks changelog* 7 year old link for this project takes you to a blog now.

So I looked around online for a similar site that is free to use. I found nothing.

Eventually I found a browser extension that allows you to create CSP by browsing around your website. I just tried it and so far it works great.

If you guys have a better site or extension, feel free using that instead :) 

PS. What's going on with the community forum at the moment? I don't have Discord access and the message on the forum stating it's read only temporarily is really bare bones.