### PR TITLE
Remove dot in network database message

### DIFF
--- a/roles/deploy/hooks/finalize-after.yml
+++ b/roles/deploy/hooks/finalize-after.yml
@@ -20,7 +20,7 @@
       label: "{{ item[0].item }}"
     when: project.update_wp_theme_paths | default(update_wp_theme_paths | default(true)) | bool and item[1] is match(deploy_helper.releases_path)
 
-  - name: Warn about updating network database.
+  - name: Warn about updating network database
     debug:
       msg: "Updating the network database could take a long time with a large number of sites."
     when: project.update_db_on_deploy | default(update_db_on_deploy) and project.multisite.enabled | default(false)


### PR DESCRIPTION
Hello. In yet another very useful PR of mine, this one fixes a small grammatical inconsistency in finalize-after.yml

A single name ended in a dot (period)
"Warn about updating network database."
While every other name does not:
"Update WP database"

So yeah, this fixes that. The message itself still has a period at the end which I think is fine because that's what the "Gathering Facts" task is doing.

Grammar police out!