### PR TITLE
Replace deprecated `distutils` version usage

### DIFF
--- a/lib/trellis/plugins/vars/version.py
+++ b/lib/trellis/plugins/vars/version.py
@@ -1,7 +1,6 @@
 from ansible import __version__
 from ansible.errors import AnsibleError
-from distutils.version import LooseVersion
-from operator import eq, ge, gt
+from packaging.version import Version
 from platform import python_version, python_version_tuple
 
 try:
@@ -18,10 +17,10 @@ if python_version_tuple()[0] == '2':
                         ' Python 2 reached end of life in 2020 and is unmaintained.\n'
                         'Python 3 is required as of Trellis version v1.15.0.').format(python_version()))
 
-if not ge(LooseVersion(__version__), LooseVersion(version_requirement)):
+if Version(__version__) < Version(version_requirement):
     raise AnsibleError(('Trellis no longer supports Ansible {}.\n'
         'Please upgrade to Ansible {} or higher.').format(__version__, version_requirement))
-elif gt(LooseVersion(__version__), LooseVersion(version_tested_max)):
+elif Version(__version__) > Version(version_tested_max):
     display.warning(u'Your Ansible version is {} but this version of Trellis has only been tested for '
             u'compatability with Ansible {} -> {}. It is advisable to check for Trellis updates or '
             u'downgrade your Ansible version.'.format(__version__, version_requirement, version_tested_max))


### PR DESCRIPTION
Fixes #1569

`disutils` was used to compare version numbers but it's deprecated and causes warnings which might result in Ansible skipping this plugin.

This replaces `distutils` with `packaging.version.Version` instead.