### PR TITLE
Fix CI integration workflow for Bedrock without composer.lock

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,6 +49,7 @@ jobs:
           cp ../../.github/files/inventory hosts/production
           cp ../../.github/files/wordpress_sites.yml group_vars/production/wordpress_sites.yml
           cp ../../.github/files/vault.yml group_vars/production/vault.yml
+          echo 'composer_platform_requirements_check: false' >> group_vars/production/main.yml
         working-directory: example.com/trellis
       - run: trellis exec ansible-playbook --version
         working-directory: example.com/trellis


### PR DESCRIPTION
## Summary
- Bedrock removed `composer.lock` from the repo (roots/bedrock#818)
- The deploy `check-platform-reqs` task fails without a vendor dir or lock file
- Disable `composer_platform_requirements_check` for CI deploys since Bedrock no longer ships a lock file

🤖 Generated with [Claude Code](https://claude.com/claude-code)