### PR TITLE
Set default Ansible Python interpreter

### DIFF
--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -3,6 +3,7 @@ apt_package_state: present
 apt_security_package_state: latest
 apt_dev_package_state: latest
 apt_clean_sources: false
+ansible_python_interpreter: /usr/bin/python3
 composer_keep_updated: true
 php_version: "8.3"
 ntp_timezone: Etc/UTC


### PR DESCRIPTION
## Summary

Sets Trellis' default Ansible Python interpreter to the stable Ubuntu system Python path:

```yaml
ansible_python_interpreter: /usr/bin/python3
```

This avoids Ansible interpreter discovery warnings during provisioning while keeping the value in project vars, where projects can still override it per environment or host if needed.

## Current warning

Without an explicit interpreter, Ansible can emit this during provision:

```text
TASK [Gathering Facts] *********************************************************
[WARNING]: Platform linux on host 159.203.174.217 is using the discovered
Python interpreter at /usr/bin/python3.12, but future installation of another
Python interpreter could change the meaning of that path. See
https://docs.ansible.com/ansible-
core/2.18/reference_appendices/interpreter_discovery.html for more information.
ok: [159.203.174.217]
```

## Related issues

- **2018-12-05** [#1034](https://github.com/roots/trellis/issues/1034) reported remote provisioning failures after Trellis changed remote interpreter handling during the Python 2/3 transition. The fix was [#1036](https://github.com/roots/trellis/pull/1036), which removed the `server.yml` interpreter setup because Trellis still installed Python 2-specific packages on servers at the time.
- **2021-01-26** [#1267](https://github.com/roots/trellis/issues/1267) reported Vagrant provisioning failures from pip/Python 2 behavior. The fix was [#1269](https://github.com/roots/trellis/pull/1269), which forced Vagrant's local Ansible provisioner to use Python 3.
- **2022-03-11** [#1371](https://github.com/roots/trellis/issues/1371) reported hosts using the wrong Python interpreter after the old `python_interpreter` role was removed. The issue mentions `interpreter_python = /usr/bin/python3` and per-host `ansible_python_interpreter=/usr/bin/python3` as workarounds, and was closed after [#1373](https://github.com/roots/trellis/pull/1373) allowed newer Ansible versions with improved interpreter discovery.
- **2024-06-19** [#1525](https://github.com/roots/trellis/issues/1525) reported an Ansible 2.17 deploy failure where Ansible selected `/usr/bin/python3.8`; the reporter confirmed that adding `ansible_python_interpreter=/usr/bin/python3` to the host fixed it.

## Related PR history

- **2018-12-05** [#1033](https://github.com/roots/trellis/pull/1033) - "Python version compatibility fixes": changed the remote setup to find `python3 || python` and set `ansible_python_interpreter` from the discovered path.
- **2018-12-09** [#1036](https://github.com/roots/trellis/pull/1036) - "Remove ansible_python_interpreter in server.yml": removed that dynamic `server.yml` interpreter setup because Python 2-specific remote packages still made Python 3 unsafe on some supported servers.
- **2018-12-12** [#992](https://github.com/roots/trellis/pull/992) - "Ubuntu 18.04" (`Python version compatibility`): added a `server.yml` task that set `ansible_python_interpreter: python3` for Ubuntu 18.04/Bionic hosts.
- **2018-12-13** [#1039](https://github.com/roots/trellis/pull/1039) - "Fix Ubuntu 18.04 python interpreter" (`Set ansible_python_interpreter in dev`): reintroduced interpreter handling through a `python_interpreter` role and added it to development provisioning.
- **2020-08-06** [#1211](https://github.com/roots/trellis/pull/1211) - "Improve python interpreter check": updated the role from an Ubuntu 18.04/Bionic codename check to an Ubuntu `>= 18.04` version check.
- **2021-01-30** [#1269](https://github.com/roots/trellis/pull/1269) - "Use Python 3 for `ansible_local` Vagrant provisioner" (`Vagrant: use python3`): set Vagrant's `ansible_python_interpreter` default to `/usr/bin/python3`.
- **2022-02-20** [#1361](https://github.com/roots/trellis/pull/1361) - "Remove Python 2 support": removed the `python_interpreter` role and its plays because Python 3 became a Trellis requirement.
- **2026-01-13** [#1620](https://github.com/roots/trellis/pull/1620) - "Ansible 2.19 support": set `ansible_python_interpreter=/usr/bin/python3` in the CI inventory so local CI runs use system Python where apt-installed Python packages are available.
