### PR TITLE
Allow removal of old SSH keys on provision

### DIFF
--- a/group_vars/all/security.yml
+++ b/group_vars/all/security.yml
@@ -38,8 +38,3 @@ sshd_password_authentication: false
 ip_whitelist:
   - 127.0.0.0/8
   - "{{ ipify_public_ip | default('') }}"
-
-# Only enable this when you want to reset the SSH keys on the server.
-# You probably don't need this enabled for every server provision.
-# Double check your keys are correct in group_vars/all/users.yml first.
-reset_user_ssh_keys: false

--- a/group_vars/all/security.yml
+++ b/group_vars/all/security.yml
@@ -38,3 +38,8 @@ sshd_password_authentication: false
 ip_whitelist:
   - 127.0.0.0/8
   - "{{ ipify_public_ip | default('') }}"
+
+# Only enable this when you want to reset the SSH keys on the server.
+# You probably don't need this enabled for every server provision.
+# Double check your keys are correct in group_vars/all/users.yml first.
+reset_user_ssh_keys: false

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -51,6 +51,18 @@
     validate: "/usr/sbin/visudo -cf %s"
   when: web_sudoers[0] is defined
 
+- name: Replace all user SSH keys with first non-empty key
+  authorized_key:
+    user: "{{ item.name }}"
+    key: "{{ (item['keys'] | select('truthy') | list).0 }}"
+    exclusive: true
+  loop: "{{ users | default([]) }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when:
+    - reset_user_ssh_keys | default(false)
+    - (item['keys'] | select('truthy') | list | length) > 0
+
 - name: Add user SSH keys
   authorized_key:
     user: "{{ item.0.name }}"


### PR DESCRIPTION
Rel: roots/trellis#1087

This PR adds the ability to enable removing old SSH keys from the server. 

The added task replaces **all SSH keys on the server** for the users defined in Trellis with the _first found_ SSH key set in `group_vars/all/users.yml`. This allows for cases where the Trellis defaults `~/.ssh/id_rsa.pub` and `~/.ssh/id_ed25519.pub` don't exist. The existing task "Add user SSH keys" then adds the remaining keys as usual. 

Given this has the power to lock a user out of their server, a flag has been added to allow making this an optional task to run. To enable, set `reset_user_ssh_keys: true`. I've placed this in `group_vars/all/security.yml` but arguments can be made for this in `users.yml` or `main.yml`.

### Scenarios
Given the default Trellis keys:

```yaml
  keys:
      - "{{ lookup('file', '~/.ssh/id_rsa.pub', errors='ignore') }}"
      - "{{ lookup('file', '~/.ssh/id_ed25519.pub', errors='ignore') }}"
      # - https://github.com/username.keys
```

If...
- `~/.ssh/id_rsa.pub` does not exist, `~/.ssh/id_ed25519.pub` does exist
  - `keys` becomes `["", "ssh-ed25519 AAAAC3NzaC1.."]` (example)
  - `select('truthy')` filters out empty strings, `keys` becomes `["ssh-ed25519 AAAAC3NzaC1.."]`
  - The value of `~/.ssh/id_ed25519.pub` is used (e.g. `ssh-ed25519 AAAAC3NzaC1..`)
  - The task is run. Note: Until the subsequent (existing) task is run, access is temporarily only available to `~/.ssh/id_ed25519.pub`.
- Neither `~/.ssh/id_rsa.pub` nor `~/.ssh/id_ed25519.pub` exist
  - `keys` becomes `["", ""]`
  - `select('truthy')` filters out empty strings, `keys` becomes `[]`
  - The `when` clause `(item['keys'] | select('truthy') | list | length) > 0` evaluates to false
  - The task is skipped - no SSH keys removed from the server.