### PR TITLE
Remove `raw` string for `ansible_become_pass`

### DIFF
--- a/roles/connection/tasks/main.yml
+++ b/roles/connection/tasks/main.yml
@@ -53,7 +53,7 @@
 
   - name: Load become password
     set_fact:
-      ansible_become_pass: "{% raw %}{% for user in vault_users | default([]) if user.name == ansible_user %}{{ user.password | default('') }}{% endfor %}{% endraw %}"
+      ansible_become_pass: "{% for user in vault_users | default([]) if user.name == ansible_user %}{{ user.password | default('') }}{% endfor %}"
     when: ansible_user != 'root' and not cli_ask_become_pass | default(false) and ansible_become_pass is not defined
     no_log: true
 


### PR DESCRIPTION
Fixes https://github.com/roots/trellis/issues/1650.

Raw string causes ansible to fail using the `sudo` password.