### PR TITLE
Remove unsupported `use` param from nginx service task

### DIFF
--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -60,4 +60,3 @@
     name: nginx
     enabled: yes
     state: started
-    use: service


### PR DESCRIPTION
The `use` directive was consumed by the `service` action plugin to force the generic SysV `service` backend instead of auto-detecting systemd. Newer ansible-core (2.20+) no longer handles it in the action plugin, so it gets passed through to the underlying module and fails:

    Unsupported parameters for (ansible.legacy.service) module: use

Dropping it lets the service module auto-detect the init system, which is systemd on Trellis's supported Ubuntu targets.

Fixes #1668