### PR TITLE
Remove memcached_fs_file_max setting

### DIFF
--- a/roles/memcached/defaults/main.yml
+++ b/roles/memcached/defaults/main.yml
@@ -1,6 +1,5 @@
 ---
 memcached_cache_size: 64
-memcached_fs_file_max: 756024
 memcached_listen_ip: 127.0.0.1
 memcached_max_conn: 1024
 memcached_port: 11211

--- a/roles/memcached/tasks/main.yml
+++ b/roles/memcached/tasks/main.yml
@@ -15,12 +15,6 @@
     mode: '0644'
   notify: restart memcached
 
-- name: Set the max open file descriptors
-  sysctl:
-    name: fs.file-max
-    value: "{{ memcached_fs_file_max | string }}"
-    state: present
-
 - name: Start the memcached service
   service:
     name: memcached


### PR DESCRIPTION
`memcached_fs_file_max` would set the `fs.file-max` (max open file descriptors) to that value. This was likely done to ensure a high number of memcached connections was possible, but the default value is high enough. Plus this is a global setting and not memcached specific.

😂 the default on my VM was `9223372036854775807`, so this drastically lowered it