### PR TITLE
Remove timezone validation

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -91,17 +91,6 @@
   loop_control:
     label: "{{ item.key }}"
 
-- name: Validate timezone variable
-  stat:
-    path: /usr/share/zoneinfo/{{ ntp_timezone }}
-  register: timezone_path
-  changed_when: false
-
-- name: Explain timezone error
-  fail:
-    msg: "{{ ntp_timezone }} is not a valid timezone. For a list of valid timezones, check https://php.net/manual/en/timezones.php"
-  when: not timezone_path.stat.exists
-
 - name: Add myhostname to nsswitch.conf to ensure resolvable hostname
   lineinfile:
     backrefs: yes


### PR DESCRIPTION
NTP role will fail on its own with a helpful message:

```
TASK [ntp : Set timezone.] *****************************************************
fatal: [default]: FAILED! => {"changed": false, "msg": "Error message:\ngiven timezone \"lol_nope\" is not available"}
```