### PR TITLE
Allow cleaning apt sources on provision

### DIFF
--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -2,6 +2,7 @@ apt_cache_valid_time: 3600
 apt_package_state: present
 apt_security_package_state: latest
 apt_dev_package_state: latest
+apt_clean_sources: false
 composer_keep_updated: true
 php_version: "8.2"
 ntp_timezone: Etc/UTC

--- a/roles/common/tasks/clean-apt-sources.yml
+++ b/roles/common/tasks/clean-apt-sources.yml
@@ -2,7 +2,10 @@
 - name: Clean stale APT sources from /etc/apt/sources.list.d
   find:
     paths: /etc/apt/sources.list.d
-    patterns: '*.list,*.list.save,*.list.distUpgrade'
+    patterns:
+      - *.list
+      - *.list.save
+      - *.list.distUpgrade
     use_regex: false
   register: stale_sources
   become: true

--- a/roles/common/tasks/clean-apt-sources.yml
+++ b/roles/common/tasks/clean-apt-sources.yml
@@ -3,9 +3,9 @@
   find:
     paths: /etc/apt/sources.list.d
     patterns:
-      - *.list
-      - *.list.save
-      - *.list.distUpgrade
+      - '*.list'
+      - '*.list.save'
+      - '*.list.distUpgrade'
     use_regex: false
   register: stale_sources
   become: true

--- a/roles/common/tasks/clean-apt-sources.yml
+++ b/roles/common/tasks/clean-apt-sources.yml
@@ -1,0 +1,16 @@
+---
+- name: Clean stale APT sources from /etc/apt/sources.list.d
+  find:
+    paths: /etc/apt/sources.list.d
+    patterns: '*.list,*.list.save,*.list.distUpgrade'
+    use_regex: false
+  register: stale_sources
+  become: true
+
+- name: Remove stale APT source files
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ stale_sources.files }}"
+  when: stale_sources.matched > 0
+  become: true

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -137,6 +137,10 @@
   when: openssh_6_8_plus and validate_ssh | default(true)
   tags: [sshd]
 
+- name: Clean old APT sources
+  import_tasks: clean-apt-sources.yml
+  when: apt_clean_sources | default(false)
+
 - name: Update apt packages
   apt:
     update_cache: yes


### PR DESCRIPTION
Rel: roots/trellis#1577

Motivation for this PR is in the related issue.

### Considerations
- used `apt_clean_sources` to follow existing naming convention for APT vars
- placed `apt_clean_sources` with existing APT vars for logical grouping
- set `apt_clean_sources` false by default so this is is opt-in and doesn't do unexpected things for people updating
- placed task to clean sources as late as possible i.e. immediately before APT packages are updated and new sources found. 