### PR TITLE
Refactor User password hash creation

### DIFF
--- a/lib/trellis/plugins/callback/vars.py
+++ b/lib/trellis/plugins/callback/vars.py
@@ -79,16 +79,6 @@ class CallbackModule(CallbackBase):
 
         return ' '.join(options)
 
-    def darwin_without_passlib(self):
-        if not sys.platform.startswith('darwin'):
-            return False
-
-        try:
-            import passlib.hash
-            return False
-        except:
-            return True
-
     def v2_playbook_on_play_start(self, play):
         play_context = PlayContext(play=play)
 
@@ -103,4 +93,3 @@ class CallbackModule(CallbackBase):
             host.vars['cli_options'] = self.cli_options()
             host.vars['cli_ask_pass'] = self._options.get('ask_pass', False)
             host.vars['cli_ask_become_pass'] = self._options.get('become_ask_pass', False)
-            host.vars['darwin_without_passlib'] = self.darwin_without_passlib()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 ansible>=2.10.0
 ansible-core<2.19.0
-passlib

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -96,27 +96,6 @@
       Staging/Production: Create a new server with Ubuntu 20.04 and provision
   when: ansible_distribution_version is version('18.04', '<')
 
-- name: Check whether passlib is needed
-  fail:
-    msg: |
-      Ansible on macOS requires Python's passlib module to create user password hashes
-
-      If you're seeing this error message, you likely didn't use trellis-cli to create your project.
-      We highly recommend installing and using trellis-cli to manage your Trellis projects.
-
-      See https://github.com/roots/trellis-cli for more documentation.
-
-      For existing projects, you can run `trellis init` which will manage the dependencies automatically and fix this problem
-      as long as you use the `trellis` commands (like `trellis provision`) afterwards.
-
-      To fix this manually, use pip to install the package: pip install passlib
-
-      If pip is not installed, you'll have to install it first.
-      See https://stackoverflow.com/questions/17271319/how-do-i-install-pip-on-macos-or-os-x for many options.
-
-  when: env != 'development' and darwin_without_passlib | default(false)
-  run_once: true
-
 - name: Retrieve local SSH client's settings per host
   set_fact:
     ssh_client_ciphers: "{{ lookup('pipe', 'ssh -ttG ' + ansible_host + ' | grep ciphers') }}"

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -28,12 +28,25 @@
   when: not sshd_permit_root_login
   tags: sshd
 
+- name: Hash user passwords
+  command:
+    cmd: |
+      mkpasswd -m sha-512 --salt={{ (item.salt | default(''))[:16] |  regex_replace("[^\.\/a-zA-Z0-9]", "x") }}
+    stdin: "{{ item.password }}"
+  loop: "{{ vault_users | default([]) }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when: item.password is defined
+  register: user_passwords_hashed
+  no_log: true
+  changed_when: false
+
 - name: Setup users
   user:
     name: "{{ item.name }}"
     group: "{{ item.groups[0] }}"
     groups: "{{ item.groups | join(',') }}"
-    password: '{% for user in vault_users | default([]) if user.name == item.name and user.password is defined %}{{ user.password | password_hash("sha512", (user.salt | default(""))[:16] | regex_replace("[^\.\/a-zA-Z0-9]", "x")) }}{% else %}{{ "!" }}{% endfor %}'
+    password: "{{ (user_passwords_hashed.results | selectattr('item.name', 'equalto', item.name) | map(attribute='stdout') | first) | default(omit) }}"
     state: present
     shell: /bin/bash
     update_password: "{{ item.update_password | default('always') }}"


### PR DESCRIPTION
Use `mkpasswd` on the server instead of Ansible's `password_hash` on the host which requires the `passlib` dependency on macOS. `mkpasswd` already installed on Trellis configured Ubuntu.