### PR TITLE
Set git depth to 1 for deploy role

### DIFF
--- a/roles/deploy/tasks/update.yml
+++ b/roles/deploy/tasks/update.yml
@@ -30,6 +30,7 @@
     version: "{{ project_version }}"
     accept_hostkey: "{{ project.repo_accept_hostkey | default(repo_accept_hostkey | default(true)) }}"
     force: yes
+    depth: 1
   ignore_errors: true
   no_log: true
   register: git_clone


### PR DESCRIPTION
Setting a shallow clone on deploy speeds up the process for us when dealing with large repos. Also saves disk space. Seems a sensible default. 