### PR TITLE
Add a User-Agent header to test_challenges.py

### DIFF
--- a/roles/letsencrypt/library/test_challenges.py
+++ b/roles/letsencrypt/library/test_challenges.py
@@ -43,7 +43,9 @@ EXAMPLES = '''
 def get_status(host, path, file):
     try:
         conn = HTTPConnection(host)
-        conn.request('HEAD', '/{0}/{1}'.format(path, file))
+        conn.request('HEAD', '/{0}/{1}'.format(path, file), None, {
+            'User-Agent': 'Trellis Ansible test_challenges module'
+        })
         res = conn.getresponse()
     except (HTTPException, socket.timeout, socket.error):
         return 0


### PR DESCRIPTION
## What
This PR adds a User-Agent header to the HTTP request made by test_challenges.py module in Ansible `letsencrypt` role. The test challenge step is performed by during provisioning.

## Why?
Some hosts have a Web Application Firewall. It's a common rule to block an HTTP request with no User-Agent header. This happened to me when setting up AWS Cloudfront with a WAF in front of Trellis sites. 

Also, while not required by [this RFC](https://datatracker.ietf.org/doc/html/rfc7231#section-5.5.3), adding the header is labeled as a "SHOULD".

Finally, having the header in the request would also help when debugging. It's easier to identify the failed test challenge request when its User-Agent contains "Trellis" and "Ansible".
