### PR TITLE
🩹 Add retry to adding PPA's

### DIFF
--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -8,6 +8,10 @@
   apt_repository:
     repo: "{{ mariadb_ppa }}"
     update_cache: yes
+  register: result
+  until: result is success
+  retries: 3
+  delay: 5
 
 - name: Install MySQL client
   ansible.builtin.apt:

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -8,6 +8,10 @@
   apt_repository:
     repo: "{{ nginx_ppa }}"
     update_cache: yes
+  register: result
+  until: result is success
+  retries: 3
+  delay: 5
 
 - name: Install Nginx
   ansible.builtin.apt:

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -3,6 +3,10 @@
   apt_repository:
     repo: "ppa:ondrej/php"
     update_cache: yes
+  register: result
+  until: result is success
+  retries: 3
+  delay: 5
 
 - name: Install PHP and extensions
   apt:


### PR DESCRIPTION
Something that happens fairly frequently for folks is a network failure when Trellis tries to add the PPA for PHP, MariaDB, or Nginx. The failure looks like this:

```
TASK [php : Add PHP PPA] *******************************************************
fatal: [default]: FAILED! => {"changed": false, "msg": "failed to fetch PPA information, error was: Connection failure: The read operation timed out"}
```

The provisioning will sometimes continue a bit further before ending in a failure, and you're left with an unusable VM. Almost always, immediately trying to re-provision will work without an issue.

This PR adds 3 retries to any failures when trying to add a PPA.