### PR TITLE
Fix type error in renew-certs script

### DIFF
--- a/roles/letsencrypt/templates/renew-certs.py
+++ b/roles/letsencrypt/templates/renew-certs.py
@@ -51,7 +51,7 @@ for site in {{ sites_using_letsencrypt }}:
         with open(bundled_hashed_cert_path, 'rb') as bundled_hashed_cert_file:
             bundled_hashed_cert = bundled_hashed_cert_file.read()
 
-            with open(bundled_cert_path, 'w') as bundled_cert_file:
+            with open(bundled_cert_path, 'wb') as bundled_cert_file:
                 bundled_cert_file.write(bundled_hashed_cert)
                 print('Created bundled certificate {}'.format(bundled_cert_path))
 


### PR DESCRIPTION
`write()` on a file opened with text mode expects a `str` but we have `bytes`
from `bundled_hashed_cert_file` (opened in binary mode).

Use binary mode to write content as `bytes` to bundled cert without id in filename.

Fixes the following error (site specifics changed for privacy):

```
non-zero return code
Traceback (most recent call last):
  File "./renew-certs.py", line 55, in <module>
    bundled_cert_file.write(bundled_hashed_cert)
TypeError: write() argument must be str, not bytes
fatal: [my-hostname]: FAILED! => {"changed": false, "cmd": ["./renew-certs.py"], "delta": "0:00:00.274440", "end": "2026-06-12 03:00:17.361174", "rc": 1, "start": "2026-06-12 03:00:17.086734", "stderr_lines": ["Traceback (most recent call last):", "  File \"./renew-certs.py\", line 55, in <module>", "    bundled_cert_file.write(bundled_hashed_cert)", "TypeError: write() argument must be str, not bytes"], "stdout": "Certificate file /etc/nginx/ssl/letsencrypt/example.com-1234abc-bundled.cert already exists and is younger than 60 days. Not creating a new certificate.", "stdout_lines": ["Certificate file /etc/nginx/ssl/letsencrypt/example.com-1234abc-bundled.cert already exists and is younger than 60 days. Not creating a new certificate."]}
```