### PR TITLE
Set php_fpm_process_control_timeout to 10 to prevent deploy downtime

### DIFF
--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -40,5 +40,5 @@ php_fpm_set_emergency_restart_threshold: false
 php_fpm_emergency_restart_threshold: 0
 php_fpm_set_emergency_restart_interval: false
 php_fpm_emergency_restart_interval: 0
-php_fpm_set_process_control_timeout: false
-php_fpm_process_control_timeout: 0
+php_fpm_set_process_control_timeout: true
+php_fpm_process_control_timeout: 10


### PR DESCRIPTION
Hello!

As discussed in [this thread](https://discourse.roots.io/t/104-connection-reset-by-peer-for-a-few-seconds-directly-after-deploy-how-are-you-handling-it/29912) there is a small downtime when PHP FPM is reloading. This fixes that by giving FPM 10 seconds to finish before a new worker takes over.