### PR TITLE
Remove complex duplicate sites validation

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,25 +1,5 @@
 ntp_timezone: Etc/UTC
 
-env_groups: "{{ ['development', 'staging', 'production'] | intersect(group_names) }}"
-
-envs_with_wp_sites: "{{
-  lookup('filetree', playbook_dir + '/group_vars') |
-  selectattr('path', 'match', '(' + env_groups | join('|') + ')/wordpress_sites\\.yml$') |
-  map(attribute='path') | map('regex_replace', '([^/]*)/.*', '\\1') | list
-}}"
-
-site_keys_by_env_pair: "[
-  {% for env_pair in envs_with_wp_sites | combinations(2) | list %}
-    {
-      'env_pair': {{ env_pair }},
-      'site_keys': {{
-                     (vars[env_pair[0] + '_sites'].wordpress_sites | default({})).keys() | intersect(
-                     (vars[env_pair[1] + '_sites'].wordpress_sites | default({})).keys())
-                   }}
-    },
-  {% endfor %}
-]"
-
 apt_packages_default:
   build-essential: "{{ apt_package_state }}"
   cron: "{{ apt_package_state }}"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,26 +1,4 @@
 ---
-- block:
-  - name: Load wordpress_sites.yml vars into <env>_sites vars
-    include_vars:
-      file: group_vars/{{ item }}/wordpress_sites.yml
-      name: "{{ item }}_sites"
-    loop: "{{ envs_with_wp_sites }}"
-    when: envs_with_wp_sites | count > 1
-
-  - name: Fail if there are duplicate site keys within host's wordpress_sites
-    fail:
-      msg: >
-        If you put multiple environments on `{{ inventory_hostname }}`, `wordpress_sites`
-        must use different site keys per environment. Adjust the following site keys that
-        are duplicated between the `{{ item.env_pair | join('` and `') }}` groups:
-          {{ item.site_keys | to_nice_yaml | indent(2) }}
-    when: item.site_keys | count
-    loop: "{{ site_keys_by_env_pair }}"
-
-  when:
-    - env_groups | count > 1
-    - validate_site_keys | default(true) | bool
-
 - name: Validate wordpress_sites
   fail:
     msg: "{{ lookup('template', 'wordpress_sites.j2') }}"


### PR DESCRIPTION
This is a complicated validation for an uncommon edge case. It's also using brittle loops in jinja which is prone to break on Ansible upgrades.

This was originally added in https://github.com/roots/trellis/pull/910.

@retlehs what do you think?