### PR TITLE
fix(php): accept short names in php_extensions_custom

### DIFF
--- a/lib/trellis/plugins/filter/filters.py
+++ b/lib/trellis/plugins/filter/filters.py
@@ -12,6 +12,19 @@ def underscore(value):
     ''' Convert dots to underscore in a string '''
     return value.replace('.', '_')
 
+def php_extensions(value, php_version, package_state):
+    """Normalize php_extensions_custom into a dict.
+
+    Accepts either a dict (passed through unchanged for back-compat) or a
+    list of short names. Each short name is expanded to
+    "php<version>-<name>": "<package_state>".
+    """
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, list):
+        return {f"php{php_version}-{name}": package_state for name in value}
+    return {}
+
 def get_nested_attr(data, attr_path):
     """Helper to safely get a nested attribute from a dict."""
     keys = attr_path.split('.')
@@ -58,4 +71,5 @@ class FilterModule(object):
             'select_sites': select_sites,
             'to_env': to_env,
             'underscore': underscore,
+            'php_extensions': php_extensions,
         }

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -31,16 +31,32 @@
     msg: "{{ lookup('template', 'package_vars_wrong_format_msg.j2') }}"
   when: package_vars_wrong_format | count > 0
   vars:
-    package_vars:
+    # All package vars must remain dicts except php_extensions_custom,
+    # which additionally accepts a list of short names.
+    package_vars_dict_only:
       apt_packages_default: "{{ apt_packages_default }}"
       apt_packages_custom: "{{ apt_packages_custom }}"
       memcached_packages_default: "{{ memcached_packages_default }}"
       memcached_packages_custom: "{{ memcached_packages_custom }}"
       php_extensions_default: "{{ php_extensions_default }}"
-      php_extensions_custom: "{{ php_extensions_custom }}"
       sshd_packages_default: "{{ sshd_packages_default }}"
       sshd_packages_custom: "{{ sshd_packages_custom }}"
-    package_vars_wrong_format: "{{ package_vars | dict2items | rejectattr('value', 'mapping') | map(attribute='key') | list }}"
+    package_vars_list_or_dict:
+      php_extensions_custom: "{{ php_extensions_custom }}"
+    # dict-only wrong: anything that is not a mapping
+    package_vars_dict_only_wrong: "{{ package_vars_dict_only | dict2items | rejectattr('value', 'mapping') | map(attribute='key') | list }}"
+    # list-or-dict wrong: not a mapping and not a (sequence that is not a string)
+    package_vars_list_or_dict_valid_keys: >-
+      {{ package_vars_list_or_dict | dict2items
+         | selectattr('value', 'mapping') | map(attribute='key') | list
+         | union(package_vars_list_or_dict | dict2items
+                 | selectattr('value', 'sequence')
+                 | rejectattr('value', 'string')
+                 | map(attribute='key') | list) }}
+    package_vars_list_or_dict_wrong: >-
+      {{ package_vars_list_or_dict | dict2items | map(attribute='key') | list
+         | difference(package_vars_list_or_dict_valid_keys) }}
+    package_vars_wrong_format: "{{ package_vars_dict_only_wrong | union(package_vars_list_or_dict_wrong) }}"
   tags: [memcached, php, sshd]
 
 - name: Verify dict format for package combined variables

--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -3,8 +3,9 @@ memcached_sessions: false
 redis_sessions: false
 redis_sessions_database: 1
 
-php_extensions_custom: {}
-php_extensions: "{{ php_extensions_default | combine(php_extensions_custom) }}"
+php_extensions_custom: []
+php_extensions_custom_normalized: "{{ php_extensions_custom | php_extensions(php_version, apt_package_state) }}"
+php_extensions: "{{ php_extensions_default | combine(php_extensions_custom_normalized) }}"
 
 php_error_reporting: 'E_ALL & ~E_DEPRECATED & ~E_STRICT'
 php_display_errors: 'Off'

