### PR TITLE
Update `apt_repository` to `deb822_repository` for mariadb, nginx and php

### DIFF
--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -5,7 +5,7 @@
     state: present
 
 - name: Add MariaDB PPA
-  apt_repository:
+  deb822_repository:
     repo: "{{ mariadb_ppa }}"
     update_cache: yes
   register: result

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -5,7 +5,7 @@
     state: present
 
 - name: Add Nginx PPA
-  apt_repository:
+  deb822_repository:
     repo: "{{ nginx_ppa }}"
     update_cache: yes
   register: result

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Add PHP PPA
-  apt_repository:
+  deb822_repository:
     repo: "ppa:ondrej/php"
     update_cache: yes
   register: result


### PR DESCRIPTION
as per Ansible deprecation warnings.