### PR TITLE
Ubuntu 26.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     strategy:
       matrix:
         python-version: ['3.x']

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - run: mkdir $HOME/.ssh
       - name: Remove and cleanup mysql


### PR DESCRIPTION
Prep for Ubuntu 26.04, releasing tomorrow (Apr 22)

[https://canonical.com/blog/ubuntu-26-04-lts-security-update](https://canonical.com/blog/ubuntu-26-04-lts-security-updates)

Need to wait for the GH runner to make Ubuntu 26.04 available, and for DO and Hetzner to support it

Ref https://github.com/roots/trellis-cli/pull/676
Ref https://github.com/roots/docs/pull/585
Ref https://github.com/actions/runner-images/issues/13855
Ref https://github.com/actions/runner-images/issues/13964