### PR TITLE
Use sudo for become method

### DIFF
--- a/roles/wordpress-install/tasks/directories.yml
+++ b/roles/wordpress-install/tasks/directories.yml
@@ -9,6 +9,7 @@
   loop: "{{ wordpress_sites | dict2items }}"
   loop_control:
     label: "{{ item.key }}"
+  become_method: sudo
 
 - name: Create shared folder of sites
   file:
@@ -20,6 +21,7 @@
   loop: "{{ wordpress_sites | dict2items }}"
   loop_control:
     label: "{{ item.key }}"
+  become_method: sudo
 
 - name: Change site owner to user
   file:
@@ -31,4 +33,5 @@
   loop: "{{ wordpress_sites | dict2items }}"
   loop_control:
     label: "{{ item.key }}"
+  become_method: sudo
   when: chown_site_directory | default(false)


### PR DESCRIPTION
These tasks related to creating directories are run on mounted directories for local VMs. Using `sudo` as the `become_method` can provide better guarantees that the UID/GIDs mapping are preserved properly.

This might only matter for VM solutions like LXD but it shouldn't change solutions like Lima that already work correctly.