### PR TITLE
Flush rewrite rules at the end of each deploy

### DIFF
--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -49,6 +49,9 @@ project_current_path: "{{ project.current_path | default('current') }}"
 # Whether to run `wp core update-db` at end of each deploy
 update_db_on_deploy: true
 
+# Whether to flush rewrite rules at end of each deploy
+flush_rewrite_rules_on_deploy: true
+
 # Most scripts are used in development instead of remote servers. Use with caution.
 composer_no_scripts: true
 # Whether to run `composer check-platform-reqs`.

--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -31,6 +31,12 @@
       chdir: "{{ deploy_helper.current_path }}"
     when: project.update_db_on_deploy | default(update_db_on_deploy)
 
+  - name: Flush rewrite rules
+    command: wp rewrite flush
+    args:
+      chdir: "{{ deploy_helper.current_path }}"
+    when: project.flush_rewrite_rules_on_deploy | default(flush_rewrite_rules_on_deploy)
+
   when: wp_installed.rc == 0
 
 - name: Reload php-fpm


### PR DESCRIPTION
Permalinks aren’t automatically flushed on deployment, so I usually handle it in a deploy hook. Since rewrites function like a cache—similar to Acorn, ACF, or Redis—it makes sense to clear them during deployment.

For example, adding a new CPT requires flushing rewrites manually for the archive page to work. Automating this would help ensure rewrite *just work* after deployment.