### PR TITLE
Add ansible-core version constraint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ansible>=2.10.0
+ansible-core<2.19.0
 passlib


### PR DESCRIPTION
Temporary fix for #1599, props @LucasDemea 

Will be following up proper Ansible 2.19 compatibility