### PR TITLE
Use double quotes for env values

### DIFF
--- a/lib/trellis/plugins/filter/filters.py
+++ b/lib/trellis/plugins/filter/filters.py
@@ -5,7 +5,7 @@ from ansible.module_utils.six import string_types
 from jinja2 import pass_environment
 
 def to_env(dict_value):
-    envs = ["{0}='{1}'".format(key.upper(), str(value).replace("'","\\'")) for key, value in sorted(dict_value.items())]
+    envs = ['{0}="{1}"'.format(key.upper(), str(value).replace('"', '\\"')) for key, value in sorted(dict_value.items())]
     return "\n".join(envs)
 
 def underscore(value):


### PR DESCRIPTION
Replaces https://github.com/roots/trellis/pull/1563

Updates the `to_env` filter to use double quotes for values instead of single quotes. This preserves literal newline character as a multiline string.