### PR TITLE
Update build-after.yml to say Sage 11 instead of Sage 10

### DIFF
--- a/deploy-hooks/build-after.yml
+++ b/deploy-hooks/build-after.yml
@@ -1,8 +1,8 @@
 # Placeholder `deploy_build_after` hook
 #
-# ⚠️ This example assumes your theme is using Sage 10
+# ⚠️ This example assumes your theme is using Sage 11
 #
-# Uncomment the lines below if you are using Sage 10
+# Uncomment the lines below if you are using Sage 11
 # NOTE: this task will fail if Sage theme is not activated at time of deployment.
 #
 # ---


### PR DESCRIPTION
Hello! This adjusts the build-after.yml to mention Sage 11 instead of Sage 10. Technically works for Sage 10 too (obviously) but this aligns it with build-before.yml.