### PR TITLE
Parallelize independent wordpress-setup tasks

### DIFF
--- a/roles/wordpress-setup/defaults/main.yml
+++ b/roles/wordpress-setup/defaults/main.yml
@@ -2,6 +2,10 @@ site_uses_local_db: "{{ site_env.db_host == 'localhost' }}"
 nginx_wordpress_site_conf: wordpress-site.conf.j2
 nginx_ssl_path: "{{ nginx_path }}/ssl"
 
+wordpress_setup_async_timeout: 900
+wordpress_setup_async_poll_delay: 2
+wordpress_setup_async_retries: 450
+
 nginx_sites_confs:
   - src: no-default.conf.j2
   - src: ssl.no-default.conf.j2

--- a/roles/wordpress-setup/tasks/database.yml
+++ b/roles/wordpress-setup/tasks/database.yml
@@ -1,32 +1,48 @@
 ---
-- block:
-  - name: Create databases for sites
-    mysql_db:
-      name: "{{ site_env.db_name }}"
-      state: present
-      login_host: "{{ site_env.db_host }}"
-      login_user: "{{ mysql_root_user }}"
-      login_password: "{{ mysql_root_password }}"
-    no_log: true
-    loop: "{{ wordpress_sites | dict2items }}"
-    loop_control:
-      label: "{{ item.key }}"
+- name: Create databases for sites
+  mysql_db:
+    name: "{{ site_env.db_name }}"
+    state: present
+    login_host: "{{ site_env.db_host }}"
+    login_user: "{{ mysql_root_user }}"
+    login_password: "{{ mysql_root_password }}"
+  async: "{{ wordpress_setup_async_timeout }}"
+  poll: 0
+  register: wordpress_setup_database_jobs
+  changed_when: false
+  no_log: true
+  loop: "{{ wordpress_sites | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  when: site_uses_local_db and item.value.db_create | default(true)
 
-  - name: Create/assign database user to db and grant permissions
-    mysql_user:
-      name: "{{ site_env.db_user }}"
-      password: "{{ site_env.db_password }}"
-      host: "{{ site_env.db_user_host }}"
-      append_privs: yes
-      priv: "{{ site_env.db_name }}.*:ALL"
-      state: present
-      login_host: "{{ site_env.db_host }}"
-      login_user: "{{ mysql_root_user }}"
-      login_password: "{{ mysql_root_password }}"
-      column_case_sensitive: no
-    no_log: true
-    loop: "{{ wordpress_sites | dict2items }}"
-    loop_control:
-      label: "{{ item.key }}"
+- name: Wait for database creation jobs
+  async_status:
+    jid: "{{ item.ansible_job_id }}"
+  register: wordpress_setup_database_job_result
+  until: wordpress_setup_database_job_result.finished
+  retries: "{{ wordpress_setup_async_retries }}"
+  delay: "{{ wordpress_setup_async_poll_delay }}"
+  changed_when: wordpress_setup_database_job_result.changed | default(false)
+  no_log: true
+  loop: "{{ wordpress_setup_database_jobs.results | default([]) | selectattr('ansible_job_id', 'defined') | list }}"
+  loop_control:
+    label: "{{ item.item.key }}"
 
+- name: Create/assign database user to db and grant permissions
+  mysql_user:
+    name: "{{ site_env.db_user }}"
+    password: "{{ site_env.db_password }}"
+    host: "{{ site_env.db_user_host }}"
+    append_privs: yes
+    priv: "{{ site_env.db_name }}.*:ALL"
+    state: present
+    login_host: "{{ site_env.db_host }}"
+    login_user: "{{ mysql_root_user }}"
+    login_password: "{{ mysql_root_password }}"
+    column_case_sensitive: no
+  no_log: true
+  loop: "{{ wordpress_sites | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
   when: site_uses_local_db and item.value.db_create | default(true)

--- a/roles/wordpress-setup/tasks/nginx-client-cert.yml
+++ b/roles/wordpress-setup/tasks/nginx-client-cert.yml
@@ -1,10 +1,41 @@
 ---
