### PR TITLE
Flush Redis cache using redis-cli to prevent Redis Facade items from being removed

### DIFF
--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -37,10 +37,25 @@
       chdir: "{{ deploy_helper.current_path }}"
     when: project.flush_rewrite_rules_on_deploy | default(flush_rewrite_rules_on_deploy)
 
-  - name: Flush cache
+  - name: Flush cache for Redis
+    command: redis-cli --scan --pattern '*' |
+      grep -E '^{{ (vault_wordpress_sites[item.key].db_user | default(item.key | underscore)) }}_wp:|^wp:' |
+      tr '\n' '\0' | xargs -0 -r -n 100 redis-cli unlink
+    when: item.value.object_cache.enabled | default(false) and item.value.object_cache.provider | default('') == 'redis'
+    loop: "{{ wordpress_sites | dict2items }}"
+    loop_control:
+      label: "{{ item.key }}"
+    args:
+      chdir: "{{ deploy_helper.current_path }}"
+
+  - name: Flush cache for non-Redis
     command: wp cache flush
     args:
       chdir: "{{ deploy_helper.current_path }}"
+    when: not (item.value.object_cache.enabled | default(false) and item.value.object_cache.provider | default('') == 'redis')
+    loop: "{{ wordpress_sites | dict2items }}"
+    loop_control:
+      label: "{{ item.key }}"
 
   when: wp_installed.rc == 0
 


### PR DESCRIPTION
Hello! As mentioned in this thread:
https://discourse.roots.io/t/trellis-v1-26-1-released/29972

`wp cache flush` seems to remove _everything_ inside of Redis. This includes anything added by the [Redis Facade](https://laravel.com/docs/12.x/redis) which is a bit of a problem since I (at least) am storing stuff in there. 😅

This pull request adds a check to see if Redis is enabled. If so, redis-cli is used to clean up the namespaces used by [Redis Object Cache](https://wordpress.org/plugins/redis-cache/) which in practice means "wp" and "site_name_wp".