### PR TITLE
Fix HSTS header omitted parts

### DIFF
--- a/roles/wordpress-setup/defaults/main.yml
+++ b/roles/wordpress-setup/defaults/main.yml
@@ -17,8 +17,8 @@ nginx_hsts_preload: false
 
 # HSTS helpers
 hsts_max_age: "{{ item.value.ssl.hsts_max_age | default(nginx_hsts_max_age) }}"
-hsts_include_subdomains: "{{ item.value.ssl.hsts_include_subdomains | default(nginx_hsts_include_subdomains) | ternary('includeSubDomains', None) }}"
-hsts_preload: "{{ item.value.ssl.hsts_preload | default(nginx_hsts_preload) | ternary('preload', None) }}"
+hsts_include_subdomains: "{{ item.value.ssl.hsts_include_subdomains | default(nginx_hsts_include_subdomains) | ternary('includeSubDomains', omit) }}"
+hsts_preload: "{{ item.value.ssl.hsts_preload | default(nginx_hsts_preload) | ternary('preload', omit) }}"
 
 # Fastcgi cache params
 nginx_cache_duration: 30s

--- a/roles/wordpress-setup/templates/wordpress-site.conf.j2
+++ b/roles/wordpress-setup/templates/wordpress-site.conf.j2
@@ -86,7 +86,7 @@ server {
   ssl_buffer_size 1400; # 1400 bytes to fit in one MTU
 
   {% if item.value.ssl.provider | default('manual') != 'self-signed' -%}
-  add_header Strict-Transport-Security "max-age={{ [hsts_max_age, hsts_include_subdomains, hsts_preload] | reject('none') | join('; ') | trim }}";
+  add_header Strict-Transport-Security "max-age={{ [hsts_max_age, hsts_include_subdomains, hsts_preload] | reject('equalto', omit) | join('; ') | trim }}";
   {% endif -%}
 
   {% if item.value.ssl.client_cert_url is defined -%}


### PR DESCRIPTION
`None` seems to be replaced by an empty string by ansible. This can result in the `Strict-Transport-Security` header with a value like `"max-age=1234; ; "` or `"max-age=1234; includeSubdomains; "`

Follow the [ansible playbook guide example for omitting items from a list](https://docs.ansible.com/ansible/latest/playbook_guide/complex_data_manipulation.html#omit-elements-from-a-list) using the special `omit` variable. This removes extra `; ` from the header.