### PR TITLE
Rename connection probe task to reflect its actual purpose

### DIFF
--- a/roles/connection/tasks/main.yml
+++ b/roles/connection/tasks/main.yml
@@ -6,7 +6,7 @@
       ansible-playbook server.yml -e env={{ env | default('production') }} -u root --ask-pass
   when: dynamic_user | default(true) and ansible_user is not defined and cli_ask_pass | default(false)
 
-- name: Check whether Ansible can connect as {{ dynamic_user | default(true) | ternary('root', web_user) }}
+- name: Determine remote user by probing connection as {{ dynamic_user | default(true) | ternary('root', web_user) }}
   command: |
     ansible {{ inventory_hostname }} -m raw -a whoami
     -u {{ dynamic_user | default(true) | ternary('root', web_user) }} {{ cli_options | default('') }} -vvvv


### PR DESCRIPTION
Fixes #1466

The task named "Check whether Ansible can connect as <user>" reads like a connectivity gate, but it is not one: `failed_when: false` is required for the root -> admin_user fallback, so the task is really detecting which remote user to use, not asserting that SSH works. Genuine SSH failures are intentionally surfaced by Ansible's own later connection error rather than duplicated here.

Rename it to "Determine remote user by probing connection as <user>" so the name stops advertising a guarantee it never made.