### PR TITLE
Fix `ansible_user` detection condition

### DIFF
--- a/roles/connection/tasks/main.yml
+++ b/roles/connection/tasks/main.yml
@@ -43,7 +43,7 @@
 - block:
   - name: Set remote user for each host
     set_fact:
-      ansible_user: "{{ ansible_user | default((connection_status.stdout_lines | intersect(['root', '\e[0;32mroot', '\e[0;33mroot']) | count) | ternary('root', admin_user)) }}"
+      ansible_user: "{{ ansible_user | default(('| CHANGED |' in connection_status.stdout) | ternary('root', admin_user)) }}"
     check_mode: no
 
   - name: Announce which user was selected


### PR DESCRIPTION
The previous solution relied on matching against ANSI control codes which was brittle. This broke (again) on Ansible 2.20 because color codes are now displayed which breaks this `intersect` substring match expression.

The simpler solution is to just check for the Ansible `CHANGED` output which means the raw command and connection succeeded.