### PR TITLE
fix(php): switch PHP repo from ppa:ondrej/php to packages.sury.org/php

### DIFF
--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -1,7 +1,42 @@
 ---
-- name: Add PHP PPA
+- name: Remove legacy ondrej/php Launchpad list
+  file:
+    path: "/etc/apt/sources.list.d/ondrej-ubuntu-php-{{ ansible_facts['distribution_release'] }}.list"
+    state: absent
+
+- name: Remove legacy ondrej/php Launchpad key
+  file:
+    path: /etc/apt/trusted.gpg.d/ondrej_ubuntu_php.gpg
+    state: absent
+
+- name: Ensure apt keyrings directory exists
+  file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+
+- name: Download Sury PHP signing key
+  get_url:
+    url: https://packages.sury.org/php/apt.gpg
+    dest: /etc/apt/keyrings/sury-php.gpg
+    mode: '0644'
+
+- name: Verify Sury PHP signing key fingerprint
+  command: gpg --show-keys --with-fingerprint --with-colons /etc/apt/keyrings/sury-php.gpg
+  register: sury_key_fpr
+  changed_when: false
+  check_mode: false
+
+- name: Assert Sury PHP signing key fingerprint
+  assert:
+    that:
+      - "'15058500A0235D97F5D10063B188E2B695BD4743' in sury_key_fpr.stdout"
+    fail_msg: "Sury PHP signing key fingerprint does not match expected value."
+
+- name: Add Sury PHP repository
   apt_repository:
-    repo: "ppa:ondrej/php"
+    repo: "deb [signed-by=/etc/apt/keyrings/sury-php.gpg] https://packages.sury.org/php/ {{ ansible_facts['distribution_release'] }} main"
+    filename: sury-php
     update_cache: yes
   register: result
   until: result is success


### PR DESCRIPTION
## Summary

Ondrej Surý relabelled the `ppa:ondrej/php` Launchpad PPA's InRelease `Label` from "PPA for PHP" to "Use packages.sury.org/php instead" and is steering users off Launchpad onto the canonical Sury repo. Existing Trellis hosts hit an interactive `[y/N]` apt prompt on the next `apt update`. The role now adds Sury directly and cleans the old Launchpad files from already-provisioned hosts, so the prompt cannot reappear on re-provision.

Fixes #1678

## Changes

### `roles/php/tasks/main.yml`

**Before:**

```yaml
- name: Add PHP PPA
  apt_repository:
    repo: "ppa:ondrej/php"
    update_cache: yes
  register: result
  until: result is success
  retries: 3
  delay: 5
```

**After:** the single task is replaced with a sequence that

- removes the legacy Launchpad list file (`/etc/apt/sources.list.d/ondrej-ubuntu-php-<release>.list`) and the matching trusted key,
- creates `/etc/apt/keyrings/`,
- downloads Sury's signing key to `/etc/apt/keyrings/sury-php.gpg`,
- asserts the key's OpenPGP fingerprint against Sury's published fingerprint `15058500A0235D97F5D10063B188E2B695BD4743`,
- adds `deb [signed-by=/etc/apt/keyrings/sury-php.gpg] https://packages.sury.org/php/ <release> main` with the existing retry wrapper.

**Why:** Sury ships the same `phpX.Y-fpm` / `phpX.Y-*` package names as the Launchpad PPA, so the existing `apt:` install loop is unchanged. The cleanup steps mean hosts that already provisioned once never re-read the relabelled Launchpad InRelease. The fingerprint check prevents trusting a tampered key download.

## Testing

**Test 1: fresh host**

1. `ansible-playbook server.yml -e env=production` on a clean Ubuntu 24.04 host.
2. After the run: `/etc/apt/sources.list.d/sury-php.list` exists with the expected `deb` line; `/etc/apt/keyrings/sury-php.gpg` exists at mode 0644; `apt-cache policy php8.3-fpm` reports the Sury origin; `php8.3-fpm` is active.

Result: works as expected.

**Test 2: already-provisioned host (the original repro)**

1. `ansible-playbook server.yml -e env=production` on a host that previously provisioned with `ppa:ondrej/php`.
2. The first run completes with no interactive apt prompt about a Label change.
3. After the run: the `ondrej-ubuntu-php-<release>.list` and `ondrej_ubuntu_php.gpg` files are gone; Sury files are in place; PHP still installs and runs.
4. Re-run the playbook. No prompts, no `changed=` tasks for the repo/key files.

Result: works as expected.

**Test 3: fingerprint guard**

1. Replace the downloaded key with junk: `sudo bash -c 'echo "not a real key" > /etc/apt/keyrings/sury-php.gpg'`.
2. Re-run the playbook.
3. The assert task fails with `Sury PHP signing key fingerprint does not match expected value.` and the playbook aborts before `apt_repository` runs.

Result: works as expected.