--- a/tests/templates/test_php_extensions_custom.py
+++ b/tests/templates/test_php_extensions_custom.py
@@ -1,0 +1,41 @@
+"""Tests for the php_extensions_custom normalization (issue #1666).
+
+The defaults file (roles/php/defaults/main.yml) calls the
+`php_extensions` filter on the raw input. The filter is the single
+place where list vs. dict coercion happens, so testing the filter
+covers both the new list form and the legacy dict form.
+"""
+
+from lib.trellis.plugins.filter.filters import php_extensions
+
+
+def test_filter_expands_list_of_short_names() -> None:
+    result = php_extensions(["soap", "gd"], "8.3", "present")
+    assert result == {
+        "php8.3-soap": "present",
+        "php8.3-gd": "present",
+    }
+
+
+def test_filter_passes_legacy_dict_through_unchanged() -> None:
+    legacy = {"php8.3-soap": "present"}
+    assert php_extensions(legacy, "8.3", "present") is legacy
+
+
+def test_filter_returns_empty_dict_for_empty_input() -> None:
+    assert php_extensions([], "8.3", "present") == {}
+
+
+def test_filter_returns_empty_dict_for_unexpected_types() -> None:
+    assert php_extensions("not-a-list-or-dict", "8.3", "present") == {}
+    assert php_extensions(None, "8.3", "present") == {}
+
+
+def test_filter_uses_provided_php_version() -> None:
+    result = php_extensions(["soap"], "8.2", "present")
+    assert result == {"php8.2-soap": "present"}
+
+
+def test_filter_uses_provided_package_state() -> None:
+    result = php_extensions(["soap"], "8.3", "latest")
+    assert result == {"php8.3-soap": "latest"}


### PR DESCRIPTION
## Summary
Lets users write a plain list of short names in `php_extensions_custom` instead of the verbose `php{{ php_version }}-<name>` dict form. The legacy dict form is still accepted.

Fixes #1666

## Changes
### roles/php/defaults/main.yml
**Before:**
```yaml
php_extensions_custom: {}
php_extensions: "{{ php_extensions_default | combine(php_extensions_custom) }}"
```
**After:**
```yaml
php_extensions_custom: []
php_extensions_custom_normalized: "{{ php_extensions_custom | php_extensions(php_version, apt_package_state) }}"
php_extensions: "{{ php_extensions_default | combine(php_extensions_custom_normalized) }}"
```
**Why:** `combine()` needs a dict on the right side. A new `php_extensions` filter coerces list input to `{php<version>-<name>: <state>}` and passes dict input through unchanged.

### lib/trellis/plugins/filter/filters.py
**After:**
```python
def php_extensions(value, php_version, package_state):
    if isinstance(value, dict):
        return value
    if isinstance(value, list):
        return {f"php{php_version}-{name}": package_state for name in value}
    return {}
```
**Why:** Single source of truth for the list vs dict shape decision.

### roles/common/tasks/main.yml
**Before:** one `package_vars` dict, all entries checked with `rejectattr('value', 'mapping')`. `php_extensions_custom` was treated as dict-only.

**After:** split into `package_vars_dict_only` (mapping check) and `package_vars_list_or_dict` (mapping OR non-string sequence). The wrong-format list is the union of both wrong-key sets, so a string or int input to `php_extensions_custom` is still rejected.

**Why:** `is sequence` in Jinja2 is also true for strings, so the new predicate computes the valid-key set explicitly.

## Testing
**Test 1: list form accepted**
1. Set `php_extensions_custom: [soap, gd]` in `group_vars/all/main.yml`.
2. Run `pytest -q -ra tests/templates`.
Result: 6 new tests in `tests/templates/test_php_extensions_custom.py` pass, plus the 9 pre-existing tests.

**Test 2: dict form still works**
1. Set `php_extensions_custom: { \"php{{ php_version }}-soap\": \"{{ apt_package_state }}\" }`.
2. Run `pytest -q -ra tests/templates` and `ansible-playbook --syntax-check -e env=development server.yml`.
Result: same merged dict as before the change. Syntax check clean.

**Test 3: bad input rejected**
1. Set `php_extensions_custom: \"oops\"` (a bare string).
2. Run any play that includes the common role.
Result: verify task fails with a message naming `php_extensions_custom` as a wrong-format variable.