### PR TITLE
Filter Nginx includes by sites present on target server

### DIFF
--- a/roles/wordpress-setup/defaults/main.yml
+++ b/roles/wordpress-setup/defaults/main.yml
@@ -30,7 +30,6 @@ nginx_cache_background_update: "on"
 nginx_includes_templates_path: nginx-includes
 nginx_includes_pattern: "^({{ nginx_includes_templates_path | regex_escape }})/(.*)\\.j2$"
 nginx_includes_d_cleanup: true
-nginx_includes_extra_folders: 'all'
 
 # h5bp helpers
 not_dev: "{{ env != 'development' }}"

--- a/roles/wordpress-setup/defaults/main.yml
+++ b/roles/wordpress-setup/defaults/main.yml
@@ -30,6 +30,7 @@ nginx_cache_background_update: "on"
 nginx_includes_templates_path: nginx-includes
 nginx_includes_pattern: "^({{ nginx_includes_templates_path | regex_escape }})/(.*)\\.j2$"
 nginx_includes_d_cleanup: true
+nginx_includes_extra_folders: 'all'
 
 # h5bp helpers
 not_dev: "{{ env != 'development' }}"

--- a/roles/wordpress-setup/tasks/nginx-includes.yml
+++ b/roles/wordpress-setup/tasks/nginx-includes.yml
@@ -19,14 +19,20 @@
     set_fact:
       nginx_include_contexts: "{{ wordpress_sites.keys() | list + nginx_includes_extra_folders_list }}"
 
-  - name: Build list of Nginx includes templates
+  - name: Loop through site keys to build a list of Nginx includes templates per folder
     find:
-      paths: "{{ nginx_includes_templates_path }}"
+      paths: "{{ nginx_includes_templates_path }}/{{ item }}"
+      patterns: "*.conf.j2"
       recurse: yes
-      patterns: "{{ nginx_include_contexts | map('regex_replace', '^(.*)$', '\\1/*.conf.j2') | list }}"
+    loop: "{{ nginx_include_contexts }}"
     become: no
     delegate_to: localhost
-    register: nginx_includes_templates
+    register: nginx_includes_folder_results
+
+  - name: Flatten include template files into one list
+    set_fact:
+      nginx_includes_templates:
+        files: "{{ nginx_includes_folder_results.results | map(attribute='files') | flatten }}"
 
   - name: Create includes.d directories
     file:

--- a/roles/wordpress-setup/tasks/nginx-includes.yml
+++ b/roles/wordpress-setup/tasks/nginx-includes.yml
@@ -13,7 +13,30 @@
       recurse: yes
     become: no
     delegate_to: localhost
-    register: nginx_includes_templates
+    register: nginx_includes_templates_all
+
+  - name: Combine site keys with extra include folders
+    set_fact:
+      nginx_include_contexts: >-
+        {{
+          (wordpress_sites.keys() | list)
+          + (
+              (nginx_includes_extra_folders
+                if nginx_includes_extra_folders is iterable and not nginx_includes_extra_folders is string
+                else [nginx_includes_extra_folders | default('all')]
+              )
+            )
+        }}
+
+  - name: Filter Nginx includes templates by existing sites and global folders
+    set_fact:
+      nginx_includes_templates:
+        files: >-
+          {{
+            nginx_includes_templates_all.files
+            | selectattr('path', 'search', '/(' + nginx_include_contexts | join('|') + ')/')
+            | list
+          }}
 
   - name: Create includes.d directories
     file:

--- a/roles/wordpress-setup/tasks/nginx-includes.yml
+++ b/roles/wordpress-setup/tasks/nginx-includes.yml
@@ -6,15 +6,6 @@
   register: nginx_includes_local_directory
 
 - block:
-  - name: Build list of Nginx includes templates
-    find:
-      paths: "{{ nginx_includes_templates_path }}"
-      pattern: "*.conf.j2"
-      recurse: yes
-    become: no
-    delegate_to: localhost
-    register: nginx_includes_templates_all
-
   - name: Normalize extra include folders to a list
     set_fact:
       nginx_includes_extra_folders_list: >-
@@ -28,15 +19,14 @@
     set_fact:
       nginx_include_contexts: "{{ wordpress_sites.keys() | list + nginx_includes_extra_folders_list }}"
 
-  - name: Filter Nginx includes templates by existing sites and extra folders
-    set_fact:
-      nginx_includes_templates:
-        files: >-
-          {{
-            nginx_includes_templates_all.files
-            | selectattr('path', 'search', '/(' + nginx_include_contexts | join('|') + ')/')
-            | list
-          }}
+  - name: Build list of Nginx includes templates
+    find:
+      paths: "{{ nginx_includes_templates_path }}"
+      recurse: yes
+      patterns: "{{ nginx_include_contexts | map('regex_replace', '^(.*)$', '\\1/*.conf.j2') | list }}"
+    become: no
+    delegate_to: localhost
+    register: nginx_includes_templates
 
   - name: Create includes.d directories
     file:

