### PR TITLE
Set php-fpm log_level default to fix 'unknown value'

### DIFF
--- a/roles/php/templates/php-fpm.conf.j2
+++ b/roles/php/templates/php-fpm.conf.j2
@@ -43,7 +43,7 @@ error_log = /var/log/php{{ php_version }}-fpm.log
 ; Log level
 ; Possible Values: alert, error, warning, notice, debug
 ; Default Value: notice
-;log_level = notice
+log_level = notice
 
 ; Log limit on number of characters in the single line (log entry). If the
 ; line is over the limit, it is wrapped on multiple lines. The limit is for


### PR DESCRIPTION
### Before

```zsh
$ sudo php-fpm8.2 -tt
[sudo] password for admin: 
[15-Oct-2025 04:47:24] NOTICE: [global]
... other bits
[15-Oct-2025 04:47:24] NOTICE:  log_level = unknown value
... etc etc
```

### After
```zsh
$ sudo php-fpm8.2 -tt
[15-Oct-2025 04:50:46] NOTICE: [global]
... other bits
[15-Oct-2025 04:50:46] NOTICE:  log_level = NOTICE
... etc etc
```