-- name: Download client cert
-  get_url:
-    url: "{{ item.value.ssl.client_cert_url }}"
-    dest: "{{ nginx_ssl_path }}/client-{{ (item.value.ssl.client_cert_url | hash('md5'))[:7] }}.crt"
-    mode: '0640'
+- name: Initialize client cert downloads
+  set_fact:
+    wordpress_setup_client_cert_downloads: []
+
+- name: Build client cert download list
+  set_fact:
+    wordpress_setup_client_cert_downloads: "{{ wordpress_setup_client_cert_downloads + [client_cert_download] }}"
+  vars:
+    client_cert_download:
+      url: "{{ item.value.ssl.client_cert_url }}"
+      dest: "{{ nginx_ssl_path }}/client-{{ (item.value.ssl.client_cert_url | hash('md5'))[:7] }}.crt"
   loop: "{{ wordpress_sites | dict2items }}"
   loop_control:
     label: "{{ item.key }}"
   when: ssl_enabled and 'client_cert_url' in item.value.ssl
+
+- name: Download client cert
+  get_url:
+    url: "{{ item.url }}"
+    dest: "{{ item.dest }}"
+    mode: '0640'
+  async: "{{ wordpress_setup_async_timeout }}"
+  poll: 0
+  register: wordpress_setup_client_cert_jobs
+  changed_when: false
+  loop: "{{ wordpress_setup_client_cert_downloads | unique(attribute='url') | list }}"
+  loop_control:
+    label: "{{ item.url }}"
+
+- name: Wait for client cert downloads
+  async_status:
+    jid: "{{ item.ansible_job_id }}"
+  register: wordpress_setup_client_cert_job_result
+  until: wordpress_setup_client_cert_job_result.finished
+  retries: "{{ wordpress_setup_async_retries }}"
+  delay: "{{ wordpress_setup_async_poll_delay }}"
+  changed_when: wordpress_setup_client_cert_job_result.changed | default(false)
+  loop: "{{ wordpress_setup_client_cert_jobs.results | default([]) | selectattr('ansible_job_id', 'defined') | list }}"
+  loop_control:
+    label: "{{ item.item.url }}"

--- a/roles/wordpress-setup/tasks/self-signed-certificate.yml
+++ b/roles/wordpress-setup/tasks/self-signed-certificate.yml
@@ -33,6 +33,22 @@
     - sites_use_ssl | bool
     - ssl_enabled | bool
     - item.value.ssl.provider | default('manual') == 'self-signed'
+  async: "{{ wordpress_setup_async_timeout }}"
+  poll: 0
+  register: wordpress_setup_self_signed_cert_jobs
+  changed_when: false
+
+- name: Wait for self-signed certificate jobs
+  async_status:
+    jid: "{{ item.ansible_job_id }}"
+  register: wordpress_setup_self_signed_cert_job_result
+  until: wordpress_setup_self_signed_cert_job_result.finished
+  retries: "{{ wordpress_setup_async_retries }}"
+  delay: "{{ wordpress_setup_async_poll_delay }}"
+  changed_when: wordpress_setup_self_signed_cert_job_result.changed | default(false)
+  loop: "{{ wordpress_setup_self_signed_cert_jobs.results | default([]) | selectattr('ansible_job_id', 'defined') | list }}"
+  loop_control:
+    label: "{{ item.item.key }}"
   notify: reload nginx
 
 - name: Clean up openssl configs directory


### PR DESCRIPTION
This experiments with task-level parallelism in `wordpress-setup` for independent per-site work:

- run local database creation asynchronously per site, then wait before DB grants
- run self-signed certificate generation asynchronously per site, then wait before cleanup and Nginx config
- build a unique client certificate download list and download client certs asynchronously
- keep DB user grants, PHP-FPM config, and Nginx config serialized to avoid shared-resource conflicts

The goal is to reduce provision time for projects with multiple sites or SSL/client-cert work without changing the observable provisioning order of shared services

## Notes

This intentionally avoids role-level parallelism. `wordpress-setup` still waits before touching shared Nginx/PHP-FPM state, and DB grants remain serial because multiple sites may share a DB user.

Async behavior is controlled by:

- `wordpress_setup_async_timeout`
- `wordpress_setup_async_poll_delay`
- `wordpress_setup_async_retries`

## Validation Needed

- [ ] Run before/after benchmarks for local development provisioning
- [ ] Run before/after benchmarks for production/server provisioning
- [ ] Test against a fresh local VM
- [ ] Test against a fresh remote server
- [ ] Confirm repeat provisioning remains idempotent
- [ ] Confirm multi-site configs behave correctly, especially with local DBs and self-signed SSL