--- a/roles/wordpress-setup/tasks/nginx-includes.yml
+++ b/roles/wordpress-setup/tasks/nginx-includes.yml
@@ -6,25 +6,12 @@
   register: nginx_includes_local_directory
 
 - block:
-  - name: Normalize extra include folders to a list
-    set_fact:
-      nginx_includes_extra_folders_list: >-
-        {{
-          nginx_includes_extra_folders
-          if nginx_includes_extra_folders is iterable and not nginx_includes_extra_folders is string
-          else [nginx_includes_extra_folders | default('all')]
-        }}
-
-  - name: Combine site keys with extra include folders
-    set_fact:
-      nginx_include_contexts: "{{ wordpress_sites.keys() | list + nginx_includes_extra_folders_list }}"
-
   - name: Loop through site keys to build a list of Nginx includes templates per folder
     find:
       paths: "{{ nginx_includes_templates_path }}/{{ item }}"
       patterns: "*.conf.j2"
       recurse: yes
-    loop: "{{ nginx_include_contexts }}"
+    loop: "{{ wordpress_sites.keys() | list + ['all'] }}"
     become: no
     delegate_to: localhost
     register: nginx_includes_folder_results

--- a/roles/wordpress-setup/tasks/nginx-includes.yml
+++ b/roles/wordpress-setup/tasks/nginx-includes.yml
@@ -15,20 +15,20 @@
     delegate_to: localhost
     register: nginx_includes_templates_all
 
-  - name: Combine site keys with extra include folders
+  - name: Normalize extra include folders to a list
     set_fact:
-      nginx_include_contexts: >-
+      nginx_includes_extra_folders_list: >-
         {{
-          (wordpress_sites.keys() | list)
-          + (
-              (nginx_includes_extra_folders
-                if nginx_includes_extra_folders is iterable and not nginx_includes_extra_folders is string
-                else [nginx_includes_extra_folders | default('all')]
-              )
-            )
+          nginx_includes_extra_folders
+          if nginx_includes_extra_folders is iterable and not nginx_includes_extra_folders is string
+          else [nginx_includes_extra_folders | default('all')]
         }}
 
-  - name: Filter Nginx includes templates by existing sites and global folders
+  - name: Combine site keys with extra include folders
+    set_fact:
+      nginx_include_contexts: "{{ wordpress_sites.keys() | list + nginx_includes_extra_folders_list }}"
+
+  - name: Filter Nginx includes templates by existing sites and extra folders
     set_fact:
       nginx_includes_templates:
         files: >-


### PR DESCRIPTION
One for those of us using multiple remote servers with Trellis.

Currently, Trellis templates out anything you put into `nginx-includes/` to the remote servers. Take the following:

```
trellis/
└── group_vars/         
    └── production/
        ├── main.yml
        └── vault.yml
    └── staging/
└── host_vars
    └── server1/
        └── wordpress_sites.yml
    └── server2/
        └── wordpress_sites.yml
    └── staging1/
    └── staging2/
```

Assume server1 has a different site(s) to server2, and perhaps staging1 and staging 2 have additional sites. Your Nginx includes folder might look like this:

```
trellis/
└── nginx-includes/         
    └── all/
        ├── rewrites.conf.j2
        └── proxy.conf.j2
    └── site1/
        └── rewrites.conf.j2
    └── site2/
        └── rewrites.conf.j2
    └── site3/
        └── rewrites.conf.j2
...etc
```

 **All** servers will end up with **all** Nginx includes files, even if the sites don't exist on that server:

```
/etc/nginx/includes.d/
└── all/  
    ├── rewrites.conf
    └── proxy.conf
└── site1/  
    └── rewrites.conf
└── site2/  
    └── rewrites.conf
└── site3/  
    └── rewrites.conf
└── site4/  
    └── rewrites.conf
```

This PR filters the Nginx includes that are to be 'included' by combining the sites that exist on the target server (taken from  wordpress_sites keys) with a default 'all'. This follows with the default setup [shown in the docs](https://roots.io/trellis/docs/nginx-includes/#default). 

~Also included is the ability to override the default 'all' folder. I've only included this because it is possible to override the [block in the Nginx conf template](https://github.com/roots/trellis/blob/d4b6f29648ae0759f319eee8a9e4d4ace684224d/roles/wordpress-setup/templates/wordpress-site.conf.j2#L116-L120) and if someone did that, they may also want to determine their own Nginx includes locations.~

~To override or otherwise add to the Nginx includes locations, in e.g. `group_vars/all/main.yml` you can do~

```yml
# Edit: this change was removed 
```

Note: in testing, the folders for sites not present on a remote are not cleaned up if they already exist but the files inside them are. That's to do with what happens when setting `nginx_includes_d_cleanup: true` which is a separate issue. 