### PR TITLE
Add support for Composer custom-headers authentication

### DIFF
--- a/group_vars/all/helpers.yml
+++ b/group_vars/all/helpers.yml
@@ -48,4 +48,5 @@ composer_authentications: "{{ vault_wordpress_sites[site].composer_authenticatio
 # Default `type` is `http-basic`.
 composer_authentications_using_basic_auth: "{{ composer_authentications | rejectattr('type', 'defined') | union( composer_authentications | selectattr('type', 'defined') | selectattr('type', 'equalto', 'http-basic') ) }}"
 composer_authentications_using_bitbucket_oauth: "{{ composer_authentications | selectattr('type', 'defined') | selectattr('type', 'equalto', 'bitbucket-oauth') }}"
-composer_authentications_using_other_token: "{{ composer_authentications | selectattr('type', 'defined') | rejectattr('type', 'equalto', 'http-basic') | rejectattr('type', 'equalto', 'bitbucket-oauth') }}"
+composer_authentications_using_custom_headers: "{{ composer_authentications | selectattr('type', 'defined') | selectattr('type', 'equalto', 'custom-headers') }}"
+composer_authentications_using_other_token: "{{ composer_authentications | selectattr('type', 'defined') | rejectattr('type', 'equalto', 'http-basic') | rejectattr('type', 'equalto', 'bitbucket-oauth') | rejectattr('type', 'equalto', 'custom-headers') }}"

--- a/roles/deploy/hooks/build-after.yml
+++ b/roles/deploy/hooks/build-after.yml
@@ -38,6 +38,22 @@
   loop_control:
     label: "{{ item.type }}.{{ item.hostname }}"
 
+- name: Setup composer authentications (Custom Headers)
+  composer:
+    command: config
+    arguments: --auth custom-headers.{{ item.hostname | quote }} {{ item.headers | map('quote') | join(' ') }}
+    working_dir: "{{ deploy_helper.new_release_path }}"
+  no_log: true
+  changed_when: false
+  when:
+    - item.hostname is defined and item.hostname != ""
+    - item.headers is defined and item.headers | length > 0
+    - item.headers is sequence
+    - item.headers is not string
+  loop: "{{ composer_authentications_using_custom_headers }}"
+  loop_control:
+    label: "{{ item.type }}.{{ item.hostname }}"
+
 - name: Setup composer authentications (Other Tokens)
   composer:
     command: config

--- a/roles/wordpress-install/tasks/composer-authentications.yml
+++ b/roles/wordpress-install/tasks/composer-authentications.yml
@@ -30,6 +30,23 @@
   loop_control:
     label: "{{ item.type }}.{{ item.hostname }}"
 
+- name: "Setup composer authentications (Custom Headers) - {{ site }}"
+  composer:
+    command: config
+    arguments: --auth custom-headers.{{ item.hostname | quote }} {{ item.headers | map('quote') | join(' ') }}
+    working_dir: "{{ working_dir }}"
+  become: no
+  no_log: true
+  changed_when: false
+  when:
+    - item.hostname is defined and item.hostname != ""
+    - item.headers is defined and item.headers | length > 0
+    - item.headers is sequence
+    - item.headers is not string
+  loop: "{{ composer_authentications_using_custom_headers }}"
+  loop_control:
+    label: "{{ item.type }}.{{ item.hostname }}"
+
 - name: "Setup composer authentications (Other Tokens) - {{ site }}"
   composer:
     command: config


### PR DESCRIPTION
## Summary
- Adds the `custom-headers` authentication type introduced in Composer 2.9 ([composer/composer#12372](https://github.com/composer/composer/pull/12372))
- Allows private repositories using custom HTTP headers for authentication
- Adds `composer_authentications_using_custom_headers` filter in helpers and excludes it from the `other_token` catch-all
- Adds tasks in both wordpress-install and deploy roles

## Configuration example

```yaml
# group_vars/<env>/vault.yml
vault_wordpress_sites:
  example.com:
    composer_authentications:
      - { type: custom-headers, hostname: repo.example.org, headers: ["API-TOKEN: my-api-token", "X-CUSTOM-HEADER: value"] }
```

Docs updates: https://github.com/roots/docs/pull/577

🤖 Generated with [Claude Code](https://claude.com/claude-code)