### PR TITLE
Remove FLUSHDB from redis_disabled_commands

### DIFF
--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -18,7 +18,7 @@ redis_databases: 16
 # Persistence - RDB snapshots
 redis_save:
   - "900 1"
-  - "300 10" 
+  - "300 10"
   - "60 10000"
 
 redis_stop_writes_on_bgsave_error: "yes"
@@ -71,7 +71,6 @@ redis_aof_rewrite_incremental_fsync: "yes"
 # Security
 redis_requirepass: false
 redis_disabled_commands:
-  - FLUSHDB
   - FLUSHALL
   - KEYS
   - CONFIG


### PR DESCRIPTION
There are errors when setting up Object Cache with REDIS as per the [documentation](https://roots.io/trellis/docs/redis/).

The following WP-CLI commands cause an error:

```
wp redis enable
wp cache flush
```

Also deployments to staging/production fail due to the same errors triggered by `wp cache flush` in `finalize-after.yml`

`redis-cache` plugin uses `FLUSHDB` when enabling and flushing the cache, however the `FLUSHDB` command was disabled in `roles/redis/defaults/main.yml`.