### PR TITLE
`wp-cli-version-check.yml`: Use `gh` to fetch WP CLI release info

### DIFF
--- a/.github/workflows/wp-cli-version-check.yml
+++ b/.github/workflows/wp-cli-version-check.yml
@@ -18,8 +18,10 @@ jobs:
       - name: Get latest WP-CLI version
         id: get-version
         run: |
-          LATEST_VERSION=$(curl -s https://api.github.com/repos/wp-cli/wp-cli/releases/latest | jq -r .tag_name | sed 's/^v//')
+          LATEST_VERSION=$(gh release view --repo wp-cli/wp-cli --json 'tagName' --template '{{slice .tagName 1}}')
           echo "LATEST_VERSION=$LATEST_VERSION" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Update wp_cli_version
         run: |


### PR DESCRIPTION
To prevent updating `wp_cli_version` to `null`, e.g: https://github.com/roots/trellis/pull/1583 and https://github.com/roots/trellis/pull/1584

1. Use `gh` which exits with non-zero code when encountering errors
2. Use `GH_TOKEN` to prevent API calls from hitting rate limits

---

Root cause for https://github.com/roots/trellis/pull/1583 and https://github.com/roots/trellis/pull/1584 is unknown. I suspect the `curl` command is being rate limited.