### PR TITLE
Run ferm role when letsencrypt tag is defined on provision

### DIFF
--- a/server.yml
+++ b/server.yml
@@ -16,7 +16,7 @@
     - { role: common, tags: [common] }
     - { role: swapfile, swapfile_size: 1GB, swapfile_file: /swapfile, tags: [swapfile] }
     - { role: fail2ban, tags: [fail2ban] }
-    - { role: ferm, tags: [ferm] }
+    - { role: ferm, tags: [ferm, letsencrypt] }
     - { role: ntp, tags: [ntp] }
     - { role: users, tags: [users] }
     - { role: sshd, tags: [sshd] }


### PR DESCRIPTION
Fix for: https://github.com/roots/trellis/issues/1587


Always run the ferm role when Letsencrypt is defined in a provision command.  For example:

`trellis provision --tags letsencrypt {{env}}`

This ensures the firewall is opened up for HTTPS traffic.