### PR TITLE
Add WordPress sites to `/etc/hosts`

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -8,6 +8,7 @@
     - { role: common, tags: [common] }
     - { role: fail2ban, tags: [fail2ban] }
     - { role: ferm, tags: [ferm] }
+    - { role: hosts, tags: [hosts] }
     - { role: ntp, tags: [ntp] }
     - { role: sshd, tags: [sshd] }
     - { role: mariadb, tags: [mariadb] }

--- a/roles/hosts/tasks/main.yml
+++ b/roles/hosts/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Add WordPress sites to /etc/hosts
+  lineinfile:
+    path: /etc/hosts
+    line: "127.0.0.1 {{ item }}"
+    create: yes
+  with_items: "{{ wordpress_sites.values() | map(attribute='site_hosts') | list | flatten | map(attribute='canonical') | list | union(wordpress_sites.values() | map(attribute='site_hosts') | list | flatten | selectattr('redirects', 'defined') | map(attribute='redirects') | list | flatten) }}"

--- a/server.yml
+++ b/server.yml
@@ -17,6 +17,7 @@
     - { role: swapfile, swapfile_size: 1GB, swapfile_file: /swapfile, tags: [swapfile] }
     - { role: fail2ban, tags: [fail2ban] }
     - { role: ferm, tags: [ferm, letsencrypt] }
+    - { role: hosts, tags: [hosts] }
     - { role: ntp, tags: [ntp] }
     - { role: users, tags: [users] }
     - { role: sshd, tags: [sshd] }


### PR DESCRIPTION
This PR creates a hosts role that automatically adds all configured WordPress site domains to `/etc/hosts` with `127.0.0.1`