### PR TITLE
Fix jinja2-in-conditional deprecation warning in users sudoer assert

### DIFF
--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -16,8 +16,8 @@
 - name: Fail if root login will be disabled but admin_user will not be a sudoer
   assert:
     that:
-      - "{% for user in users if user.name == admin_user %}{{ 'sudo' in user.groups }}{% else %}{{ false }}{% endfor %}"
-      - "{% for user in vault_users | default([]) if user.name == admin_user %}{{ user.password is defined }}{% else %}{{ false }}{% endfor %}"
+      - "{{ 'sudo' in (users | selectattr('name', 'equalto', admin_user) | map(attribute='groups') | first | default([])) }}"
+      - "{{ (vault_users | default([]) | selectattr('name', 'equalto', admin_user) | first | default({})).password is defined }}"
     msg: |
       When `sshd_permit_root_login: false`, you must add `sudo` to the `groups` for admin_user (in `users` hash), and set a password for admin_user in `vault_users` (in `group_vars/{{ env }}/vault.yml`). Otherwise Ansible could lose the ability to run the necessary sudo commands. {% if sudoer_passwords is defined or vault_sudoer_passwords is defined %}
 


### PR DESCRIPTION
Fixes #1657

Ansible conditionals are already evaluated as Jinja2 expressions, so wrapping them in {{ }}/{% %} delimiters triggers a deprecation warning ("conditional statements should not include jinja2 templating delimiters") and is on a path to becoming a hard error.

Rewrite the two `assert` conditions as delimiter-free filter expressions. `selectattr(...) | first | default(...)` reproduces the original `{% for ... %}...{% else %}...{% endfor %}` no-match handling.