### PR TITLE
Disable PHP OPcache JIT by default

### DIFF
--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -35,8 +35,8 @@ php_opcache_revalidate_freq: 60
 php_opcache_validate_timestamps: 1
 php_opcache_max_wasted_percentage: 5
 php_opcache_huge_code_pages: 0
-php_opcache_jit: 'tracing'
-php_opcache_jit_buffer_size: 256M
+php_opcache_jit: 'disable'
+php_opcache_jit_buffer_size: 0
 
 php_fpm_set_emergency_restart_threshold: false
 php_fpm_emergency_restart_threshold: 0

--- a/roles/php/templates/10-opcache.ini.j2
+++ b/roles/php/templates/10-opcache.ini.j2
@@ -4,3 +4,4 @@
 ; priority=10
 zend_extension=opcache.so
 opcache.jit={{ php_opcache_jit }}
+opcache.jit_buffer_size={{ php_opcache_jit_buffer_size }}

--- a/roles/php/templates/php-fpm.ini.j2
+++ b/roles/php/templates/php-fpm.ini.j2
@@ -33,4 +33,3 @@ opcache.revalidate_freq = {{ php_opcache_revalidate_freq }}
 opcache.fast_shutdown = {{ php_opcache_fast_shutdown }}
 opcache.max_wasted_percentage = {{ php_opcache_max_wasted_percentage }}
 opcache.huge_code_pages = {{ php_opcache_huge_code_pages }}
-opcache.jit_buffer_size = {{ php_opcache_jit_buffer_size }}


### PR DESCRIPTION
## Summary

- Disable JIT by default (`php_opcache_jit: 'disable'`, `php_opcache_jit_buffer_size: 0`)
- Consolidate JIT directives into `10-opcache.ini.j2` (previously split across `10-opcache.ini.j2` and `php-fpm.ini.j2`)

## Context

PHP 8.3's JIT tracing mode has known memory corruption bugs that cause recurring PHP-FPM worker crashes. The crash signature is a consistent ~4GB allocation attempt (`0x100040000`), which is a JIT corruption artifact — not real application memory demand.

Reported here: https://discourse.roots.io/t/php-8-3-jit-tracing-recurring-crash-at-theme-php-325-4gb-allocation/30241

Since Trellis defaults to PHP 8.3 with JIT tracing enabled, all sites on default configuration carry this risk. WordPress workloads are overwhelmingly I/O-bound and see negligible real-world performance benefit from JIT, making it a poor tradeoff.

OPcache bytecode caching remains fully enabled and unaffected.

## Re-enabling JIT

Users who want JIT can opt in via `group_vars`:

```yaml
php_opcache_jit: 'tracing'
php_opcache_jit_buffer_size: 256M
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)