### PR TITLE
Add `select_sites` custom filter

### DIFF
--- a/group_vars/all/helpers.yml
+++ b/group_vars/all/helpers.yml
@@ -31,15 +31,15 @@ object_cache_enabled_redis: "{{ item.value.object_cache.enabled | default(false)
 object_cache_enabled_memcached: "{{ item.value.object_cache.enabled | default(false) and item.value.object_cache.provider | default('') == 'memcached' }}"
 
 # Sites using Redis or Memcached object cache
-sites_using_redis: "[{% for name, site in wordpress_sites.items() | list if site.object_cache.enabled | default(false) and site.object_cache.provider | default('') == 'redis' %}'{{ name }}',{% endfor %}]"
-sites_using_memcached: "[{% for name, site in wordpress_sites.items() | list if site.object_cache.enabled | default(false) and site.object_cache.provider | default('') == 'memcached' %}'{{ name }}',{% endfor %}]"
+sites_using_redis: "{{ (wordpress_sites | select_sites('object_cache.enabled', 'true') | select_sites('object_cache.provider', 'eq', 'redis')).keys() | list }}"
+sites_using_memcached: "{{ (wordpress_sites | select_sites('object_cache.enabled', 'true') | select_sites('object_cache.provider', 'eq', 'memcached')).keys() | list }}"
 site_hosts_canonical: "{{ item.value.site_hosts | map(attribute='canonical') | list }}"
 site_hosts_redirects: "{{ item.value.site_hosts | selectattr('redirects', 'defined') | sum(attribute='redirects', start=[]) | list }}"
 site_hosts: "{{ site_hosts_canonical | union(site_hosts_redirects) }}"
 multisite_subdomains_wildcards: "{{ item.value.multisite.subdomains | default(false) | ternary( site_hosts_canonical | map('regex_replace', '^(www\\.)?(.*)$', '*.\\2') | list, [] ) }}"
 ssl_enabled: "{{ item.value.ssl is defined and item.value.ssl.enabled | default(false) }}"
 cron_enabled: "{{ site_env.disable_wp_cron and (not item.value.multisite.enabled | default(false) or (item.value.multisite.enabled | default(false) and item.value.multisite.cron | default(true))) }}"
-sites_use_ssl: "{{ wordpress_sites.values() | map(attribute='ssl') | selectattr('enabled') | list | count > 0 }}"
+sites_use_ssl: "{{ (wordpress_sites | select_sites('ssl.enabled', 'true') | length) > 0 }}"
 
 composer_authentications: "{{ vault_wordpress_sites[site].composer_authentications | default([]) }}"
 # Default `type` is `http-basic`.

--- a/lib/trellis/plugins/filter/filters.py
+++ b/lib/trellis/plugins/filter/filters.py
@@ -2,6 +2,7 @@ import types
 
 from ansible import errors
 from ansible.module_utils.six import string_types
+from jinja2 import pass_environment
 
 def to_env(dict_value):
     envs = ["{0}='{1}'".format(key.upper(), str(value).replace("'","\\'")) for key, value in sorted(dict_value.items())]
@@ -11,11 +12,50 @@ def underscore(value):
     ''' Convert dots to underscore in a string '''
     return value.replace('.', '_')
 
-class FilterModule(object):
-    ''' Trellis jinja2 filters '''
+def get_nested_attr(data, attr_path):
+    """Helper to safely get a nested attribute from a dict."""
+    keys = attr_path.split('.')
+    for key in keys:
+        if not isinstance(data, dict) or key not in data:
+            return None
+        data = data[key]
+    return data
 
+@pass_environment
+def select_sites(env, sites, attr_path, test_name='defined', *args):
+    """
+    A filter that mimics selectattr but works on nested attributes safely.
+    It uses Jinja's own built-in tests.
+    """
+    test_func = env.tests.get(test_name)
+    if test_func is None:
+        raise Exception(f"Unknown Jinja2 test '{test_name}'")
+
+    if not isinstance(sites, dict):
+        return {}
+
+    result = {}
+    for name, site_data in sites.items():
+        value_to_test = get_nested_attr(site_data, attr_path)
+
+        # For most tests, we skip sites where the attribute doesn't exist.
+        if value_to_test is None and test_name != 'defined':
+            continue
+
+        # Handle tests that don't take arguments, like 'true' or 'false'
+        if not args and test_name in ['true', 'false', 'undefined', 'defined']:
+             if test_func(value_to_test):
+                result[name] = site_data
+        # Handle tests that do take arguments
+        elif test_func(value_to_test, *args):
+            result[name] = site_data
+
+    return result
+
+class FilterModule(object):
     def filters(self):
         return {
+            'select_sites': select_sites,
             'to_env': to_env,
             'underscore': underscore,
         }

--- a/roles/letsencrypt/defaults/main.yml
+++ b/roles/letsencrypt/defaults/main.yml
@@ -1,4 +1,4 @@
-sites_using_letsencrypt: "[{% for name, site in wordpress_sites.items() | list if site.ssl.enabled and site.ssl.provider | default('manual') == 'letsencrypt' %}'{{ name }}',{% endfor %}]"
+sites_using_letsencrypt: "{{ (wordpress_sites | select_sites('ssl.enabled', 'true') | select_sites('ssl.provider', 'eq', 'letsencrypt')).keys() | list }}"
 site_uses_letsencrypt: "{{ (ssl_enabled and item.value.ssl.provider | default('manual') == 'letsencrypt') | bool }}"
 missing_hosts: "{{ site_hosts | difference((current_hosts.results | selectattr('item.key', 'equalto', item.key) | selectattr('stdout_lines', 'defined') | sum(attribute='stdout_lines', start=[]) | map('trim') | list | join(' ')).split(' ')) }}"
 letsencrypt_cert_ids: "{ {% for item in (generate_cert_ids | default({'results':[{'skipped':True}]})).results if item is not skipped %}'{{ item.item.key }}':'{{ item.stdout }}', {% endfor %} }"

--- a/roles/mariadb/defaults/main.yml
+++ b/roles/mariadb/defaults/main.yml
@@ -7,7 +7,7 @@ mariadb_server_package: mariadb-server
 mysql_binary_logging_disabled: true
 mysql_root_user: root
 
-sites_using_remote_db: "[{% for name, site in wordpress_sites.items() | list if site.env is defined and site.env.db_host | default('localhost') != 'localhost' %}'{{ name }}',{% endfor %}]"
+sites_using_remote_db: "{{ (wordpress_sites | select_sites('env.db_host', 'ne', 'localhost')).keys() | list }}"
 
 mariadb_set_innodb_buffer_pool_size: false
 mariadb_innodb_buffer_pool_size: 128M


### PR DESCRIPTION
Simplifies complex Jinja templating logic which is brittle and breaks across Ansible versions.

This is a common enough pattern I think a custom filter makes sense. There is another alternative to avoid the `for` loops but it's quite complex:

```yaml
{{ wordpress_sites | dict2items | selectattr('value.env', 'defined') | selectattr('value.env.db_host',
  'defined') | selectattr('value.env.db_host', 'ne', 'localhost') | map(attribute='key') | list }}
```