### PR TITLE
Fix inject facts as vars

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -22,4 +22,4 @@ roles:
 
   - name: mailpit
     src: roots.mailpit
-    version: v1.0.0
+    version: v1.0.1

--- a/roles/mariadb/defaults/main.yml
+++ b/roles/mariadb/defaults/main.yml
@@ -1,5 +1,5 @@
 mariadb_version: 10.11
-mariadb_ppa: "deb https://mirror.rackspace.com/mariadb/repo/{{ mariadb_version }}/ubuntu {{ ansible_distribution_release }} main"
+mariadb_ppa: "deb https://mirror.rackspace.com/mariadb/repo/{{ mariadb_version }}/ubuntu {{ ansible_facts['distribution_release'] }} main"
 
 mariadb_client_package: mariadb-client
 mariadb_server_package: mariadb-server

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -77,7 +77,7 @@
     loop:
       - localhost
       - "{{ inventory_hostname }}"
-      - "{{ ansible_hostname }}"
+      - "{{ ansible_facts['hostname'] }}"
 
   - name: Remove the test database
     mysql_db:

--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-nginx_ppa: "deb http://nginx.org/packages/mainline/ubuntu {{ ansible_distribution_release }} nginx"
+nginx_ppa: "deb http://nginx.org/packages/mainline/ubuntu {{ ansible_facts['distribution_release'] }} nginx"
 nginx_package: nginx
 nginx_conf: nginx.conf.j2
 nginx_path: /etc/nginx

--- a/roles/xdebug-tunnel/defaults/main.yml
+++ b/roles/xdebug-tunnel/defaults/main.yml
@@ -2,9 +2,9 @@ xdebug_tunnel_remote_port: 9003
 xdebug_tunnel_host: localhost
 xdebug_tunnel_local_port: 9003
 xdebug_tunnel_control_socket: /tmp/trellis-xdebug-{{ xdebug_tunnel_inventory_host }}
-xdebug_tunnel_control_identity: "{{ ansible_user_id }}"
+xdebug_tunnel_control_identity: "{{ ansible_facts['user_id'] }}"
 
 xdebug_tunnel_port_mapping: "{{ xdebug_tunnel_remote_port }}:{{ xdebug_tunnel_host }}:{{ xdebug_tunnel_local_port }}"
 xdebug_tunnel_ssh_user: "{{ hostvars[xdebug_tunnel_inventory_host]['ansible_user'] | default(admin_user) }}"
-xdebug_tunnel_ssh_host: "{{ hostvars[xdebug_tunnel_inventory_host]['ansible_default_ipv4']['address'] | default(xdebug_tunnel_inventory_host) }}"
+xdebug_tunnel_ssh_host: "{{ hostvars[xdebug_tunnel_inventory_host]['ansible_facts']['default_ipv4']['address'] | default(xdebug_tunnel_inventory_host) }}"
 xdebug_tunnel_user_at_host: "{{ xdebug_tunnel_ssh_user }}@{{ xdebug_tunnel_ssh_host }}"


### PR DESCRIPTION
Closes https://github.com/roots/trellis/issues/1667

Access gathered facts via the `ansible_facts` dictionary rather than the injected top-level `ansible_*` variables in roles we control:

- mariadb: ansible_hostname, ansible_distribution_release
- nginx: ansible_distribution_release
- xdebug-tunnel: ansible_user_id, ansible_default_ipv4

Also bump roots.mailpit to v1.0.1, which makes the same migration for its `ansible_architecture` reference, so no actively-run role references a top-level fact var anymore.

`INJECT_FACTS_AS_VARS` can't be changed yet due to one upstream issue. We are blocked by https://github.com/geerlingguy/ansible-role-ntp/pull/149
