### PR TITLE
Add Redis PHP session storage support

### DIFF
--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -1,5 +1,7 @@
 disable_default_pool: true
 memcached_sessions: false
+redis_sessions: false
+redis_sessions_database: 1
 
 php_extensions_custom: {}
 php_extensions: "{{ php_extensions_default | combine(php_extensions_custom) }}"

--- a/roles/wordpress-setup/templates/php-fpm-pool-wordpress.conf.j2
+++ b/roles/wordpress-setup/templates/php-fpm-pool-wordpress.conf.j2
@@ -19,4 +19,7 @@ php_admin_value[open_basedir] = {{ www_root }}/:/tmp
 {% if memcached_sessions %}
 php_value[session.save_handler] = memcached
 php_value[session.save_path] = "{{ memcached_listen_ip }}:{{ memcached_port }}"
+{% elif redis_sessions %}
+php_value[session.save_handler] = redis
+php_value[session.save_path] = "tcp://{{ redis_bind_interface }}:{{ redis_port }}?database={{ redis_sessions_database }}{% if redis_requirepass %}&auth={{ redis_requirepass }}{% endif %}"
 {% endif %}


### PR DESCRIPTION
Mirrors the existing Memcached session option. Sessions use Redis database 1 by default to stay separate from object cache on database 0.

Ref https://discourse.roots.io/t/work-in-progress-storing-php-sessions-in-redis/30148